### PR TITLE
Fix resizing breaking scrolling

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -147,6 +147,8 @@ impl Painter {
             self.width = current_width;
         } else if self.height != current_height || self.width != current_width {
             app_state.is_resized = true;
+            self.height = current_height;
+            self.width = current_width;
         }
 
         terminal.autoresize()?;


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes resizing breaking scrolling, caused by forgetting to set the height/width fields upon the first detection of a resize

## Issue

_If applicable, what issue does this address?_

Closes: #80 

## Type of change

_Remove the irrelevant ones:_

- [x] Bug fix (non-breaking change which fixes an issue)

## Test methodology

_Please state how this was tested:_

Tested on Arch Linux to fix the issue.

_Please tick which platforms this change was tested on:_

- [ ] Windows
- [ ] macOS
- [x] Linux

## Checklist

_Please ensure all are ticked (and actually done):_

- [x] Change has been tested to work
- [x] Areas your change affects has been linted using rustfmt
- [x] Code has been self-reviewed
- [x] Code has been tested and no new breakage is introduced
- [x] Documentation has been added/updated if needed
- [x] No merge conflicts arise from the change

## Other information

_Provide any other relevant information:_
