### PR TITLE
Add space after arrow due for Konsole

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1406,9 +1406,9 @@ impl Painter {
 		let mut mem = "Mem%(m)".to_string();
 
 		let direction_val = if app_state.process_sorting_reverse {
-			"⯆".to_string()
+			"⯆ ".to_string()
 		} else {
-			"⯅".to_string()
+			"⯅ ".to_string()
 		};
 
 		match app_state.process_sorting_type {


### PR DESCRIPTION
Fix as per https://old.reddit.com/r/kde/comments/6fxf5t/konsole_font_issue/

## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes an issue with the arrow not being displayed properly on Konsole

![image](https://user-images.githubusercontent.com/34804052/75310163-2835c900-5821-11ea-9241-8b4f715e0ea4.png)

## Issue

If applicable, what issue does this address?

Closes #35 

## Type of change

_Remove the irrelevant one:_

- [x] Bug fix (non-breaking change which fixes an issue)

## Test methodology

_Please state how this was tested:_

Tested on Konsole, Kitty, and Terminator on Arch Linux.

## Checklist

_Please ensure all are ticked (and actually done):_

- [x] Code has been linted
- [x] Code has been self-reviewed
- [x] Code has been tested and no new breakage is introduced
- [x] Documentation has been added

## Other information

_Provide any other relevant information:_
