### PR TITLE
Fix division by zero when memory data is not available

### DIFF
--- a/src/app/data_farmer.rs
+++ b/src/app/data_farmer.rs
@@ -144,9 +144,10 @@ impl DataCollection {
         &mut self, harvested_data: &Data, harvested_time: Instant, new_entry: &mut TimedData,
     ) {
         // Memory
-        let mem_percent = harvested_data.memory.mem_used_in_mb as f64
-            / harvested_data.memory.mem_total_in_mb as f64
-            * 100.0;
+        let mem_percent = match harvested_data.memory.mem_total_in_mb {
+            0 => 0f64,
+            total => (harvested_data.memory.mem_used_in_mb as f64) / (total as f64) * 100.0,
+        };
         let mem_joining_pts = if let Some((time, last_pt)) = self.timed_data_vec.last() {
             generate_joining_points(*time, last_pt.mem_data.0, harvested_time, mem_percent)
         } else {
@@ -157,9 +158,10 @@ impl DataCollection {
 
         // Swap
         if harvested_data.swap.mem_total_in_mb > 0 {
-            let swap_percent = harvested_data.swap.mem_used_in_mb as f64
-                / harvested_data.swap.mem_total_in_mb as f64
-                * 100.0;
+            let swap_percent = match harvested_data.swap.mem_total_in_mb {
+                0 => 0f64,
+                total => (harvested_data.swap.mem_used_in_mb as f64) / (total as f64) * 100.0,
+            };
             let swap_joining_pt = if let Some((time, last_pt)) = self.timed_data_vec.last() {
                 generate_joining_points(*time, last_pt.swap_data.0, harvested_time, swap_percent)
             } else {


### PR DESCRIPTION
The total memory values may be zero when bottom is run on an unsupported
(or not-fully-supported) platform.

The previous behavior resulted in a NaN value for the memory datapoints,
which was passed through to tui-rs which ultimately panicked when
attempting to graph the memory widget.

## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

## Issue

_If applicable, what issue does this address?_

_Closes:_ #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_
- [x] _New feature (non-breaking change which adds functionality)_
- [x] _Other (something else - please specify if relevant):_

## Test methodology

_Please state how this was tested:_

_Please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [X] _Linux_

## Checklist

_Please ensure all are ticked (and actually done):_

- [x] _Change has been tested to work_
- [x] _Areas your change affects has been linted using rustfmt_
- [x] _Code has been self-reviewed_
- [x] _Code has been tested and no new breakage is introduced_
- [X] _Documentation has been added/updated if needed_
- [X] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
