### PR TITLE
Switch to another arrow.

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1423,9 +1423,9 @@ impl Painter {
 		let mut mem = "Mem%(m)".to_string();
 
 		let direction_val = if app_state.process_sorting_reverse {
-			"⯆ ".to_string()
+			"▼".to_string()
 		} else {
-			"⯅ ".to_string()
+			"▲".to_string()
 		};
 
 		match app_state.process_sorting_type {


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Switches the character we used for arrows from ⯆⯅ to ▼▲

Seems like the old one caused rendering issues for macOS.

## Issue

If applicable, what issue does this address?

Closes: #45
Potentially #42 

## Type of change

_Remove the irrelevant one:_

- [x] Bug fix (non-breaking change which fixes an issue)

## Test methodology

_Please state how this was tested:_

Tested whether the arrow shows on Konsole, Terminator, and Kitty on Arch Linux.

Tested on macOS Catalina with Terminal and Kitty.

## Checklist

_Please ensure all are ticked (and actually done):_

- [x] Change has been tested to work
- [x] Code has been linted using rustfmt
- [x] Code has been self-reviewed
- [x] Code has been tested and no new breakage is introduced
- [x] Documentation has been added/updated if needed

## Other information

_Provide any other relevant information:_
