### PR TITLE
Cargo optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ path = "src/main.rs"
 #debug = true
 debug = 1
 opt-level = 3
-lto = true
+#lto = true
+lto = "fat"
+codegen-units = 1
 
 [dependencies]
 chrono = "0.4.10"


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Switch to "fat" for lto and change codegen units to 1.  May revert.

This should improve binary size (and potentially performance) a bit.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant one:_

- [x] Other (something else)

## Test methodology

_Please state how this was tested:_

Builds.

_Please tick which platforms this change was tested on:_

- [ ] Windows
- [ ] macOS
- [x] Linux

## Checklist

_Please ensure all are ticked (and actually done):_

- [ ] Change has been tested to work
- [ ] Areas your change affects has been linted using rustfmt
- [ ] Code has been self-reviewed
- [ ] Code has been tested and no new breakage is introduced
- [ ] Documentation has been added/updated if needed
- [ ] No merge conflicts arise from the change

## Other information

_Provide any other relevant information:_
