### PR TITLE
Fix cpu legend colouring

### DIFF
--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -66,6 +66,7 @@ pub struct DataState {
     last_collection_time: Instant,
     total_rx: u64,
     total_tx: u64,
+    show_average_cpu: bool,
 }
 
 impl Default for DataState {
@@ -82,6 +83,7 @@ impl Default for DataState {
             last_collection_time: Instant::now(),
             total_rx: 0,
             total_tx: 0,
+            show_average_cpu: false,
         }
     }
 }
@@ -93,6 +95,10 @@ impl DataState {
 
     pub fn set_use_current_cpu_total(&mut self, use_current_cpu_total: bool) {
         self.use_current_cpu_total = use_current_cpu_total;
+    }
+
+    pub fn set_show_average_cpu(&mut self, show_average_cpu: bool) {
+        self.show_average_cpu = show_average_cpu;
     }
 
     pub fn init(&mut self) {
@@ -116,7 +122,7 @@ impl DataState {
         let current_instant = std::time::Instant::now();
 
         // CPU
-        self.data.cpu = cpu::get_cpu_data_list(&self.sys);
+        self.data.cpu = cpu::get_cpu_data_list(&self.sys, self.show_average_cpu);
 
         // Processes.  This is the longest part of the harvesting process... changing this might be
         // good in the future.  What was tried already:

--- a/src/app/data_harvester/cpu.rs
+++ b/src/app/data_harvester/cpu.rs
@@ -8,13 +8,17 @@ pub struct CPUData {
 
 pub type CPUHarvest = Vec<CPUData>;
 
-pub fn get_cpu_data_list(sys: &System) -> CPUHarvest {
+pub fn get_cpu_data_list(sys: &System, show_average_cpu: bool) -> CPUHarvest {
     let cpu_data = sys.get_processors();
     let avg_cpu_usage = sys.get_global_processor_info().get_cpu_usage();
-    let mut cpu_vec = vec![CPUData {
-        cpu_name: "AVG".to_string(),
-        cpu_usage: avg_cpu_usage as f64,
-    }];
+    let mut cpu_vec = vec![];
+
+    if show_average_cpu {
+        cpu_vec.push(CPUData {
+            cpu_name: "AVG".to_string(),
+            cpu_usage: avg_cpu_usage as f64,
+        });
+    }
 
     for cpu in cpu_data {
         cpu_vec.push(CPUData {

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -169,6 +169,12 @@ impl CpuGraphWidget for Painter {
         );
 
         let sliced_cpu_data = &cpu_data[start_position as usize..];
+
+        let mut offset_scroll_index = (app_state
+            .app_scroll_positions
+            .cpu_scroll_state
+            .current_scroll_position
+            - start_position) as usize;
         let cpu_rows = sliced_cpu_data.iter().enumerate().filter_map(|(itx, cpu)| {
             let cpu_string_row: Vec<Cow<'_, str>> = if app_state.cpu_state.is_showing_tray {
                 vec![
@@ -191,19 +197,14 @@ impl CpuGraphWidget for Painter {
             };
 
             if cpu_string_row.is_empty() {
+                offset_scroll_index += 1;
                 None
             } else {
                 Some(Row::StyledData(
                     cpu_string_row.into_iter(),
                     match app_state.current_widget_selected {
                         WidgetPosition::CpuLegend => {
-                            if itx as u64
-                                == app_state
-                                    .app_scroll_positions
-                                    .cpu_scroll_state
-                                    .current_scroll_position
-                                    - start_position
-                            {
+                            if itx == offset_scroll_index {
                                 self.colours.currently_selected_text_style
                             } else if app_state.app_config_fields.show_average_cpu && itx == 0 {
                                 self.colours.avg_colour_style

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -169,73 +169,63 @@ impl CpuGraphWidget for Painter {
         );
 
         let sliced_cpu_data = &cpu_data[start_position as usize..];
-        let mut stringified_cpu_data: Vec<Vec<Cow<'_, str>>> = Vec::new();
-
-        for (itx, cpu) in sliced_cpu_data.iter().enumerate() {
-            if app_state.cpu_state.is_showing_tray {
-                stringified_cpu_data.push(vec![
+        let cpu_rows = sliced_cpu_data.iter().enumerate().filter_map(|(itx, cpu)| {
+            let cpu_string_row: Vec<Cow<'_, str>> = if app_state.cpu_state.is_showing_tray {
+                vec![
                     Cow::Borrowed(&cpu.cpu_name),
                     if app_state.cpu_state.core_show_vec[itx + start_position as usize] {
                         "[*]".into()
                     } else {
                         "[ ]".into()
                     },
-                ]);
+                ]
             } else if app_state.app_config_fields.show_disabled_data
                 || app_state.cpu_state.core_show_vec[itx]
             {
-                stringified_cpu_data.push(vec![
+                vec![
                     Cow::Borrowed(&cpu.cpu_name),
                     Cow::Borrowed(&cpu.legend_value),
-                ]);
+                ]
             } else {
-                stringified_cpu_data.push(Vec::new());
-            }
-        }
+                Vec::new()
+            };
 
-        let cpu_rows =
-            stringified_cpu_data
-                .iter()
-                .enumerate()
-                .filter_map(|(itx, cpu_string_row)| {
-                    if cpu_string_row.is_empty() {
-                        None
-                    } else {
-                        Some(Row::StyledData(
-                            cpu_string_row.iter(),
-                            match app_state.current_widget_selected {
-                                WidgetPosition::CpuLegend => {
-                                    if itx as u64
-                                        == app_state
-                                            .app_scroll_positions
-                                            .cpu_scroll_state
-                                            .current_scroll_position
-                                            - start_position
-                                    {
-                                        self.colours.currently_selected_text_style
-                                    } else if app_state.app_config_fields.show_average_cpu
-                                        && itx == 0
-                                    {
-                                        self.colours.avg_colour_style
-                                    } else {
-                                        self.colours.cpu_colour_styles[itx
-                                            + start_position as usize
-                                                % self.colours.cpu_colour_styles.len()]
-                                    }
-                                }
-                                _ => {
-                                    if app_state.app_config_fields.show_average_cpu && itx == 0 {
-                                        self.colours.avg_colour_style
-                                    } else {
-                                        self.colours.cpu_colour_styles[itx
-                                            + start_position as usize
-                                                % self.colours.cpu_colour_styles.len()]
-                                    }
-                                }
-                            },
-                        ))
-                    }
-                });
+            if cpu_string_row.is_empty() {
+                None
+            } else {
+                Some(Row::StyledData(
+                    cpu_string_row.into_iter(),
+                    match app_state.current_widget_selected {
+                        WidgetPosition::CpuLegend => {
+                            if itx as u64
+                                == app_state
+                                    .app_scroll_positions
+                                    .cpu_scroll_state
+                                    .current_scroll_position
+                                    - start_position
+                            {
+                                self.colours.currently_selected_text_style
+                            } else if app_state.app_config_fields.show_average_cpu && itx == 0 {
+                                self.colours.avg_colour_style
+                            } else {
+                                self.colours.cpu_colour_styles[itx
+                                    + start_position as usize
+                                        % self.colours.cpu_colour_styles.len()]
+                            }
+                        }
+                        _ => {
+                            if app_state.app_config_fields.show_average_cpu && itx == 0 {
+                                self.colours.avg_colour_style
+                            } else {
+                                self.colours.cpu_colour_styles[itx
+                                    + start_position as usize
+                                        % self.colours.cpu_colour_styles.len()]
+                            }
+                        }
+                    },
+                ))
+            }
+        });
 
         // Calculate widths
         let width = f64::from(draw_loc.width);

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -38,6 +38,7 @@ pub struct ConvertedCpuData {
     pub cpu_name: String,
     /// Tuple is time, value
     pub cpu_data: Vec<Point>,
+    pub legend_value: String,
 }
 
 pub fn convert_temp_row(app: &App) -> Vec<Vec<String>> {
@@ -133,6 +134,8 @@ pub fn convert_cpu_data_points(
                 cpu_data_vector[itx_offset].cpu_name =
                     current_data.cpu_harvest[itx].cpu_name.clone();
             }
+
+            cpu_data_vector[itx_offset].legend_value = format!("{:.0}%", cpu.0.round());
 
             //Insert joiner points
             for &(joiner_offset, joiner_val) in &cpu.1 {

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -103,8 +103,7 @@ pub fn convert_disk_row(current_data: &data_farmer::DataCollection) -> Vec<Vec<S
 }
 
 pub fn convert_cpu_data_points(
-    show_avg_cpu: bool, current_data: &data_farmer::DataCollection, display_time: u64,
-    is_frozen: bool,
+    current_data: &data_farmer::DataCollection, display_time: u64, is_frozen: bool,
 ) -> Vec<ConvertedCpuData> {
     let mut cpu_data_vector: Vec<ConvertedCpuData> = Vec::new();
     let current_time = if is_frozen {
@@ -116,19 +115,14 @@ pub fn convert_cpu_data_points(
     } else {
         current_data.current_instant
     };
-    let cpu_listing_offset = if show_avg_cpu { 0 } else { 1 };
 
     for (time, data) in &current_data.timed_data_vec {
         let time_from_start: f64 =
             (display_time as f64 - current_time.duration_since(*time).as_millis() as f64).floor();
 
         for (itx, cpu) in data.cpu_data.iter().enumerate() {
-            if !show_avg_cpu && itx == 0 {
-                continue;
-            }
-
             // Check if the vector exists yet
-            let itx_offset = itx - cpu_listing_offset;
+            let itx_offset = itx;
             if cpu_data_vector.len() <= itx_offset {
                 cpu_data_vector.push(ConvertedCpuData::default());
                 cpu_data_vector[itx_offset].cpu_name =

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,7 @@ fn main() -> error::Result<()> {
         use_current_cpu_total,
         update_rate_in_milliseconds as u64,
         app.app_config_fields.temperature_type.clone(),
+        app.app_config_fields.show_average_cpu,
     );
 
     let mut painter = canvas::Painter::default();
@@ -252,7 +253,6 @@ fn main() -> error::Result<()> {
 
                         // CPU
                         app.canvas_data.cpu_data = convert_cpu_data_points(
-                            app.app_config_fields.show_average_cpu,
                             &app.data_collection,
                             app.cpu_state.display_time,
                             false,
@@ -589,7 +589,6 @@ fn handle_force_redraws(app: &mut App) {
 
     if app.cpu_state.force_update {
         app.canvas_data.cpu_data = convert_cpu_data_points(
-            app.app_config_fields.show_average_cpu,
             &app.data_collection,
             app.cpu_state.display_time,
             app.is_frozen,
@@ -755,6 +754,7 @@ fn create_event_thread(
     >,
     rrx: std::sync::mpsc::Receiver<ResetEvent>, use_current_cpu_total: bool,
     update_rate_in_milliseconds: u64, temp_type: data_harvester::temperature::TemperatureType,
+    show_average_cpu: bool,
 ) {
     thread::spawn(move || {
         let tx = tx.clone();
@@ -762,6 +762,7 @@ fn create_event_thread(
         data_state.init();
         data_state.set_temperature_type(temp_type);
         data_state.set_use_current_cpu_total(use_current_cpu_total);
+        data_state.set_show_average_cpu(show_average_cpu);
         loop {
             if let Ok(message) = rrx.try_recv() {
                 match message {

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,6 +242,14 @@ fn main() -> error::Result<()> {
                         app.canvas_data.mem_label = memory_and_swap_labels.0;
                         app.canvas_data.swap_label = memory_and_swap_labels.1;
 
+                        // Pre-fill CPU if needed
+                        if first_run {
+                            let cpu_len = app.data_collection.cpu_harvest.len();
+                            app.cpu_state.core_show_vec = vec![true; cpu_len];
+                            app.cpu_state.num_cpus_shown = cpu_len as u64;
+                            first_run = false;
+                        }
+
                         // CPU
                         app.canvas_data.cpu_data = convert_cpu_data_points(
                             app.app_config_fields.show_average_cpu,
@@ -249,14 +257,6 @@ fn main() -> error::Result<()> {
                             app.cpu_state.display_time,
                             false,
                         );
-
-                        // Pre-fill CPU if needed
-                        if first_run {
-                            app.cpu_state.core_show_vec =
-                                vec![true; app.canvas_data.cpu_data.len()];
-                            app.cpu_state.num_cpus_shown = app.canvas_data.cpu_data.len() as u64;
-                            first_run = false;
-                        }
 
                         // Processes
                         let (single, grouped) = convert_process_data(&app.data_collection);


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes cpu legend colouring when hidden due to using the incorrect index, as well as merges two separate iterations together.

## Issue

_If applicable, what issue does this address?_

Closes: #79 

## Type of change

_Remove the irrelevant ones:_

- [x] Bug fix (non-breaking change which fixes an issue)

## Test methodology

_Please state how this was tested:_

Tested to fix the problem on Arch Linux with no performance or feature regressions.

_Please tick which platforms this change was tested on:_

- [ ] Windows
- [ ] macOS
- [x] Linux

## Checklist

_Please ensure all are ticked (and actually done):_

- [x] Change has been tested to work
- [x] Areas your change affects has been linted using rustfmt
- [x] Code has been self-reviewed
- [x] Code has been tested and no new breakage is introduced
- [x] Documentation has been added/updated if needed
- [x] No merge conflicts arise from the change

## Other information

_Provide any other relevant information:_
