### PR TITLE
Fix basic bars overlapping

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1658,8 +1658,7 @@ impl Painter {
             let margin_space = 2;
             let remaining_width = max(
                 0,
-                draw_loc.width as i64
-                    - ((9 + margin_space) * REQUIRED_COLUMNS - margin_space) as i64,
+                draw_loc.width as i64 - ((9 + margin_space) * REQUIRED_COLUMNS) as i64,
             ) as usize;
 
             let bar_length = remaining_width / REQUIRED_COLUMNS;


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes an overlapping issue on basic bars.

## Issue

_If applicable, what issue does this address?_

Closes: #66 

## Type of change

_Remove the irrelevant one:_

- [x] Bug fix (non-breaking change which fixes an issue)

## Test methodology

_Please state how this was tested:_

Checked to work on small windows on macOS and Arch Linux.

_Please tick which platforms this change was tested on:_

- [ ] Windows
- [x] macOS
- [x] Linux

## Checklist

_Please ensure all are ticked (and actually done):_

- [x] Change has been tested to work
- [x] Areas your change affects has been linted using rustfmt
- [x] Code has been self-reviewed
- [x] Code has been tested and no new breakage is introduced
- [x] Documentation has been added/updated if needed
- [x] No merge conflicts arise from the change

## Other information

_Provide any other relevant information:_
