### PR TITLE
Time scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Run using `btm`.
 
 - `-t`, `--default_time_value` will set the default time interval graphs will display to (in milliseconds). Lowest is 30 seconds, defaults to 60 seconds.
 
-- `-i`, `--time_delta` will set the amount each zoom in/out action will change the time interval of a graph (in milliseconds). Lowest is 1 second, defaults to 15 seconds.
+- `-d`, `--time_delta` will set the amount each zoom in/out action will change the time interval of a graph (in milliseconds). Lowest is 1 second, defaults to 15 seconds.
 
 ### Keybindings
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ Note that `q` is disabled while in the search widget.
 
 - Scrolling with the mouse will scroll through the currently selected list if the widget is a scrollable table.
 
+- Scrolling on a graph will zoom in (scroll up) or zoom out (scroll down).
+
 ## Bugs and Requests
 
 Spot an bug? Have an idea? Leave an issue that explains what you want in detail and I'll try to take a look.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Run using `btm`.
 
 - `-v`, `--version` displays the version number and exits.
 
-- `-r <RATE>`, `--rate <RATE>` will set the refresh rate in _milliseconds_. Lowest it can go is 250ms, the highest it can go is 2<sup>128</sup> - 1. Defaults to 1000ms, and lower values may take more resources due to more frequent polling of data, and may be less accurate in some circumstances.
+- `-r <RATE>`, `--rate <RATE>` will set the refresh rate in _milliseconds_. Lowest it can go is 250ms, the highest it can go is 2<sup>64</sup> - 1. Defaults to 1000ms, and lower values may take more resources due to more frequent polling of data, and may be less accurate in some circumstances.
 
 - `-l`, `--left_legend` will move external table legends to the left side rather than the right side. Right side is default.
 
@@ -139,6 +139,10 @@ Run using `btm`.
 - `-C`, `--config` takes in a file path leading to a TOML file. If the file doesn't exist, one will be created.
 
 - `-b`, `--basic` will enable basic mode, removing all graphs from the main interface and condensing data.
+
+- `-t`, `--default_time_value` will set the default time interval graphs will display to (in milliseconds). Lowest is 30 seconds, defaults to 60 seconds.
+
+- `-i`, `--time_delta` will set the amount each zoom in/out action will change the time interval of a graph (in milliseconds). Lowest is 1 second, defaults to 15 seconds.
 
 ### Keybindings
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ Run using `btm`.
 
 - `Enter` on a widget to maximize the widget.
 
+- `+` to zoom in (reduce time interval, smallest is 30 seconds).
+
+- `-` to zoom out (increase time interval, largest is 10 minutes).
+
+- `=` to reset zoom.
+
 #### CPU
 
 - `/` to allow for enabling/disabling showing certain cores with `Space`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Features of bottom include:
 
 - Maximizing of widgets of interest to take up the entire window.
 
-- Basic mode
+- A minimal mode that focuses less on graphs and more on data, similar to [htop](https://hisham.hm/htop/).
+
+- Zooming in/out to see more/less data.
 
 More details about each widget and compatibility can be found [here](./docs/widgets.md).
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -246,7 +246,7 @@ impl Default for NetState {
             zoom_level: 100.0,
             display_time: constants::DEFAULT_TIME_MILLISECONDS,
             force_update: false,
-            display_time_instant: Some(Instant::now()),
+            display_time_instant: None,
         }
     }
 }
@@ -269,7 +269,7 @@ impl Default for CpuState {
             core_show_vec: Vec::new(),
             display_time: constants::DEFAULT_TIME_MILLISECONDS,
             force_update: false,
-            display_time_instant: Some(Instant::now()),
+            display_time_instant: None,
         }
     }
 }
@@ -294,7 +294,7 @@ impl Default for MemState {
             zoom_level: 100.0,
             display_time: constants::DEFAULT_TIME_MILLISECONDS,
             force_update: false,
-            display_time_instant: Some(Instant::now()),
+            display_time_instant: None,
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -246,7 +246,7 @@ impl Default for NetState {
             zoom_level: 100.0,
             display_time: constants::DEFAULT_TIME_MILLISECONDS,
             force_update: false,
-            display_time_instant: None,
+            display_time_instant: Some(Instant::now()),
         }
     }
 }
@@ -269,7 +269,7 @@ impl Default for CpuState {
             core_show_vec: Vec::new(),
             display_time: constants::DEFAULT_TIME_MILLISECONDS,
             force_update: false,
-            display_time_instant: None,
+            display_time_instant: Some(Instant::now()),
         }
     }
 }
@@ -294,7 +294,7 @@ impl Default for MemState {
             zoom_level: 100.0,
             display_time: constants::DEFAULT_TIME_MILLISECONDS,
             force_update: false,
-            display_time_instant: None,
+            display_time_instant: Some(Instant::now()),
         }
     }
 }

--- a/src/app/data_farmer.rs
+++ b/src/app/data_farmer.rs
@@ -84,12 +84,12 @@ impl DataCollection {
         self.frozen_instant = Some(self.current_instant);
     }
 
-    pub fn clean_data(&mut self, max_time_millis: u128) {
+    pub fn clean_data(&mut self, max_time_millis: u64) {
         let current_time = Instant::now();
 
         let mut remove_index = 0;
         for entry in &self.timed_data_vec {
-            if current_time.duration_since(entry.0).as_millis() >= max_time_millis {
+            if current_time.duration_since(entry.0).as_millis() >= max_time_millis as u128 {
                 remove_index += 1;
             } else {
                 break;

--- a/src/app/data_farmer.rs
+++ b/src/app/data_farmer.rs
@@ -45,6 +45,7 @@ pub struct TimedData {
 #[derive(Debug)]
 pub struct DataCollection {
     pub current_instant: Instant,
+    pub frozen_instant: Option<Instant>,
     pub timed_data_vec: Vec<(Instant, TimedData)>,
     pub network_harvest: network::NetworkHarvest,
     pub memory_harvest: mem::MemHarvest,
@@ -62,6 +63,7 @@ impl Default for DataCollection {
     fn default() -> Self {
         DataCollection {
             current_instant: Instant::now(),
+            frozen_instant: None,
             timed_data_vec: Vec::default(),
             network_harvest: network::NetworkHarvest::default(),
             memory_harvest: mem::MemHarvest::default(),
@@ -78,6 +80,10 @@ impl Default for DataCollection {
 }
 
 impl DataCollection {
+    pub fn set_frozen_time(&mut self) {
+        self.frozen_instant = Some(self.current_instant);
+    }
+
     pub fn clean_data(&mut self, max_time_millis: u128) {
         let current_time = Instant::now();
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -235,7 +235,7 @@ impl Painter {
                     .constraints([Constraint::Percentage(100)].as_ref())
                     .split(f.size());
                 match &app_state.current_widget_selected {
-                    WidgetPosition::Cpu | WidgetPosition::BasicCpu => {
+                    WidgetPosition::Cpu | WidgetPosition::BasicCpu | WidgetPosition::CpuLegend => {
                         let cpu_chunk = Layout::default()
                             .direction(Direction::Horizontal)
                             .margin(0)
@@ -272,7 +272,9 @@ impl Painter {
                     WidgetPosition::Temp => {
                         self.draw_temp_table(&mut f, app_state, rect[0], true);
                     }
-                    WidgetPosition::Network | WidgetPosition::BasicNet => {
+                    WidgetPosition::Network
+                    | WidgetPosition::BasicNet
+                    | WidgetPosition::NetworkLegend => {
                         self.draw_network_graph(&mut f, &app_state, rect[0]);
                     }
                     WidgetPosition::Process | WidgetPosition::ProcessSearch => {

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -72,44 +72,47 @@ pub struct Painter {
 impl Painter {
     /// Must be run once before drawing, but after setting colours.
     /// This is to set some remaining styles and text.
-    /// This bypasses some logic checks (size > 2, for example) but this
-    /// assumes that you, the programmer, are sane and do not do stupid things.
-    /// RIGHT?
     pub fn initialize(&mut self) {
         self.is_mac_os = cfg!(target_os = "macos");
 
-        self.styled_general_help_text.push(Text::Styled(
-            GENERAL_HELP_TEXT[0].into(),
-            self.colours.table_header_style,
-        ));
-        self.styled_general_help_text.extend(
-            GENERAL_HELP_TEXT[1..]
-                .iter()
-                .map(|&text| Text::Styled(text.into(), self.colours.text_style))
-                .collect::<Vec<_>>(),
-        );
+        if GENERAL_HELP_TEXT.len() > 1 {
+            self.styled_general_help_text.push(Text::Styled(
+                GENERAL_HELP_TEXT[0].into(),
+                self.colours.table_header_style,
+            ));
+            self.styled_general_help_text.extend(
+                GENERAL_HELP_TEXT[1..]
+                    .iter()
+                    .map(|&text| Text::Styled(text.into(), self.colours.text_style))
+                    .collect::<Vec<_>>(),
+            );
+        }
 
-        self.styled_process_help_text.push(Text::Styled(
-            PROCESS_HELP_TEXT[0].into(),
-            self.colours.table_header_style,
-        ));
-        self.styled_process_help_text.extend(
-            PROCESS_HELP_TEXT[1..]
-                .iter()
-                .map(|&text| Text::Styled(text.into(), self.colours.text_style))
-                .collect::<Vec<_>>(),
-        );
+        if PROCESS_HELP_TEXT.len() > 1 {
+            self.styled_process_help_text.push(Text::Styled(
+                PROCESS_HELP_TEXT[0].into(),
+                self.colours.table_header_style,
+            ));
+            self.styled_process_help_text.extend(
+                PROCESS_HELP_TEXT[1..]
+                    .iter()
+                    .map(|&text| Text::Styled(text.into(), self.colours.text_style))
+                    .collect::<Vec<_>>(),
+            );
+        }
 
-        self.styled_search_help_text.push(Text::Styled(
-            SEARCH_HELP_TEXT[0].into(),
-            self.colours.table_header_style,
-        ));
-        self.styled_search_help_text.extend(
-            SEARCH_HELP_TEXT[1..]
-                .iter()
-                .map(|&text| Text::Styled(text.into(), self.colours.text_style))
-                .collect::<Vec<_>>(),
-        );
+        if SEARCH_HELP_TEXT.len() > 1 {
+            self.styled_search_help_text.push(Text::Styled(
+                SEARCH_HELP_TEXT[0].into(),
+                self.colours.table_header_style,
+            ));
+            self.styled_search_help_text.extend(
+                SEARCH_HELP_TEXT[1..]
+                    .iter()
+                    .map(|&text| Text::Styled(text.into(), self.colours.text_style))
+                    .collect::<Vec<_>>(),
+            );
+        }
     }
 
     pub fn draw_specific_table<B: Backend>(
@@ -260,11 +263,11 @@ impl Painter {
                             0
                         };
 
-                        self.draw_cpu_graph(&mut f, &app_state, cpu_chunk[graph_index]);
+                        self.draw_cpu_graph(&mut f, app_state, cpu_chunk[graph_index]);
                         self.draw_cpu_legend(&mut f, app_state, cpu_chunk[legend_index]);
                     }
                     WidgetPosition::Mem | WidgetPosition::BasicMem => {
-                        self.draw_memory_graph(&mut f, &app_state, rect[0]);
+                        self.draw_memory_graph(&mut f, app_state, rect[0]);
                     }
                     WidgetPosition::Disk => {
                         self.draw_disk_table(&mut f, app_state, rect[0], true);
@@ -275,7 +278,7 @@ impl Painter {
                     WidgetPosition::Network
                     | WidgetPosition::BasicNet
                     | WidgetPosition::NetworkLegend => {
-                        self.draw_network_graph(&mut f, &app_state, rect[0]);
+                        self.draw_network_graph(&mut f, app_state, rect[0]);
                     }
                     WidgetPosition::Process | WidgetPosition::ProcessSearch => {
                         self.draw_process_and_search(&mut f, app_state, rect[0], true);
@@ -408,10 +411,10 @@ impl Painter {
                     0
                 };
 
-                self.draw_cpu_graph(&mut f, &app_state, cpu_chunk[graph_index]);
+                self.draw_cpu_graph(&mut f, app_state, cpu_chunk[graph_index]);
                 self.draw_cpu_legend(&mut f, app_state, cpu_chunk[legend_index]);
-                self.draw_memory_graph(&mut f, &app_state, middle_chunks[0]);
-                self.draw_network_graph(&mut f, &app_state, network_chunk[0]);
+                self.draw_memory_graph(&mut f, app_state, middle_chunks[0]);
+                self.draw_network_graph(&mut f, app_state, network_chunk[0]);
                 self.draw_network_labels(&mut f, app_state, network_chunk[1]);
                 self.draw_temp_table(&mut f, app_state, middle_divided_chunk_2[0], true);
                 self.draw_disk_table(&mut f, app_state, middle_divided_chunk_2[1], true);

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -35,12 +35,12 @@ pub struct DisplayableData {
     pub network_data_tx: Vec<(f64, f64)>,
     pub disk_data: Vec<Vec<String>>,
     pub temp_sensor_data: Vec<Vec<String>>,
+    // Not the final value
     pub process_data: HashMap<u32, ProcessHarvest>,
     // Not the final value
     pub grouped_process_data: Vec<ConvertedProcessData>,
-    // Not the final value
-    pub finalized_process_data: Vec<ConvertedProcessData>,
     // What's actually displayed
+    pub finalized_process_data: Vec<ConvertedProcessData>,
     pub mem_label: String,
     pub swap_label: String,
     pub mem_data: Vec<(f64, f64)>,

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -17,7 +17,7 @@ use tui::{
     widgets::{Axis, Block, Borders, Chart, Dataset, Marker, Row, Table, Widget},
 };
 
-const CPU_SELECT_LEGEND_HEADER: [&str; 2] = ["CPU", "Show (Space)"];
+const CPU_SELECT_LEGEND_HEADER: [&str; 2] = ["CPU", "Show"];
 const CPU_LEGEND_HEADER: [&str; 2] = ["CPU", "Use%"];
 lazy_static! {
     static ref CPU_LEGEND_HEADER_LENS: Vec<usize> = CPU_LEGEND_HEADER
@@ -92,22 +92,22 @@ impl CpuGraphWidget for Painter {
             " CPU ".to_string()
         };
 
+        let border_style = match app_state.current_widget_selected {
+            WidgetPosition::Cpu => self.colours.highlighted_border_style,
+            _ => self.colours.border_style,
+        };
+
         Chart::default()
             .block(
                 Block::default()
                     .title(&title)
                     .title_style(if app_state.is_expanded {
-                        self.colours.highlighted_border_style
+                        border_style
                     } else {
                         self.colours.widget_title_style
                     })
                     .borders(Borders::ALL)
-                    .border_style(match app_state.current_widget_selected {
-                        WidgetPosition::Cpu | WidgetPosition::BasicCpu => {
-                            self.colours.highlighted_border_style
-                        }
-                        _ => self.colours.border_style,
-                    }),
+                    .border_style(border_style),
             )
             .x_axis(x_axis)
             .y_axis(y_axis)
@@ -167,7 +167,7 @@ impl CpuGraphWidget for Painter {
                 Row::StyledData(
                     cpu_string_row.iter(),
                     match app_state.current_widget_selected {
-                        WidgetPosition::Cpu => {
+                        WidgetPosition::CpuLegend => {
                             if itx as u64
                                 == app_state
                                     .app_scroll_positions
@@ -225,6 +225,11 @@ impl CpuGraphWidget for Painter {
             "".to_string()
         };
 
+        let title_and_border_style = match app_state.current_widget_selected {
+            WidgetPosition::CpuLegend => self.colours.highlighted_border_style,
+            _ => self.colours.border_style,
+        };
+
         // Draw
         Table::new(
             if app_state.cpu_state.is_showing_tray {
@@ -238,19 +243,9 @@ impl CpuGraphWidget for Painter {
         .block(
             Block::default()
                 .title(&title)
-                .title_style(if app_state.is_expanded {
-                    self.colours.highlighted_border_style
-                } else {
-                    match app_state.current_widget_selected {
-                        WidgetPosition::Cpu => self.colours.highlighted_border_style,
-                        _ => self.colours.border_style,
-                    }
-                })
+                .title_style(title_and_border_style)
                 .borders(Borders::ALL)
-                .border_style(match app_state.current_widget_selected {
-                    WidgetPosition::Cpu => self.colours.highlighted_border_style,
-                    _ => self.colours.border_style,
-                }),
+                .border_style(title_and_border_style),
         )
         .header_style(self.colours.table_header_style)
         .widths(

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -41,8 +41,17 @@ impl CpuGraphWidget for Painter {
     fn draw_cpu_graph<B: Backend>(&self, f: &mut Frame<'_, B>, app_state: &App, draw_loc: Rect) {
         let cpu_data: &[ConvertedCpuData] = &app_state.canvas_data.cpu_data;
 
-        // CPU usage graph
-        let x_axis: Axis<'_, String> = Axis::default().bounds([0.0, TIME_STARTS_FROM as f64]);
+        let display_time_labels = [
+            format!("{}s", app_state.cpu_state.display_time / 1000),
+            "0s".to_string(),
+        ];
+        let x_axis = Axis::default()
+            .bounds([0.0, app_state.cpu_state.display_time as f64])
+            .style(self.colours.graph_style)
+            .labels_style(self.colours.graph_style)
+            .labels(&display_time_labels);
+
+        // Note this is offset as otherwise the 0 value is not drawn!
         let y_axis = Axis::default()
             .style(self.colours.graph_style)
             .labels_style(self.colours.graph_style)

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -47,8 +47,10 @@ impl CpuGraphWidget for Painter {
             format!("{}s", app_state.cpu_state.display_time / 1000),
             "0s".to_string(),
         ];
+
         let x_axis = if app_state.app_config_fields.hide_time
-            || app_state.cpu_state.display_time_instant.is_none()
+            || (app_state.app_config_fields.autohide_time
+                && app_state.cpu_state.display_time_instant.is_none())
         {
             Axis::default().bounds([0.0, app_state.cpu_state.display_time as f64])
         } else if let Some(time) = app_state.cpu_state.display_time_instant {

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -31,25 +31,46 @@ lazy_static! {
 }
 
 pub trait CpuGraphWidget {
-    fn draw_cpu_graph<B: Backend>(&self, f: &mut Frame<'_, B>, app_state: &App, draw_loc: Rect);
+    fn draw_cpu_graph<B: Backend>(&self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect);
     fn draw_cpu_legend<B: Backend>(
         &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect,
     );
 }
 
 impl CpuGraphWidget for Painter {
-    fn draw_cpu_graph<B: Backend>(&self, f: &mut Frame<'_, B>, app_state: &App, draw_loc: Rect) {
+    fn draw_cpu_graph<B: Backend>(
+        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect,
+    ) {
         let cpu_data: &[ConvertedCpuData] = &app_state.canvas_data.cpu_data;
 
         let display_time_labels = [
             format!("{}s", app_state.cpu_state.display_time / 1000),
             "0s".to_string(),
         ];
-        let x_axis = Axis::default()
-            .bounds([0.0, app_state.cpu_state.display_time as f64])
-            .style(self.colours.graph_style)
-            .labels_style(self.colours.graph_style)
-            .labels(&display_time_labels);
+        let x_axis = if app_state.app_config_fields.hide_time
+            || app_state.cpu_state.display_time_instant.is_none()
+        {
+            Axis::default().bounds([0.0, app_state.cpu_state.display_time as f64])
+        } else if let Some(time) = app_state.cpu_state.display_time_instant {
+            if std::time::Instant::now().duration_since(time).as_millis()
+                < AUTOHIDE_TIMEOUT_MILLISECONDS as u128
+            {
+                Axis::default()
+                    .bounds([0.0, app_state.cpu_state.display_time as f64])
+                    .style(self.colours.graph_style)
+                    .labels_style(self.colours.graph_style)
+                    .labels(&display_time_labels)
+            } else {
+                app_state.cpu_state.display_time_instant = None;
+                Axis::default().bounds([0.0, app_state.cpu_state.display_time as f64])
+            }
+        } else {
+            Axis::default()
+                .bounds([0.0, app_state.cpu_state.display_time as f64])
+                .style(self.colours.graph_style)
+                .labels_style(self.colours.graph_style)
+                .labels(&display_time_labels)
+        };
 
         // Note this is offset as otherwise the 0 value is not drawn!
         let y_axis = Axis::default()

--- a/src/canvas/widgets/mem_graph.rs
+++ b/src/canvas/widgets/mem_graph.rs
@@ -79,9 +79,7 @@ impl MemGraphWidget for Painter {
                     })
                     .borders(Borders::ALL)
                     .border_style(match app_state.current_widget_selected {
-                        WidgetPosition::Mem | WidgetPosition::BasicMem => {
-                            self.colours.highlighted_border_style
-                        }
+                        WidgetPosition::Mem => self.colours.highlighted_border_style,
                         _ => self.colours.border_style,
                     }),
             )

--- a/src/canvas/widgets/mem_graph.rs
+++ b/src/canvas/widgets/mem_graph.rs
@@ -31,7 +31,8 @@ impl MemGraphWidget for Painter {
             "0s".to_string(),
         ];
         let x_axis = if app_state.app_config_fields.hide_time
-            || app_state.mem_state.display_time_instant.is_none()
+            || (app_state.app_config_fields.autohide_time
+                && app_state.mem_state.display_time_instant.is_none())
         {
             Axis::default().bounds([0.0, app_state.mem_state.display_time as f64])
         } else if let Some(time) = app_state.mem_state.display_time_instant {

--- a/src/canvas/widgets/mem_graph.rs
+++ b/src/canvas/widgets/mem_graph.rs
@@ -3,7 +3,6 @@ use std::cmp::max;
 use crate::{
     app::{App, WidgetPosition},
     canvas::Painter,
-    constants::*,
 };
 
 use tui::{
@@ -22,7 +21,15 @@ impl MemGraphWidget for Painter {
         let mem_data: &[(f64, f64)] = &app_state.canvas_data.mem_data;
         let swap_data: &[(f64, f64)] = &app_state.canvas_data.swap_data;
 
-        let x_axis: Axis<'_, String> = Axis::default().bounds([0.0, TIME_STARTS_FROM as f64]);
+        let display_time_labels = [
+            format!("{}s", app_state.mem_state.display_time / 1000),
+            "0s".to_string(),
+        ];
+        let x_axis = Axis::default()
+            .bounds([0.0, app_state.mem_state.display_time as f64])
+            .style(self.colours.graph_style)
+            .labels_style(self.colours.graph_style)
+            .labels(&display_time_labels);
 
         // Offset as the zero value isn't drawn otherwise...
         let y_axis: Axis<'_, &str> = Axis::default()

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -37,7 +37,17 @@ impl NetworkGraphWidget for Painter {
         let network_data_rx: &[(f64, f64)] = &app_state.canvas_data.network_data_rx;
         let network_data_tx: &[(f64, f64)] = &app_state.canvas_data.network_data_tx;
 
-        let x_axis: Axis<'_, String> = Axis::default().bounds([0.0, 60_000.0]);
+        let display_time_labels = [
+            format!("{}s", app_state.net_state.display_time / 1000),
+            "0s".to_string(),
+        ];
+        let x_axis = Axis::default()
+            .bounds([0.0, app_state.net_state.display_time as f64])
+            .style(self.colours.graph_style)
+            .labels_style(self.colours.graph_style)
+            .labels(&display_time_labels);
+
+            // 0 is offset.
         let y_axis: Axis<'_, &str> = Axis::default()
             .style(self.colours.graph_style)
             .labels_style(self.colours.graph_style)

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -23,7 +23,9 @@ lazy_static! {
 }
 
 pub trait NetworkGraphWidget {
-    fn draw_network_graph<B: Backend>(&self, f: &mut Frame<'_, B>, app_state: &App, draw_loc: Rect);
+    fn draw_network_graph<B: Backend>(
+        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect,
+    );
 
     fn draw_network_labels<B: Backend>(
         &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect,
@@ -32,7 +34,7 @@ pub trait NetworkGraphWidget {
 
 impl NetworkGraphWidget for Painter {
     fn draw_network_graph<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &App, draw_loc: Rect,
+        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect,
     ) {
         let network_data_rx: &[(f64, f64)] = &app_state.canvas_data.network_data_rx;
         let network_data_tx: &[(f64, f64)] = &app_state.canvas_data.network_data_tx;
@@ -41,13 +43,32 @@ impl NetworkGraphWidget for Painter {
             format!("{}s", app_state.net_state.display_time / 1000),
             "0s".to_string(),
         ];
-        let x_axis = Axis::default()
-            .bounds([0.0, app_state.net_state.display_time as f64])
-            .style(self.colours.graph_style)
-            .labels_style(self.colours.graph_style)
-            .labels(&display_time_labels);
+        let x_axis = if app_state.app_config_fields.hide_time
+            || app_state.net_state.display_time_instant.is_none()
+        {
+            Axis::default().bounds([0.0, app_state.net_state.display_time as f64])
+        } else if let Some(time) = app_state.net_state.display_time_instant {
+            if std::time::Instant::now().duration_since(time).as_millis()
+                < AUTOHIDE_TIMEOUT_MILLISECONDS as u128
+            {
+                Axis::default()
+                    .bounds([0.0, app_state.net_state.display_time as f64])
+                    .style(self.colours.graph_style)
+                    .labels_style(self.colours.graph_style)
+                    .labels(&display_time_labels)
+            } else {
+                app_state.net_state.display_time_instant = None;
+                Axis::default().bounds([0.0, app_state.net_state.display_time as f64])
+            }
+        } else {
+            Axis::default()
+                .bounds([0.0, app_state.net_state.display_time as f64])
+                .style(self.colours.graph_style)
+                .labels_style(self.colours.graph_style)
+                .labels(&display_time_labels)
+        };
 
-            // 0 is offset.
+        // 0 is offset.
         let y_axis: Axis<'_, &str> = Axis::default()
             .style(self.colours.graph_style)
             .labels_style(self.colours.graph_style)

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -71,9 +71,7 @@ impl NetworkGraphWidget for Painter {
                     })
                     .borders(Borders::ALL)
                     .border_style(match app_state.current_widget_selected {
-                        WidgetPosition::Network | WidgetPosition::BasicNet => {
-                            self.colours.highlighted_border_style
-                        }
+                        WidgetPosition::Network => self.colours.highlighted_border_style,
                         _ => self.colours.border_style,
                     }),
             )

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -44,7 +44,8 @@ impl NetworkGraphWidget for Painter {
             "0s".to_string(),
         ];
         let x_axis = if app_state.app_config_fields.hide_time
-            || app_state.net_state.display_time_instant.is_none()
+            || (app_state.app_config_fields.autohide_time
+                && app_state.net_state.display_time_instant.is_none())
         {
             Axis::default().bounds([0.0, app_state.net_state.display_time as f64])
         } else if let Some(time) = app_state.net_state.display_time_instant {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,15 +1,15 @@
 // How long to store data.
-pub const STALE_MAX_MILLISECONDS: u128 = 300 * 1000; // Keep 5 minutes of data.
+pub const STALE_MAX_MILLISECONDS: u64 = 300 * 1000; // Keep 5 minutes of data.
 
 // How much data is SHOWN
-pub const DEFAULT_DISPLAY_MILLISECONDS: u128 = 60 * 1000; // Defaults to 1 min.
-pub const STALE_MIN_MILLISECONDS: u128 = 30 * 1000; // Lowest is 30 seconds
-pub const TIME_CHANGE_MILLISECONDS: u128 = 15 * 1000; // How much to increment each time
+pub const DEFAULT_TIME_MILLISECONDS: u64 = 60 * 1000; // Defaults to 1 min.
+pub const STALE_MIN_MILLISECONDS: u64 = 30 * 1000; // Lowest is 30 seconds
+pub const TIME_CHANGE_MILLISECONDS: u64 = 15 * 1000; // How much to increment each time
 
 pub const TICK_RATE_IN_MILLISECONDS: u64 = 200;
 // How fast the screen refreshes
-pub const DEFAULT_REFRESH_RATE_IN_MILLISECONDS: u128 = 1000;
-pub const MAX_KEY_TIMEOUT_IN_MILLISECONDS: u128 = 1000;
+pub const DEFAULT_REFRESH_RATE_IN_MILLISECONDS: u64 = 1000;
+pub const MAX_KEY_TIMEOUT_IN_MILLISECONDS: u64 = 1000;
 // Number of colours to generate for the CPU chart/table
 pub const NUM_COLOURS: i32 = 256;
 
@@ -30,7 +30,7 @@ lazy_static! {
 }
 
 // Help text
-pub const GENERAL_HELP_TEXT: [&str; 15] = [
+pub const GENERAL_HELP_TEXT: [&str; 18] = [
     "General Keybindings\n\n",
     "q, Ctrl-c      Quit bottom\n",
     "Esc            Close filters, dialog boxes, etc.\n",
@@ -46,6 +46,9 @@ pub const GENERAL_HELP_TEXT: [&str; 15] = [
     "G              Skip to the last entry of a list\n",
     "Enter          Maximize the currently selected widget\n",
     "/              Filter out graph lines (only CPU at the moment)\n",
+    "+              Zoom in (decrease time range)\n",
+    "-              Zoom out (increase time range)\n",
+    "=              Reset zoom\n",
 ];
 
 pub const PROCESS_HELP_TEXT: [&str; 8] = [
@@ -90,15 +93,34 @@ pub const DEFAULT_CONFIG_CONTENT: &str = r##"
 # is also set here.
 [flags]
 
+# Whether to display an average cpu entry.
 #avg_cpu = true
+
+# Whether to use dot markers rather than braille.
 #dot_marker = false
+
+# The update rate of the application.
 #rate = 1000
+
+# Whether to put the CPU legend to the left.
 #left_legend = false
+
+# Whether to set CPU% on a process to be based on the total CPU or just current usage.
 #current_usage = false
+
+# Whether to group processes with the same name together by default.
 #group_processes = false
+
+# Whether to make process searching case sensitive by default.
 #case_sensitive = false
+
+# Whether to make process searching look for matching the entire word by default.
 #whole_word = true
+
+# Whether to make process searching use regex by default.
 #regex = true
+
+# Whether to show CPU entries in the legend when they are hidden.
 #show_disabled_data = true
 
 # Defaults to Celsius.  Temperature is one of:
@@ -117,6 +139,11 @@ pub const DEFAULT_CONFIG_CONTENT: &str = r##"
 #default_widget = "network_default"
 #default_widget = "process_default"
 
+# The default time interval (in milliseconds).
+#default_time_value = 60000
+
+# The time delta on each zoom in/out action (in milliseconds).
+# time_delta = 15000
 
 # These are all the components that support custom theming.  Currently, it only
 # supports taking in a string representing a hex colour.  Note that colour support
@@ -132,7 +159,7 @@ pub const DEFAULT_CONFIG_CONTENT: &str = r##"
 # Represents the colour of the label each widget has.
 #widget_title_color="#cc241d"
 
-# Represents the average CPU color
+# Represents the average CPU color.
 #avg_cpu_color="#d3869b"
 
 # Represents the colour the core will use in the CPU legend and graph.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,11 @@
 // How long to store data.
-pub const STALE_MAX_MILLISECONDS: u128 = 60 * 1000;
-pub const TIME_STARTS_FROM: u64 = 60 * 1000;
+pub const STALE_MAX_MILLISECONDS: u128 = 300 * 1000; // Keep 5 minutes of data.
+
+// How much data is SHOWN
+pub const DEFAULT_DISPLAY_MILLISECONDS: u128 = 60 * 1000; // Defaults to 1 min.
+pub const STALE_MIN_MILLISECONDS: u128 = 30 * 1000; // Lowest is 30 seconds
+pub const TIME_CHANGE_MILLISECONDS: u128 = 15 * 1000; // How much to increment each time
+
 pub const TICK_RATE_IN_MILLISECONDS: u64 = 200;
 // How fast the screen refreshes
 pub const DEFAULT_REFRESH_RATE_IN_MILLISECONDS: u128 = 1000;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,10 +1,11 @@
 // How long to store data.
-pub const STALE_MAX_MILLISECONDS: u64 = 300 * 1000; // Keep 5 minutes of data.
+pub const STALE_MAX_MILLISECONDS: u64 = 600 * 1000; // Keep 10 minutes of data.
 
 // How much data is SHOWN
 pub const DEFAULT_TIME_MILLISECONDS: u64 = 60 * 1000; // Defaults to 1 min.
 pub const STALE_MIN_MILLISECONDS: u64 = 30 * 1000; // Lowest is 30 seconds
 pub const TIME_CHANGE_MILLISECONDS: u64 = 15 * 1000; // How much to increment each time
+pub const AUTOHIDE_TIMEOUT_MILLISECONDS: u64 = 5000; // 5 seconds to autohide
 
 pub const TICK_RATE_IN_MILLISECONDS: u64 = 200;
 // How fast the screen refreshes
@@ -143,7 +144,7 @@ pub const DEFAULT_CONFIG_CONTENT: &str = r##"
 #default_time_value = 60000
 
 # The time delta on each zoom in/out action (in milliseconds).
-# time_delta = 15000
+#time_delta = 15000
 
 # These are all the components that support custom theming.  Currently, it only
 # supports taking in a string representing a hex colour.  Note that colour support

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -102,7 +102,7 @@ pub fn convert_disk_row(current_data: &data_farmer::DataCollection) -> Vec<Vec<S
 }
 
 pub fn convert_cpu_data_points(
-    show_avg_cpu: bool, current_data: &data_farmer::DataCollection, display_time: u128,
+    show_avg_cpu: bool, current_data: &data_farmer::DataCollection, display_time: u64,
     is_frozen: bool,
 ) -> Vec<ConvertedCpuData> {
     let mut cpu_data_vector: Vec<ConvertedCpuData> = Vec::new();
@@ -156,7 +156,7 @@ pub fn convert_cpu_data_points(
 }
 
 pub fn convert_mem_data_points(
-    current_data: &data_farmer::DataCollection, display_time: u128, is_frozen: bool,
+    current_data: &data_farmer::DataCollection, display_time: u64, is_frozen: bool,
 ) -> Vec<Point> {
     let mut result: Vec<Point> = Vec::new();
     let current_time = if is_frozen {
@@ -190,7 +190,7 @@ pub fn convert_mem_data_points(
 }
 
 pub fn convert_swap_data_points(
-    current_data: &data_farmer::DataCollection, display_time: u128, is_frozen: bool,
+    current_data: &data_farmer::DataCollection, display_time: u64, is_frozen: bool,
 ) -> Vec<Point> {
     let mut result: Vec<Point> = Vec::new();
     let current_time = if is_frozen {
@@ -260,7 +260,7 @@ pub fn convert_mem_labels(current_data: &data_farmer::DataCollection) -> (String
 }
 
 pub fn get_rx_tx_data_points(
-    current_data: &data_farmer::DataCollection, display_time: u128, is_frozen: bool,
+    current_data: &data_farmer::DataCollection, display_time: u64, is_frozen: bool,
 ) -> (Vec<Point>, Vec<Point>) {
     let mut rx: Vec<Point> = Vec::new();
     let mut tx: Vec<Point> = Vec::new();
@@ -275,6 +275,7 @@ pub fn get_rx_tx_data_points(
         current_data.current_instant
     };
 
+    // TODO: [REFACTOR] Can we use combine on this, CPU, and MEM?
     for (time, data) in &current_data.timed_data_vec {
         let time_from_start: f64 =
             (display_time as f64 - current_time.duration_since(*time).as_millis() as f64).floor();
@@ -302,7 +303,7 @@ pub fn get_rx_tx_data_points(
 }
 
 pub fn convert_network_data_points(
-    current_data: &data_farmer::DataCollection, display_time: u128, is_frozen: bool,
+    current_data: &data_farmer::DataCollection, display_time: u64, is_frozen: bool,
 ) -> ConvertedNetworkData {
     let (rx, tx) = get_rx_tx_data_points(current_data, display_time, is_frozen);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,8 +87,10 @@ fn get_matches() -> clap::ArgMatches<'static> {
 		(@arg REGEX_DEFAULT: -R --regex "Use regex in searching by default.")
         (@arg SHOW_DISABLED_DATA: -s --show_disabled_data "Show disabled data entries.")
         (@arg DEFAULT_TIME_VALUE: -t --default_time_value +takes_value "Default time value for graphs in milliseconds; minimum is 30s, defaults to 60s.")
-        (@arg TIME_DELTA: -i --time_delta +takes_value "The amount changed upon zooming in/out in milliseconds; minimum is 1s, defaults to 15s.")
-		(@group DEFAULT_WIDGET =>
+        (@arg TIME_DELTA: -d --time_delta +takes_value "The amount changed upon zooming in/out in milliseconds; minimum is 1s, defaults to 15s.")
+        (@arg HIDE_TIME: --hide_time "Completely hide the time scaling")
+        (@arg AUTOHIDE_TIME: --autohide_time "Automatically hide the time scaling in graphs after being shown for a brief moment when zoomed in/out.  If time is disabled then this will have no effect.")
+        (@group DEFAULT_WIDGET =>
 			(@arg CPU_WIDGET: --cpu_default "Selects the CPU widget to be selected by default.")
 			(@arg MEM_WIDGET: --memory_default "Selects the memory widget to be selected by default.")
 			(@arg DISK_WIDGET: --disk_default "Selects the disk widget to be selected by default.")

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ fn get_matches() -> clap::ArgMatches<'static> {
         (@arg DEFAULT_TIME_VALUE: -t --default_time_value +takes_value "Default time value for graphs in milliseconds; minimum is 30s, defaults to 60s.")
         (@arg TIME_DELTA: -d --time_delta +takes_value "The amount changed upon zooming in/out in milliseconds; minimum is 1s, defaults to 15s.")
         (@arg HIDE_TIME: --hide_time "Completely hide the time scaling")
-        (@arg AUTOHIDE_TIME: --autohide_time "Automatically hide the time scaling in graphs after being shown for a brief moment when zoomed in/out.  If time is disabled then this will have no effect.")
+        (@arg AUTOHIDE_TIME: --autohide_time "Automatically hide the time scaling in graphs after being shown for a brief moment when zoomed in/out.  If time is disabled via --hide_time then this will have no effect.")
         (@group DEFAULT_WIDGET =>
 			(@arg CPU_WIDGET: --cpu_default "Selects the CPU widget to be selected by default.")
 			(@arg MEM_WIDGET: --memory_default "Selects the memory widget to be selected by default.")
@@ -143,6 +143,8 @@ fn main() -> error::Result<()> {
     enable_app_case_sensitive(&matches, &config, &mut app);
     enable_app_match_whole_word(&matches, &config, &mut app);
     enable_app_use_regex(&matches, &config, &mut app);
+    enable_hide_time(&matches, &config, &mut app);
+    enable_autohide_time(&matches, &config, &mut app);
 
     // Set up up tui and crossterm
     let mut stdout_val = stdout();

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,8 +268,8 @@ fn main() -> error::Result<()> {
 
 fn handle_mouse_event(event: MouseEvent, app: &mut App) {
     match event {
-        MouseEvent::ScrollUp(_x, _y, _modifiers) => app.decrement_position_count(),
-        MouseEvent::ScrollDown(_x, _y, _modifiers) => app.increment_position_count(),
+        MouseEvent::ScrollUp(_x, _y, _modifiers) => app.handle_scroll_up(),
+        MouseEvent::ScrollDown(_x, _y, _modifiers) => app.handle_scroll_down(),
         _ => {}
     };
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -56,15 +56,15 @@ pub fn get_update_rate_in_milliseconds(
     update_rate: &Option<&str>, config: &Config,
 ) -> error::Result<u64> {
     let update_rate_in_milliseconds = if let Some(update_rate) = update_rate {
-        update_rate.parse::<u64>()?
+        update_rate.parse::<u128>()?
     } else if let Some(flags) = &config.flags {
         if let Some(rate) = flags.rate {
-            rate
+            rate as u128
         } else {
-            DEFAULT_REFRESH_RATE_IN_MILLISECONDS
+            DEFAULT_REFRESH_RATE_IN_MILLISECONDS as u128
         }
     } else {
-        DEFAULT_REFRESH_RATE_IN_MILLISECONDS
+        DEFAULT_REFRESH_RATE_IN_MILLISECONDS as u128
     };
 
     if update_rate_in_milliseconds < 250 {
@@ -77,7 +77,7 @@ pub fn get_update_rate_in_milliseconds(
         ));
     }
 
-    Ok(update_rate_in_milliseconds)
+    Ok(update_rate_in_milliseconds as u64)
 }
 
 pub fn get_temperature_option(
@@ -184,15 +184,15 @@ pub fn get_default_time_value_option(
     matches: &clap::ArgMatches<'static>, config: &Config,
 ) -> error::Result<u64> {
     let default_time = if let Some(default_time_value) = matches.value_of("DEFAULT_TIME_VALUE") {
-        default_time_value.parse::<u64>()?
+        default_time_value.parse::<u128>()?
     } else if let Some(flags) = &config.flags {
         if let Some(default_time_value) = flags.default_time_value {
-            default_time_value
+            default_time_value as u128
         } else {
-            DEFAULT_TIME_MILLISECONDS
+            DEFAULT_TIME_MILLISECONDS as u128
         }
     } else {
-        DEFAULT_TIME_MILLISECONDS
+        DEFAULT_TIME_MILLISECONDS as u128
     };
 
     if default_time < 30000 {
@@ -205,35 +205,35 @@ pub fn get_default_time_value_option(
         ));
     }
 
-    Ok(default_time)
+    Ok(default_time as u64)
 }
 
 pub fn get_time_interval_option(
     matches: &clap::ArgMatches<'static>, config: &Config,
 ) -> error::Result<u64> {
     let time_interval = if let Some(time_interval) = matches.value_of("TIME_DELTA") {
-        time_interval.parse::<u64>()?
+        time_interval.parse::<u128>()?
     } else if let Some(flags) = &config.flags {
         if let Some(time_interval) = flags.time_delta {
-            time_interval
+            time_interval as u128
         } else {
-            TIME_CHANGE_MILLISECONDS
+            TIME_CHANGE_MILLISECONDS as u128
         }
     } else {
-        TIME_CHANGE_MILLISECONDS
+        TIME_CHANGE_MILLISECONDS as u128
     };
 
     if time_interval < 1000 {
         return Err(BottomError::InvalidArg(
-            "Please set your time interval to be at least 1 second.".to_string(),
+            "Please set your time delta to be at least 1 second.".to_string(),
         ));
-    } else if time_interval as u128 > std::u64::MAX as u128 {
+    } else if time_interval > std::u64::MAX as u128 {
         return Err(BottomError::InvalidArg(
-            "Please set your time interval to be at most unsigned INT_MAX.".to_string(),
+            "Please set your time delta to be at most unsigned INT_MAX.".to_string(),
         ));
     }
 
-    Ok(time_interval)
+    Ok(time_interval as u64)
 }
 
 pub fn enable_app_grouping(matches: &clap::ArgMatches<'static>, config: &Config, app: &mut App) {

--- a/src/options.rs
+++ b/src/options.rs
@@ -199,11 +199,11 @@ pub fn get_default_time_value_option(
 
     if default_time < 30000 {
         return Err(BottomError::InvalidArg(
-            "Please set your default value to be at least 30 seconds.".to_string(),
+            "Please set your default value to be at least 30000 milliseconds.".to_string(),
         ));
     } else if default_time as u128 > STALE_MAX_MILLISECONDS as u128 {
         return Err(BottomError::InvalidArg(
-            "Please set your default value to be at most 10 minutes.".to_string(),
+            format!("Please set your default value to be at most {} milliseconds.", STALE_MAX_MILLISECONDS),
         ));
     }
 
@@ -227,11 +227,11 @@ pub fn get_time_interval_option(
 
     if time_interval < 1000 {
         return Err(BottomError::InvalidArg(
-            "Please set your time delta to be at least 1 second.".to_string(),
+            "Please set your time delta to be at least 1000 milliseconds.".to_string(),
         ));
     } else if time_interval > STALE_MAX_MILLISECONDS as u128 {
         return Err(BottomError::InvalidArg(
-            "Please set your time delta to be at most 10 minutes.".to_string(),
+            format!("Please set your time delta to be at most {} milliseconds.", STALE_MAX_MILLISECONDS),
         ));
     }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -305,10 +305,18 @@ pub fn enable_hide_time(matches: &clap::ArgMatches<'static>, config: &Config, ap
 pub fn enable_autohide_time(matches: &clap::ArgMatches<'static>, config: &Config, app: &mut App) {
     if matches.is_present("AUTOHIDE_TIME") {
         app.app_config_fields.autohide_time = true;
+        let time = Some(std::time::Instant::now());
+        app.cpu_state.display_time_instant = time;
+        app.mem_state.display_time_instant = time;
+        app.net_state.display_time_instant = time;
     } else if let Some(flags) = &config.flags {
         if let Some(autohide_time) = flags.autohide_time {
             if autohide_time {
                 app.app_config_fields.autohide_time = true;
+                let time = Some(std::time::Instant::now());
+                app.cpu_state.display_time_instant = time;
+                app.mem_state.display_time_instant = time;
+                app.net_state.display_time_instant = time;
             }
         }
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -29,6 +29,8 @@ pub struct ConfigFlags {
     pub basic: Option<bool>,
     pub default_time_value: Option<u64>,
     pub time_delta: Option<u64>,
+    pub autohide_time: Option<bool>,
+    pub hide_time: Option<bool>,
     //disabled_cpu_cores: Option<Vec<u64>>, // TODO: [FEATURE] Enable disabling cores in config/flags
 }
 
@@ -199,9 +201,9 @@ pub fn get_default_time_value_option(
         return Err(BottomError::InvalidArg(
             "Please set your default value to be at least 30 seconds.".to_string(),
         ));
-    } else if default_time as u128 > std::u64::MAX as u128 {
+    } else if default_time as u128 > STALE_MAX_MILLISECONDS as u128 {
         return Err(BottomError::InvalidArg(
-            "Please set your default value to be at most unsigned INT_MAX.".to_string(),
+            "Please set your default value to be at most 10 minutes.".to_string(),
         ));
     }
 
@@ -227,9 +229,9 @@ pub fn get_time_interval_option(
         return Err(BottomError::InvalidArg(
             "Please set your time delta to be at least 1 second.".to_string(),
         ));
-    } else if time_interval > std::u64::MAX as u128 {
+    } else if time_interval > STALE_MAX_MILLISECONDS as u128 {
         return Err(BottomError::InvalidArg(
-            "Please set your time delta to be at most unsigned INT_MAX.".to_string(),
+            "Please set your time delta to be at most 10 minutes.".to_string(),
         ));
     }
 
@@ -283,6 +285,30 @@ pub fn enable_app_use_regex(matches: &clap::ArgMatches<'static>, config: &Config
         if let Some(regex) = flags.regex {
             if regex {
                 app.process_search_state.search_toggle_regex();
+            }
+        }
+    }
+}
+
+pub fn enable_hide_time(matches: &clap::ArgMatches<'static>, config: &Config, app: &mut App) {
+    if matches.is_present("HIDE_TIME") {
+        app.app_config_fields.hide_time = true;
+    } else if let Some(flags) = &config.flags {
+        if let Some(hide_time) = flags.hide_time {
+            if hide_time {
+                app.app_config_fields.hide_time = true;
+            }
+        }
+    }
+}
+
+pub fn enable_autohide_time(matches: &clap::ArgMatches<'static>, config: &Config, app: &mut App) {
+    if matches.is_present("AUTOHIDE_TIME") {
+        app.app_config_fields.autohide_time = true;
+    } else if let Some(flags) = &config.flags {
+        if let Some(autohide_time) = flags.autohide_time {
+            if autohide_time {
+                app.app_config_fields.autohide_time = true;
             }
         }
     }

--- a/tests/arg_rate_tests.rs
+++ b/tests/arg_rate_tests.rs
@@ -28,7 +28,9 @@ fn test_small_rate() -> Result<(), Box<dyn std::error::Error>> {
         .arg("249")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("rate to be greater than 250"));
+        .stderr(predicate::str::contains(
+            "Please set your update rate to be at least 250 milliseconds.",
+        ));
     Ok(())
 }
 
@@ -40,7 +42,7 @@ fn test_large_rate() -> Result<(), Box<dyn std::error::Error>> {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "rate to be less than unsigned INT_MAX.",
+            "Please set your update rate to be at most unsigned INT_MAX.",
         ));
     Ok(())
 }

--- a/tests/arg_tests.rs
+++ b/tests/arg_tests.rs
@@ -35,6 +35,58 @@ fn test_small_rate() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn test_large_default_time() -> Result<(), Box<dyn std::error::Error>> {
+    Command::new(get_os_binary_loc())
+        .arg("-t")
+        .arg("18446744073709551616")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Please set your default value to be at most unsigned INT_MAX.",
+        ));
+    Ok(())
+}
+
+#[test]
+fn test_small_default_time() -> Result<(), Box<dyn std::error::Error>> {
+    Command::new(get_os_binary_loc())
+        .arg("-t")
+        .arg("900")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Please set your default value to be at least 30 seconds.",
+        ));
+    Ok(())
+}
+
+#[test]
+fn test_large_delta_time() -> Result<(), Box<dyn std::error::Error>> {
+    Command::new(get_os_binary_loc())
+        .arg("-d")
+        .arg("18446744073709551616")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Please set your time delta to be at most unsigned INT_MAX.",
+        ));
+    Ok(())
+}
+
+#[test]
+fn test_small_delta_time() -> Result<(), Box<dyn std::error::Error>> {
+    Command::new(get_os_binary_loc())
+        .arg("-d")
+        .arg("900")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Please set your time delta to be at least 1 second.",
+        ));
+    Ok(())
+}
+
+#[test]
 fn test_large_rate() -> Result<(), Box<dyn std::error::Error>> {
     Command::new(get_os_binary_loc())
         .arg("-r")

--- a/tests/arg_tests.rs
+++ b/tests/arg_tests.rs
@@ -42,7 +42,7 @@ fn test_large_default_time() -> Result<(), Box<dyn std::error::Error>> {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "Please set your default value to be at most 10 minutes.",
+            "Please set your default value to be at most",
         ));
     Ok(())
 }
@@ -55,7 +55,7 @@ fn test_small_default_time() -> Result<(), Box<dyn std::error::Error>> {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "Please set your default value to be at least 30 seconds.",
+            "Please set your default value to be at least",
         ));
     Ok(())
 }
@@ -68,7 +68,7 @@ fn test_large_delta_time() -> Result<(), Box<dyn std::error::Error>> {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "Please set your time delta to be at most 10 minutes.",
+            "Please set your time delta to be at most",
         ));
     Ok(())
 }
@@ -81,7 +81,7 @@ fn test_small_delta_time() -> Result<(), Box<dyn std::error::Error>> {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "Please set your time delta to be at least 1 second.",
+            "Please set your time delta to be at least",
         ));
     Ok(())
 }

--- a/tests/arg_tests.rs
+++ b/tests/arg_tests.rs
@@ -42,7 +42,7 @@ fn test_large_default_time() -> Result<(), Box<dyn std::error::Error>> {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "Please set your default value to be at most unsigned INT_MAX.",
+            "Please set your default value to be at most 10 minutes.",
         ));
     Ok(())
 }
@@ -68,7 +68,7 @@ fn test_large_delta_time() -> Result<(), Box<dyn std::error::Error>> {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "Please set your time delta to be at most unsigned INT_MAX.",
+            "Please set your time delta to be at most 10 minutes.",
         ));
     Ok(())
 }


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Adds time scaling to bottom.  This allows a user to use the mouse wheel and/or the `+/-` keys to zoom in and out based on time scale (currently capped to [300, 30] in terms of time limits).

The `=` button resets the scaling too.

## Issue

_If applicable, what issue does this address?_

Closes: #20 

## Type of change

_Remove the irrelevant ones:_

- [x] New feature (non-breaking change which adds functionality)

## Test methodology

_Please state how this was tested:_

Linux: Tested on Arch Linux with Kitty by allowing it to stack 10 minutes, allowing it to freeze and scrolling, and scrolling in general.

Windows: Tested on Powershell.

macOS: Tested on Kitty.

_Please tick which platforms this change was tested on:_

- [x] Windows
- [x] macOS
- [x] Linux

## Checklist

_Please ensure all are ticked (and actually done):_

- [x] Change has been tested to work
- [x] Areas your change affects has been linted using rustfmt
- [x] Code has been self-reviewed
- [x] Code has been tested and no new breakage is introduced
- [x] Documentation has been added/updated if needed
- [x] No merge conflicts arise from the change

## Other information

_Provide any other relevant information:_
