### PR TITLE
Fix for issue in powershell.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -369,21 +369,21 @@ fn handle_key_event_or_break(
 			}
 		} else if let KeyModifiers::ALT = event.modifiers {
 			match event.code {
-				KeyCode::Char('c') => {
+				KeyCode::Char('c') | KeyCode::Char('C') => {
 					if app.is_in_search_widget() {
 						app.process_search_state.toggle_ignore_case();
 						app.update_regex();
 						app.update_process_gui = true;
 					}
 				}
-				KeyCode::Char('w') => {
+				KeyCode::Char('w') | KeyCode::Char('W') => {
 					if app.is_in_search_widget() {
 						app.process_search_state.toggle_search_whole_word();
 						app.update_regex();
 						app.update_process_gui = true;
 					}
 				}
-				KeyCode::Char('r') => {
+				KeyCode::Char('r') | KeyCode::Char('R') => {
 					if app.is_in_search_widget() {
 						app.process_search_state.toggle_search_regex();
 						app.update_regex();

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,7 +325,7 @@ fn handle_key_event_or_break(
 			KeyCode::Down => app.on_down_key(),
 			KeyCode::Left => app.on_left_key(),
 			KeyCode::Right => app.on_right_key(),
-			KeyCode::Char(character) => app.on_char_key(character),
+			KeyCode::Char(caught_char) => app.on_char_key(caught_char),
 			KeyCode::Esc => app.on_esc(),
 			KeyCode::Enter => app.on_enter(),
 			KeyCode::Tab => app.on_tab(),
@@ -361,14 +361,10 @@ fn handle_key_event_or_break(
 		} else if let KeyModifiers::SHIFT = event.modifiers {
 			match event.code {
 				KeyCode::Left => app.move_widget_selection_left(),
-				KeyCode::Char('h') | KeyCode::Char('H') => app.on_char_key('H'),
 				KeyCode::Right => app.move_widget_selection_right(),
-				KeyCode::Char('l') | KeyCode::Char('L') => app.on_char_key('L'),
 				KeyCode::Up => app.move_widget_selection_up(),
-				KeyCode::Char('k') | KeyCode::Char('K') => app.on_char_key('K'),
 				KeyCode::Down => app.move_widget_selection_down(),
-				KeyCode::Char('j') | KeyCode::Char('J') => app.on_char_key('J'),
-				KeyCode::Char('/') | KeyCode::Char('?') => app.on_char_key('?'),
+				KeyCode::Char(caught_char) => app.on_char_key(caught_char),
 				_ => {}
 			}
 		} else if let KeyModifiers::ALT = event.modifiers {


### PR DESCRIPTION
## Description

Fixes a problem in windows where the shift key + char is considered a different switch statement tier.  It was therefore missing an overall `on_char_key()` call for anything w/ a shift modifier.

EDIT: Also fixes the alt-key behaviour on powershell.

## Issue

If applicable, what issue does this address?

Issue: #26

## Type of change

Remove the irrelevant one.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code has been linted
- [x] Code has been self-reviewed
- [x] Code has been tested and no new breakage is introduced
- [x] Documentation has been added

## Other information

Provide any other relevant information.
