### PR TITLE
Colours if selected and F1-3 keys for search options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ script:
   - cargo clippy -- -D clippy::all
   - cargo build --verbose --target $TARGET
   - cargo test --verbose --target $TARGET
-  - cargo install --path . --target $TARGET
 
 # Need to cache the whole `.cargo` directory to keep .crates.toml for cargo-update to work
 cache:
@@ -46,6 +45,7 @@ notifications:
     on_success: never
 
 before_deploy:
+  - cargo install --path . --target $TARGET
   - |
     if [[ $TRAVIS_OS_NAME == "windows" ]]; then
       choco install zip;

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - cargo clippy -- -D clippy::all
   - cargo build --verbose --target $TARGET
   - cargo test --verbose --target $TARGET
-  - cargo install --target $TARGET
+  - cargo install --path . --target $TARGET
 
 # Need to cache the whole `.cargo` directory to keep .crates.toml for cargo-update to work
 cache:

--- a/README.md
+++ b/README.md
@@ -184,11 +184,11 @@ Run using `btm`.
 
 - `Left` and `Right` arrow keys to move the cursor within the search bar.
 
-- `Alt-c` to toggle ignoring case.
+- `Alt-c/F1` to toggle ignoring case.
 
-- `Alt-m` to toggle matching the entire word.
+- `Alt-w/F2` to toggle matching the entire word.
 
-- `Alt-r` to toggle using regex.
+- `Alt-r/F3` to toggle using regex.
 
 Note that `q` is disabled while in the search widget.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -106,15 +106,15 @@ impl Default for ProcessSearchState {
 }
 
 impl ProcessSearchState {
-	pub fn toggle_ignore_case(&mut self) {
+	pub fn search_toggle_ignore_case(&mut self) {
 		self.is_ignoring_case = !self.is_ignoring_case;
 	}
 
-	pub fn toggle_search_whole_word(&mut self) {
+	pub fn search_toggle_whole_word(&mut self) {
 		self.is_searching_whole_word = !self.is_searching_whole_word;
 	}
 
-	pub fn toggle_search_regex(&mut self) {
+	pub fn search_toggle_regex(&mut self) {
 		self.is_searching_with_regex = !self.is_searching_with_regex;
 	}
 }
@@ -461,6 +461,24 @@ impl App {
 
 	pub fn get_current_search_query(&self) -> &String {
 		&self.process_search_state.search_state.current_search_query
+	}
+
+	pub fn toggle_ignore_case(&mut self) {
+		self.process_search_state.search_toggle_ignore_case();
+		self.update_regex();
+		self.update_process_gui = true;
+	}
+
+	pub fn toggle_search_whole_word(&mut self) {
+		self.process_search_state.search_toggle_whole_word();
+		self.update_regex();
+		self.update_process_gui = true;
+	}
+
+	pub fn toggle_search_regex(&mut self) {
+		self.process_search_state.search_toggle_regex();
+		self.update_regex();
+		self.update_process_gui = true;
 	}
 
 	pub fn update_regex(&mut self) {

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -97,6 +97,7 @@ pub struct Painter {
 	pub styled_general_help_text: Vec<Text<'static>>,
 	pub styled_process_help_text: Vec<Text<'static>>,
 	pub styled_search_help_text: Vec<Text<'static>>,
+	is_mac_os: bool,
 }
 
 impl Painter {
@@ -106,6 +107,8 @@ impl Painter {
 	/// assumes that you, the programmer, are sane and do not do stupid things.
 	/// RIGHT?
 	pub fn initialize(&mut self) {
+		self.is_mac_os = cfg!(target_os = "macos");
+
 		self.styled_general_help_text.push(Text::Styled(
 			GENERAL_HELP_TEXT[0].into(),
 			self.colours.table_header_style,
@@ -1222,27 +1225,60 @@ impl Painter {
 			option_text.push(Text::raw("\n"));
 		}
 
-		let option_row = vec![
-			Text::styled("Match Case (Alt+C)", self.colours.table_header_style),
+		let case_style = if !app_state.process_search_state.is_ignoring_case {
+			self.colours.currently_selected_text_style
+		} else {
+			self.colours.text_style
+		};
+
+		let whole_word_style = if app_state.process_search_state.is_searching_whole_word {
+			self.colours.currently_selected_text_style
+		} else {
+			self.colours.text_style
+		};
+
+		let regex_style = if app_state.process_search_state.is_searching_with_regex {
+			self.colours.currently_selected_text_style
+		} else {
+			self.colours.text_style
+		};
+
+		let case_text = format!(
+			"Match Case ({})[{}]",
+			if self.is_mac_os { "F1" } else { "Alt+C" },
 			if !app_state.process_search_state.is_ignoring_case {
-				Text::styled("[*]", self.colours.table_header_style)
+				"*"
 			} else {
-				Text::styled("[ ]", self.colours.table_header_style)
-			},
-			Text::styled("     ", self.colours.table_header_style),
-			Text::styled("Match Whole Word (Alt+W)", self.colours.table_header_style),
+				" "
+			}
+		);
+
+		let whole_text = format!(
+			"Match Whole Word ({})[{}]",
+			if self.is_mac_os { "F2" } else { "Alt+W" },
 			if app_state.process_search_state.is_searching_whole_word {
-				Text::styled("[*]", self.colours.table_header_style)
+				"*"
 			} else {
-				Text::styled("[ ]", self.colours.table_header_style)
-			},
-			Text::styled("     ", self.colours.table_header_style),
-			Text::styled("Use Regex (Alt+R)", self.colours.table_header_style),
+				" "
+			}
+		);
+
+		let regex_text = format!(
+			"Use Regex ({})[{}]",
+			if self.is_mac_os { "F3" } else { "Alt+R" },
 			if app_state.process_search_state.is_searching_with_regex {
-				Text::styled("[*]", self.colours.table_header_style)
+				"*"
 			} else {
-				Text::styled("[ ]", self.colours.table_header_style)
-			},
+				" "
+			}
+		);
+
+		let option_row = vec![
+			Text::styled(&case_text, case_style),
+			Text::raw("     "),
+			Text::styled(&whole_text, whole_word_style),
+			Text::raw("     "),
+			Text::styled(&regex_text, regex_style),
 		];
 		option_text.extend(option_row);
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -50,7 +50,7 @@ pub const SEARCH_HELP_TEXT: [&str; 13] = [
 	"Delete         Delete the character at the cursor\n",
 	"Left           Move cursor left\n",
 	"Right          Move cursor right\n",
-	"Alt-c          Toggle whether to ignore case\n",
-	"Alt-m          Toggle whether to match the whole word\n",
-	"Alt-r          Toggle whether to use regex\n",
+	"Alt-c/F1       Toggle whether to ignore case\n",
+	"Alt-w/F2       Toggle whether to match the whole word\n",
+	"Alt-r/F3       Toggle whether to use regex\n",
 ];


### PR DESCRIPTION
Added different colours to search options if selected; added F1-3 keys as an alternative for searching.  Both are available, but on macOS F1-3 will be suggested instead.

## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Two main things:

* Add colours if search options are toggled on (and no colour if off)

* Add F1, F2, and F3 as case, whole word, and regex options as alternatives.  Both the original bindings work if available, but on macOS, F1-F3 will be suggested rather than their Alt counterparts.

Finally a documentation fix in README and ? menu where ``Alt-W`` was labelled incorrectly.

## Issue

If applicable, what issue does this address?

Issue: #29 

## Type of change

_Remove the irrelevant one:_

- [x] New feature (non-breaking change which adds functionality)

## Test methodology

_Please state how this was tested:_

- Tested on Arch Linux, Kitty Term, to ensure no previous functionality was lost.  F1-F3 tested.  Colours tested.

- Tested on macOS to ensure the F1-F3 feature works and is displayed instead.

## Checklist

_Please ensure all are ticked (and actually done):_

- [x] Code has been linted
- [x] Code has been self-reviewed
- [x] Code has been tested and no new breakage is introduced
- [x] Documentation has been added

## Other information

_Provide any other relevant information:_
