### PR TITLE
Colouring of rx tx

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -901,14 +901,18 @@ impl Painter {
 					})
 					.style(self.colours.tx_style)
 					.data(&network_data_tx),
-				Dataset::default().name(&format!(
-					"Total RX: {:7}",
-					app_state.canvas_data.total_rx_display
-				)),
-				Dataset::default().name(&format!(
-					"Total TX: {:7}",
-					app_state.canvas_data.total_tx_display
-				)),
+				Dataset::default()
+					.name(&format!(
+						"Total RX: {:7}",
+						app_state.canvas_data.total_rx_display
+					))
+					.style(self.colours.rx_total_style),
+				Dataset::default()
+					.name(&format!(
+						"Total TX: {:7}",
+						app_state.canvas_data.total_tx_display
+					))
+					.style(self.colours.tx_total_style),
 			])
 			.render(f, draw_loc);
 	}

--- a/src/canvas/canvas_colours.rs
+++ b/src/canvas/canvas_colours.rs
@@ -53,38 +53,47 @@ impl CanvasColours {
 		self.text_style = get_style_from_config(colour)?;
 		Ok(())
 	}
+
 	pub fn set_border_colour(&mut self, colour: &str) -> error::Result<()> {
 		self.border_style = get_style_from_config(colour)?;
 		Ok(())
 	}
+
 	pub fn set_highlighted_border_colour(&mut self, colour: &str) -> error::Result<()> {
 		self.highlighted_border_style = get_style_from_config(colour)?;
 		Ok(())
 	}
+
 	pub fn set_table_header_colour(&mut self, colour: &str) -> error::Result<()> {
 		self.table_header_style = get_style_from_config(colour)?.modifier(Modifier::BOLD);
 		Ok(())
 	}
+
 	pub fn set_ram_colour(&mut self, colour: &str) -> error::Result<()> {
 		self.ram_style = get_style_from_config(colour)?;
 		Ok(())
 	}
+
 	pub fn set_swap_colour(&mut self, colour: &str) -> error::Result<()> {
 		self.swap_style = get_style_from_config(colour)?;
 		Ok(())
 	}
+
 	pub fn set_rx_colour(&mut self, colour: &str) -> error::Result<()> {
 		self.rx_style = get_style_from_config(colour)?;
 		Ok(())
 	}
+
 	pub fn set_tx_colour(&mut self, colour: &str) -> error::Result<()> {
 		self.tx_style = get_style_from_config(colour)?;
 		Ok(())
 	}
+
 	pub fn set_avg_cpu_colour(&mut self, colour: &str) -> error::Result<()> {
 		self.avg_colour_style = get_style_from_config(colour)?;
 		Ok(())
 	}
+
 	pub fn set_cpu_colours(&mut self, colours: &[String]) -> error::Result<()> {
 		let max_amount = std::cmp::min(colours.len(), NUM_COLOURS as usize);
 		for (itx, colour) in colours.iter().enumerate() {
@@ -95,6 +104,7 @@ impl CanvasColours {
 		}
 		Ok(())
 	}
+
 	pub fn generate_remaining_cpu_colours(&mut self) {
 		let remaining_num_colours = NUM_COLOURS - self.cpu_colour_styles.len() as i32;
 		self.cpu_colour_styles
@@ -108,6 +118,7 @@ impl CanvasColours {
 			.bg(self.currently_selected_bg_colour);
 		Ok(())
 	}
+
 	pub fn set_scroll_entry_bg_color(&mut self, colour: &str) -> error::Result<()> {
 		self.currently_selected_bg_colour = get_colour_from_config(colour)?;
 		self.currently_selected_text_style = Style::default()

--- a/src/canvas/canvas_colours.rs
+++ b/src/canvas/canvas_colours.rs
@@ -13,6 +13,8 @@ pub struct CanvasColours {
 	pub swap_style: Style,
 	pub rx_style: Style,
 	pub tx_style: Style,
+	pub rx_total_style: Style,
+	pub tx_total_style: Style,
 	pub avg_colour_style: Style,
 	pub cpu_colour_styles: Vec<Style>,
 	pub border_style: Style,
@@ -30,13 +32,13 @@ impl Default for CanvasColours {
 			currently_selected_text_colour: Color::Black,
 			currently_selected_bg_colour: Color::Cyan,
 			currently_selected_text_style: Style::default().fg(Color::Black).bg(Color::Cyan),
-			table_header_style: Style::default()
-				.fg(Color::LightBlue)
-				.modifier(Modifier::BOLD),
+			table_header_style: Style::default().fg(Color::LightBlue),
 			ram_style: Style::default().fg(STANDARD_FIRST_COLOUR),
 			swap_style: Style::default().fg(STANDARD_SECOND_COLOUR),
 			rx_style: Style::default().fg(STANDARD_FIRST_COLOUR),
 			tx_style: Style::default().fg(STANDARD_SECOND_COLOUR),
+			rx_total_style: Style::default().fg(STANDARD_THIRD_COLOUR),
+			tx_total_style: Style::default().fg(STANDARD_FOURTH_COLOUR),
 			avg_colour_style: Style::default().fg(AVG_COLOUR),
 			cpu_colour_styles: Vec::new(),
 			border_style: Style::default().fg(text_colour),
@@ -86,6 +88,16 @@ impl CanvasColours {
 
 	pub fn set_tx_colour(&mut self, colour: &str) -> error::Result<()> {
 		self.tx_style = get_style_from_config(colour)?;
+		Ok(())
+	}
+
+	pub fn set_rx_total_colour(&mut self, colour: &str) -> error::Result<()> {
+		self.rx_total_style = get_style_from_config(colour)?;
+		Ok(())
+	}
+
+	pub fn set_tx_total_colour(&mut self, colour: &str) -> error::Result<()> {
+		self.tx_total_style = get_style_from_config(colour)?;
 		Ok(())
 	}
 

--- a/src/canvas/canvas_colours/colour_utils.rs
+++ b/src/canvas/canvas_colours/colour_utils.rs
@@ -5,6 +5,8 @@ use tui::style::{Color, Style};
 const GOLDEN_RATIO: f32 = 0.618_034; // Approx, good enough for use (also Clippy gets mad if it's too long)
 pub const STANDARD_FIRST_COLOUR: Color = Color::LightMagenta;
 pub const STANDARD_SECOND_COLOUR: Color = Color::LightYellow;
+pub const STANDARD_THIRD_COLOUR: Color = Color::LightCyan;
+pub const STANDARD_FOURTH_COLOUR: Color = Color::LightGreen;
 pub const AVG_COLOUR: Color = Color::Red;
 
 lazy_static! {
@@ -66,8 +68,8 @@ pub fn gen_n_styles(num_to_gen: i32) -> Vec<Style> {
 	let mut colour_vec: Vec<Style> = vec![
 		Style::default().fg(STANDARD_FIRST_COLOUR),
 		Style::default().fg(STANDARD_SECOND_COLOUR),
-		Style::default().fg(Color::LightCyan),
-		Style::default().fg(Color::LightGreen),
+		Style::default().fg(STANDARD_THIRD_COLOUR),
+		Style::default().fg(STANDARD_FOURTH_COLOUR),
 		Style::default().fg(Color::LightBlue),
 		Style::default().fg(Color::LightRed),
 		Style::default().fg(Color::Cyan),

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,8 @@ struct ConfigColours {
 	swap_color: Option<String>,
 	rx_color: Option<String>,
 	tx_color: Option<String>,
+	rx_total_color: Option<String>,
+	tx_total_color: Option<String>,
 	border_color: Option<String>,
 	highlighted_border_color: Option<String>,
 	text_color: Option<String>,
@@ -729,6 +731,14 @@ fn generate_config_colours(config: &Config, painter: &mut canvas::Painter) -> er
 
 		if let Some(tx_color) = &colours.tx_color {
 			painter.colours.set_tx_colour(tx_color)?;
+		}
+
+		if let Some(rx_total_color) = &colours.rx_total_color {
+			painter.colours.set_rx_total_colour(rx_total_color)?;
+		}
+
+		if let Some(tx_total_color) = &colours.tx_total_color {
+			painter.colours.set_tx_total_colour(tx_total_color)?;
 		}
 
 		if let Some(table_header_color) = &colours.table_header_color {


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Adds colouring options to config files + colours by default for total rx and tx.

![image](https://user-images.githubusercontent.com/34804052/75494538-7a462e00-598a-11ea-8423-c05615daea5d.png)

## Issue

If applicable, what issue does this address?

Closes: #17 

## Type of change

_Remove the irrelevant one:_

- [x] New feature (non-breaking change which adds functionality)

## Test methodology

_Please state how this was tested:_

Tested on macOS Catalina and Arch Linux on Terminal and Kitty respectively.

## Checklist

_Please ensure all are ticked (and actually done):_

- [x] Change has been tested to work
- [x] Code has been linted using rustfmt
- [x] Code has been self-reviewed
- [x] Code has been tested and no new breakage is introduced
- [x] Documentation has been added/updated if needed

## Other information

_Provide any other relevant information:_
