### PR TITLE
Separate avg cpu colour from the other colours.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -14,19 +14,24 @@ One use of a config file is to set boot flags to execute without having to state
 
 Another use is to set colours, under the `[colors]`. The following labels are customizable with hex colour code strings:
 
-- Table header colours (`table_header_color="#ffffff"`).
-- Every CPU core colour as an array (`cpu_core_colors=["#ffffff", "#000000", "#111111"]`).
-  - bottom will look at 216 (let's be realistic here) colours at most, and in order.
-  - If not enough colours are provided for the number of threads on the CPU, then the rest will be automatically generated.
-- RAM and SWAP colours (`ram_color="#ffffff"`, `swap_color="#111111"`).
-- RX and TX colours (`rx_color="#ffffff"`, `tx_color="#111111"`).
-- Widget title colour (`widget_title_color="#ffffff"`).
-- General widget border colour (`border_color="#ffffff"`).
-- Current widget border colour (`highlighted_border_color="#ffffff"`).
-- Text colour (`text_color="#ffffff"`).
-- Label and graph colour (`graph_color="#ffffff"`).
-- Cursor colour (`cursor_color="#ffffff"`).
-- Current selected scroll entry colour (`scroll_entry_text_color="#282828"`, `scroll_entry_bg_color="#458588"`).
+| Labels                          | Details                                        | Example                                             |
+| ------------------------------- | ---------------------------------------------- | --------------------------------------------------- |
+| Table header colours            | Colour of table headers                        | `table_header_color="#ffffff"`                      |
+| CPU colour per core             | Colour of each core. Read in order.            | `cpu_core_colors=["#ffffff", "#000000", "#111111"]` |
+|                                 | Looks at 256 colours at most.                  |
+| Average CPU colour              | The average CPU color                          | `avg_cpu_color="#d3869b"`                           |
+| RAM                             | The colour RAM will use                        | `ram_color="#ffffff"`                               |
+| SWAP                            | The colour SWAP will use                       | `swap_color="#111111"`                              |
+| RX                              | The colour rx will use                         | `rx_color="#ffffff"`                                |
+| TX                              | The colour tx will use                         | `tx_color="#111111"`                                |
+| Widget title colour             | The colour of the label each widget has        | `widget_title_color="#ffffff"`                      |
+| Border colour                   | The colour of the border of unselected widgets | `border_color="#ffffff"`                            |
+| Selected border colour          | The colour of the border of selected widgets   | `highlighted_border_color="#ffffff"`                |
+| Text colour                     | The colour of most text                        | `text_color="#ffffff"`                              |
+| Graph colour                    | The colour of the lines and text of the graph  | `graph_color="#ffffff"`                             |
+| Cursor colour                   | The cursor's colour                            | `cursor_color="#ffffff"`                            |
+| Selected text colour            | The colour of text that is selected            | `scroll_entry_text_color="#282828"`                 |
+| Selected text background colour | The background colour of text that is selected | `scroll_entry_bg_color="#458588"`                   |
 
 Note some colours may not be compatible with the terminal you are using. For example, macOS's default Terminal does not play nice with many colours.
 

--- a/sample_configs/bottom.toml
+++ b/sample_configs/bottom.toml
@@ -5,7 +5,7 @@
 # This group of options represents a command-line flag/option.  Flags explicitly
 # added when running (ie: btm -a) will override this config file if an option
 # is also set here.
-#[flags]
+[flags]
 
 #avg_cpu = true
 #dot_marker = false
@@ -41,13 +41,16 @@
 # macOS default Terminal does NOT like custom colours and it will glitch out.
 # 
 # The default options here are based on gruvbox: https://github.com/morhetz/gruvbox
-#[colors]
+[colors]
 
 # Represents the colour of table headers (processes, CPU, disks, temperature).
 #table_header_color="#458588"
 
 # Represents the colour of the label each widget has.
 #widget_title_color="#cc241d"
+
+# Represents the average CPU color
+#avg_cpu_color="#d3869b"
 
 # Represents the colour the core will use in the CPU legend and graph.
 #cpu_core_colors=["#cc241d", "#98971a"]
@@ -70,7 +73,7 @@
 # Represents the colour of the border of selected widgets.
 #highlighted_border_color="#fe8019"
 
-# Represents the colour of the border of most text that is otherwise not covered.
+# Represents the colour of most text.
 #text_color="#ebdbb2"
 
 # Represents the colour of text that is selected.
@@ -81,3 +84,6 @@
 
 # Represents the colour of the lines and text of the graph.
 #graph_color="#ebdbb2"
+
+# Represents the cursor's colour.
+#cursor_color="#458588"

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -562,8 +562,12 @@ impl Painter {
 								Marker::Braille
 							})
 							.style(
-								self.colours.cpu_colour_styles
-									[itx % self.colours.cpu_colour_styles.len()],
+								if app_state.app_config_fields.show_average_cpu && itx == 0 {
+									self.colours.avg_colour_style
+								} else {
+									self.colours.cpu_colour_styles
+										[itx % self.colours.cpu_colour_styles.len()]
+								},
 							)
 							.data(&cpu.cpu_data[..]),
 					)
@@ -668,6 +672,8 @@ impl Painter {
 									.current_scroll_position - start_position
 							{
 								self.colours.currently_selected_text_style
+							} else if app_state.app_config_fields.show_average_cpu && itx == 0 {
+								self.colours.avg_colour_style
 							} else {
 								self.colours.cpu_colour_styles[itx
 									+ start_position as usize
@@ -675,8 +681,13 @@ impl Painter {
 							}
 						}
 						_ => {
-							self.colours.cpu_colour_styles[itx
-								+ start_position as usize % self.colours.cpu_colour_styles.len()]
+							if app_state.app_config_fields.show_average_cpu && itx == 0 {
+								self.colours.avg_colour_style
+							} else {
+								self.colours.cpu_colour_styles[itx
+									+ start_position as usize
+										% self.colours.cpu_colour_styles.len()]
+							}
 						}
 					},
 				)

--- a/src/canvas/canvas_colours.rs
+++ b/src/canvas/canvas_colours.rs
@@ -13,6 +13,7 @@ pub struct CanvasColours {
 	pub swap_style: Style,
 	pub rx_style: Style,
 	pub tx_style: Style,
+	pub avg_colour_style: Style,
 	pub cpu_colour_styles: Vec<Style>,
 	pub border_style: Style,
 	pub highlighted_border_style: Style,
@@ -36,6 +37,7 @@ impl Default for CanvasColours {
 			swap_style: Style::default().fg(STANDARD_SECOND_COLOUR),
 			rx_style: Style::default().fg(STANDARD_FIRST_COLOUR),
 			tx_style: Style::default().fg(STANDARD_SECOND_COLOUR),
+			avg_colour_style: Style::default().fg(AVG_COLOUR),
 			cpu_colour_styles: Vec::new(),
 			border_style: Style::default().fg(text_colour),
 			highlighted_border_style: Style::default().fg(Color::LightBlue),
@@ -48,37 +50,39 @@ impl Default for CanvasColours {
 
 impl CanvasColours {
 	pub fn set_text_colour(&mut self, hex: &str) -> error::Result<()> {
-		self.text_style = Style::default().fg(convert_hex_to_color(hex)?);
+		self.text_style = get_style_from_hex(hex)?;
 		Ok(())
 	}
 	pub fn set_border_colour(&mut self, hex: &str) -> error::Result<()> {
-		self.border_style = Style::default().fg(convert_hex_to_color(hex)?);
+		self.border_style = get_style_from_hex(hex)?;
 		Ok(())
 	}
 	pub fn set_highlighted_border_colour(&mut self, hex: &str) -> error::Result<()> {
-		self.highlighted_border_style = Style::default().fg(convert_hex_to_color(hex)?);
+		self.highlighted_border_style = get_style_from_hex(hex)?;
 		Ok(())
 	}
 	pub fn set_table_header_colour(&mut self, hex: &str) -> error::Result<()> {
-		self.table_header_style = Style::default()
-			.fg(convert_hex_to_color(hex)?)
-			.modifier(Modifier::BOLD);
+		self.table_header_style = get_style_from_hex(hex)?.modifier(Modifier::BOLD);
 		Ok(())
 	}
 	pub fn set_ram_colour(&mut self, hex: &str) -> error::Result<()> {
-		self.ram_style = Style::default().fg(convert_hex_to_color(hex)?);
+		self.ram_style = get_style_from_hex(hex)?;
 		Ok(())
 	}
 	pub fn set_swap_colour(&mut self, hex: &str) -> error::Result<()> {
-		self.swap_style = Style::default().fg(convert_hex_to_color(hex)?);
+		self.swap_style = get_style_from_hex(hex)?;
 		Ok(())
 	}
 	pub fn set_rx_colour(&mut self, hex: &str) -> error::Result<()> {
-		self.rx_style = Style::default().fg(convert_hex_to_color(hex)?);
+		self.rx_style = get_style_from_hex(hex)?;
 		Ok(())
 	}
 	pub fn set_tx_colour(&mut self, hex: &str) -> error::Result<()> {
-		self.tx_style = Style::default().fg(convert_hex_to_color(hex)?);
+		self.tx_style = get_style_from_hex(hex)?;
+		Ok(())
+	}
+	pub fn set_avg_cpu_colour(&mut self, hex: &str) -> error::Result<()> {
+		self.avg_colour_style = get_style_from_hex(hex)?;
 		Ok(())
 	}
 	pub fn set_cpu_colours(&mut self, hex_colours: &[String]) -> error::Result<()> {
@@ -114,12 +118,12 @@ impl CanvasColours {
 	}
 
 	pub fn set_widget_title_colour(&mut self, hex: &str) -> error::Result<()> {
-		self.widget_title_style = Style::default().fg(convert_hex_to_color(hex)?);
+		self.widget_title_style = get_style_from_hex(hex)?;
 		Ok(())
 	}
 
 	pub fn set_graph_colour(&mut self, hex: &str) -> error::Result<()> {
-		self.graph_style = Style::default().fg(convert_hex_to_color(hex)?);
+		self.graph_style = get_style_from_hex(hex)?;
 		Ok(())
 	}
 }

--- a/src/canvas/canvas_colours/colour_utils.rs
+++ b/src/canvas/canvas_colours/colour_utils.rs
@@ -4,6 +4,7 @@ use tui::style::{Color, Style};
 const GOLDEN_RATIO: f32 = 0.618_034; // Approx, good enough for use (also Clippy gets mad if it's too long)
 pub const STANDARD_FIRST_COLOUR: Color = Color::LightMagenta;
 pub const STANDARD_SECOND_COLOUR: Color = Color::LightYellow;
+pub const AVG_COLOUR: Color = Color::Red;
 
 /// Generates random colours.  Strategy found from
 /// https://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/
@@ -43,14 +44,13 @@ pub fn gen_n_styles(num_to_gen: i32) -> Vec<Style> {
 		Style::default().fg(Color::LightCyan),
 		Style::default().fg(Color::LightGreen),
 		Style::default().fg(Color::LightBlue),
-		Style::default().fg(Color::Red),
 		Style::default().fg(Color::Cyan),
 		Style::default().fg(Color::Green),
 		Style::default().fg(Color::Blue),
 	];
 
 	let mut h: f32 = 0.4; // We don't need random colours... right?
-	for _i in 0..(num_to_gen - 10) {
+	for _i in 0..(num_to_gen - 9) {
 		h = gen_hsv(h);
 		let result = hsv_to_rgb(h, 0.5, 0.95);
 		colour_vec.push(Style::default().fg(Color::Rgb(result.0, result.1, result.2)));
@@ -77,4 +77,8 @@ pub fn convert_hex_to_color(hex: &str) -> error::Result<Color> {
 
 	let rgb = convert_hex_to_rgb(hex)?;
 	Ok(Color::Rgb(rgb.0, rgb.1, rgb.2))
+}
+
+pub fn get_style_from_hex(hex: &str) -> error::Result<Style> {
+	Ok(Style::default().fg(convert_hex_to_color(hex)?))
 }

--- a/src/canvas/canvas_colours/colour_utils.rs
+++ b/src/canvas/canvas_colours/colour_utils.rs
@@ -40,17 +40,18 @@ pub fn gen_n_styles(num_to_gen: i32) -> Vec<Style> {
 	let mut colour_vec: Vec<Style> = vec![
 		Style::default().fg(STANDARD_FIRST_COLOUR),
 		Style::default().fg(STANDARD_SECOND_COLOUR),
-		Style::default().fg(Color::LightRed),
 		Style::default().fg(Color::LightCyan),
 		Style::default().fg(Color::LightGreen),
 		Style::default().fg(Color::LightBlue),
+		Style::default().fg(Color::LightRed),
 		Style::default().fg(Color::Cyan),
 		Style::default().fg(Color::Green),
 		Style::default().fg(Color::Blue),
+		Style::default().fg(Color::Red),
 	];
 
 	let mut h: f32 = 0.4; // We don't need random colours... right?
-	for _i in 0..(num_to_gen - 9) {
+	for _i in 0..(num_to_gen - 10) {
 		h = gen_hsv(h);
 		let result = hsv_to_rgb(h, 0.5, 0.95);
 		colour_vec.push(Style::default().fg(Color::Rgb(result.0, result.1, result.2)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ struct ConfigFlags {
 #[derive(Default, Deserialize)]
 struct ConfigColours {
 	table_header_color: Option<String>,
+	avg_cpu_color: Option<String>,
 	cpu_core_colors: Option<Vec<String>>,
 	ram_color: Option<String>,
 	swap_color: Option<String>,
@@ -690,6 +691,10 @@ fn generate_config_colours(config: &Config, painter: &mut canvas::Painter) -> er
 
 		if let Some(text_color) = &colours.text_color {
 			painter.colours.set_text_colour(text_color)?;
+		}
+
+		if let Some(avg_cpu_color) = &colours.avg_cpu_color {
+			painter.colours.set_avg_cpu_colour(avg_cpu_color)?;
 		}
 
 		if let Some(cpu_core_colors) = &(colours.cpu_core_colors) {


### PR DESCRIPTION
This is in comparison to previous behaviour where it just took the first CPU colour possible.

Also adds average cpu colouring options in config files.