### PR TITLE
bug: Fix sorting processes by name being case-sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#40](https://github.com/ClementTsang/bottom/issues/40): Rewrote README to be more clear and explicit.
 
+- [#109](https://github.com/ClementTsang/bottom/issues/109): Sorting processes by name is case-insensitive.
+
 ### Bug Fixes
 
 - [#33](https://github.com/ClementTsang/bottom/issues/33): Fix bug with search and graphemes bigger than a byte crashing due to the cursor.

--- a/src/main.rs
+++ b/src/main.rs
@@ -670,7 +670,9 @@ fn update_final_process_list(app: &mut App, widget_id: u64) {
 fn sort_process_data(
     to_sort_vec: &mut Vec<ConvertedProcessData>, proc_widget_state: &app::ProcWidgetState,
 ) {
-    to_sort_vec.sort_by(|a, b| utils::gen_util::get_ordering(&a.name, &b.name, false));
+    to_sort_vec.sort_by(|a, b| {
+        utils::gen_util::get_ordering(&a.name.to_lowercase(), &b.name.to_lowercase(), false)
+    });
 
     match proc_widget_state.process_sorting_type {
         ProcessSorting::CPU => {
@@ -696,8 +698,8 @@ fn sort_process_data(
             if proc_widget_state.process_sorting_reverse {
                 to_sort_vec.sort_by(|a, b| {
                     utils::gen_util::get_ordering(
-                        &a.name,
-                        &b.name,
+                        &a.name.to_lowercase(),
+                        &b.name.to_lowercase(),
                         proc_widget_state.process_sorting_reverse,
                     )
                 })


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes the process sort by name not being case insensitive.

![image](https://user-images.githubusercontent.com/34804052/78734383-1a8e5b80-7916-11ea-8407-eb45964e9d34.png)


## Issue

_If applicable, what issue does this address?_

Closes: #109

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_Please state how this was tested:_

_Please tick which platforms this change was tested on:_

- [x] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_Please ensure all are ticked (and actually done):_

- [x] _Change has been tested to work_
- [x] _Areas your change affects have been linted using rustfmt_
- [x] _Code has been self-reviewed_
- [x] _Code has been tested and no new breakage is introduced unless intended_
- [x] _Documentation has been added/updated if needed_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
