### PR TITLE
Skip control characters if they are somehow passed in as a char

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -771,6 +771,12 @@ impl App {
 
 	pub fn on_char_key(&mut self, caught_char: char) {
 		// Forbid any char key presses when showing a dialog box...
+
+		// Skip control code chars
+		if caught_char.is_control() {
+			return;
+		}
+
 		if !self.is_in_dialog() {
 			let current_key_press_inst = Instant::now();
 			if current_key_press_inst


### PR DESCRIPTION
## Description

Skips control characters that might be passed in (ie: caps lock to search).  We would want to ignore this case.

## Issue

If applicable, what issue does this address?

Issue: #14 

## Type of change

Remove the irrelevant one.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code has been linted
- [x] Code has been self-reviewed
- [x] Code has been tested and no new breakage is introduced
- [x] Documentation has been added

## Other information

Provide any other relevant information.
