### PR TITLE
change: add scrolling to help menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `"processes"`
   - `"temperature"`
 
-- Removed an (undocumented) feature in allowing modifying total RX/TX colours. This is mainly due to the legend change.
-
-- Updated error messages to be a bit more consistent/helpful.
-
 - [#117](https://github.com/ClementTsang/bottom/issues/117): Update tui to 0.9:
+
+  - Removed an (undocumented) feature in allowing modifying total RX/TX colours. This is mainly due to the legend change.
 
   - Use custom legend-hiding to stop hiding legends for memory and network widgets.
 
@@ -40,9 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   - Allow for option to hide the header gap on tables via `--hide_table_gap` or `hide_table_gap = true`.
 
-  - Switch to stateful widget style for tables.
+- [#126](https://github.com/ClementTsang/bottom/pull/126): Updated error messages to be a bit more consistent/helpful.
 
-  - Switch to using tui-rs' new built in linear interpolation rather than doing it manually.
+- Redesigned help menu to allow for scrolling.
 
 ### Bug Fixes
 
@@ -51,9 +49,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug where a single empty row as a layout would crash without a proper warning.
   The behaviour now errors out with a more helpful message.
 
-### Other
+### Development changes
 
-- Updated tests and added config testing.
+- Switch to stateful widget style for tables.
+
+- Switch to using tui-rs' new built in linear interpolation rather than doing it manually.
+
+- Updated arg tests and added config testing.
+
+- More refactoring.
 
 ## [0.3.0] - 2020-04-07
 

--- a/README.md
+++ b/README.md
@@ -165,19 +165,19 @@ Run using `btm`.
 
 |                                                    |                                                                                                |
 | -------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `q`, `Ctrl-c`                                      | Quit bottom                                                                                    |
+| `q`, `Ctrl-c`                                      | Quit                                                                                           |
 | `Esc`                                              | Close dialog windows, search, widgets, or exit maximized mode                                  |
 | `Ctrl-r`                                           | Reset display and any collected data                                                           |
 | `f`                                                | Freeze/unfreeze updating with new data                                                         |
 | `Ctrl`-arrow key<br>`Shift`-arrow key<br>`H/J/K/L` | Move to a different widget (on macOS some keybindings may conflict)                            |
-| `Up`,`k`                                           | Scroll up in tables                                                                            |
-| `Down`, `j`                                        | Scroll down in tables                                                                          |
+| `Up`,`k`                                           | Scroll up                                                                                      |
+| `Down`, `j`                                        | Scroll down                                                                                    |
 | `?`                                                | Open help menu                                                                                 |
-| `gg`, `Home`                                       | Jump to the first entry of a table                                                             |
-| `Shift-g`, `End`                                   | Jump to the last entry of a table                                                              |
-| `Enter`                                            | Maximize widget                                                                                |
-| `+`                                                | Zoom in on a chart                                                                             |
-| `-`                                                | Zoom out on a chart                                                                            |
+| `gg`, `Home`                                       | Jump to the first entry                                                                        |
+| `Shift-g`, `End`                                   | Jump to the last entry                                                                         |
+| `Enter`                                            | Maximize the currently selected widget                                                         |
+| `+`                                                | Zoom in on chart (decrease time range)                                                         |
+| `-`                                                | Zoom out on chart (increase time range)                                                        |
 | `=`                                                | Reset zoom                                                                                     |
 | Mouse scroll                                       | Table: Scrolls through the list<br>Chart: Zooms in or out by scrolling up or down respectively |
 
@@ -209,6 +209,9 @@ Run using `btm`.
 | `Esc`        | Close the search widget (retains the filter) |
 | `Ctrl-a`     | Skip to the start of the search query        |
 | `Ctrl-e`     | Skip to the end of the search query          |
+| `Ctrl-u`     | Clear the current search query               |
+| `Backspace`  | Delete the character behind the cursor       |
+| `Delete`     | Delete the character at the cursor           |
 | `Alt-c`/`F1` | Toggle matching case                         |
 | `Alt-w`/`F2` | Toggle matching the entire word              |
 | `Alt-r`/`F3` | Toggle using regex                           |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 A cross-platform graphical process/system monitor with a customizable interface and a multitude of features. Supports Linux, macOS, and Windows. Inspired by both [gtop](https://github.com/aksakalli/gtop) and [gotop](https://github.com/cjbassi/gotop).
 
+<!--TODO: Update recording for 0.4-->
+
 ![Quick demo recording showing off searching, maximizing, and process killing.](assets/summary_and_search.gif) _Theme based on [gruvbox](https://github.com/morhetz/gruvbox) (see [sample config](./sample_configs/demo_config.toml))._ Recorded on version 0.2.0.
 
 **Note**: This documentation is relevant to version 0.4.0 and may refer to in-development features, especially if you are reading this on the master branch. Please refer to [release branch](https://github.com/ClementTsang/bottom/tree/release/README.md) or [crates.io](https://crates.io/crates/bottom) for the most up-to-date _release_ documentation.

--- a/src/app.rs
+++ b/src/app.rs
@@ -69,6 +69,7 @@ pub struct AppHelpDialogState {
     pub is_showing_help: bool,
     pub scroll_state: ParagraphScrollState,
     pub general_index: u16,
+    pub cpu_index: u16,
     pub process_index: u16,
     pub search_index: u16,
     pub battery_index: u16,
@@ -1441,9 +1442,10 @@ impl App {
             // This is even more so as most logic already checks for dialog state.
             match caught_char {
                 '1' => self.help_scroll_to_or_max(self.help_dialog_state.general_index),
-                '2' => self.help_scroll_to_or_max(self.help_dialog_state.process_index),
-                '3' => self.help_scroll_to_or_max(self.help_dialog_state.search_index),
-                '4' => self.help_scroll_to_or_max(self.help_dialog_state.battery_index),
+                '2' => self.help_scroll_to_or_max(self.help_dialog_state.cpu_index),
+                '3' => self.help_scroll_to_or_max(self.help_dialog_state.process_index),
+                '4' => self.help_scroll_to_or_max(self.help_dialog_state.search_index),
+                '5' => self.help_scroll_to_or_max(self.help_dialog_state.battery_index),
                 'j' | 'k' | 'g' | 'G' => self.handle_char(caught_char),
                 _ => {}
             }

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -182,6 +182,19 @@ impl Painter {
                 .collect::<Vec<_>>(),
         );
 
+        // CPU
+        self.styled_help_text.push(Text::Raw("\n\n".into()));
+        self.styled_help_text.push(Text::Styled(
+            CPU_HELP_TEXT[0].into(),
+            self.colours.table_header_style,
+        ));
+        self.styled_help_text.extend(
+            CPU_HELP_TEXT[1..]
+                .iter()
+                .map(|&text| Text::Styled(text.into(), self.colours.text_style))
+                .collect::<Vec<_>>(),
+        );
+
         // Proc
         self.styled_help_text.push(Text::Raw("\n\n".into()));
         self.styled_help_text.push(Text::Styled(

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -59,9 +59,7 @@ pub struct Painter {
     pub colours: CanvasColours,
     height: u16,
     width: u16,
-    styled_general_help_text: Vec<Text<'static>>,
-    styled_process_help_text: Vec<Text<'static>>,
-    styled_search_help_text: Vec<Text<'static>>,
+    styled_help_text: Vec<Text<'static>>,
     is_mac_os: bool,
     row_constraints: Vec<Constraint>,
     col_constraints: Vec<Vec<Constraint>>,
@@ -145,9 +143,7 @@ impl Painter {
             colours: CanvasColours::default(),
             height: 0,
             width: 0,
-            styled_general_help_text: Vec::new(),
-            styled_process_help_text: Vec::new(),
-            styled_search_help_text: Vec::new(),
+            styled_help_text: Vec::new(),
             is_mac_os: false,
             row_constraints,
             col_constraints,
@@ -164,44 +160,66 @@ impl Painter {
     pub fn complete_painter_init(&mut self) {
         self.is_mac_os = cfg!(target_os = "macos");
 
-        if GENERAL_HELP_TEXT.len() > 1 {
-            self.styled_general_help_text.push(Text::Styled(
-                GENERAL_HELP_TEXT[0].into(),
-                self.colours.table_header_style,
-            ));
-            self.styled_general_help_text.extend(
-                GENERAL_HELP_TEXT[1..]
-                    .iter()
-                    .map(|&text| Text::Styled(text.into(), self.colours.text_style))
-                    .collect::<Vec<_>>(),
-            );
-        }
+        // Init help text:
+        // ToC
+        self.styled_help_text.extend(
+            HELP_CONTENTS_TEXT
+                .iter()
+                .map(|&text| Text::Styled(text.into(), self.colours.text_style))
+                .collect::<Vec<_>>(),
+        );
 
-        if PROCESS_HELP_TEXT.len() > 1 {
-            self.styled_process_help_text.push(Text::Styled(
-                PROCESS_HELP_TEXT[0].into(),
-                self.colours.table_header_style,
-            ));
-            self.styled_process_help_text.extend(
-                PROCESS_HELP_TEXT[1..]
-                    .iter()
-                    .map(|&text| Text::Styled(text.into(), self.colours.text_style))
-                    .collect::<Vec<_>>(),
-            );
-        }
+        // General
+        self.styled_help_text.push(Text::Raw("\n\n".into()));
+        self.styled_help_text.push(Text::Styled(
+            GENERAL_HELP_TEXT[0].into(),
+            self.colours.table_header_style,
+        ));
+        self.styled_help_text.extend(
+            GENERAL_HELP_TEXT[1..]
+                .iter()
+                .map(|&text| Text::Styled(text.into(), self.colours.text_style))
+                .collect::<Vec<_>>(),
+        );
 
-        if SEARCH_HELP_TEXT.len() > 1 {
-            self.styled_search_help_text.push(Text::Styled(
-                SEARCH_HELP_TEXT[0].into(),
-                self.colours.table_header_style,
-            ));
-            self.styled_search_help_text.extend(
-                SEARCH_HELP_TEXT[1..]
-                    .iter()
-                    .map(|&text| Text::Styled(text.into(), self.colours.text_style))
-                    .collect::<Vec<_>>(),
-            );
-        }
+        // Proc
+        self.styled_help_text.push(Text::Raw("\n\n".into()));
+        self.styled_help_text.push(Text::Styled(
+            PROCESS_HELP_TEXT[0].into(),
+            self.colours.table_header_style,
+        ));
+        self.styled_help_text.extend(
+            PROCESS_HELP_TEXT[1..]
+                .iter()
+                .map(|&text| Text::Styled(text.into(), self.colours.text_style))
+                .collect::<Vec<_>>(),
+        );
+
+        // Proc Search
+        self.styled_help_text.push(Text::Raw("\n\n".into()));
+        self.styled_help_text.push(Text::Styled(
+            SEARCH_HELP_TEXT[0].into(),
+            self.colours.table_header_style,
+        ));
+        self.styled_help_text.extend(
+            SEARCH_HELP_TEXT[1..]
+                .iter()
+                .map(|&text| Text::Styled(text.into(), self.colours.text_style))
+                .collect::<Vec<_>>(),
+        );
+
+        // Battery
+        self.styled_help_text.push(Text::Raw("\n\n".into()));
+        self.styled_help_text.push(Text::Styled(
+            BATTERY_HELP_TEXT[0].into(),
+            self.colours.table_header_style,
+        ));
+        self.styled_help_text.extend(
+            BATTERY_HELP_TEXT[1..]
+                .iter()
+                .map(|&text| Text::Styled(text.into(), self.colours.text_style))
+                .collect::<Vec<_>>(),
+        );
     }
 
     // TODO: [FEATURE] Auto-resizing dialog sizes.
@@ -214,11 +232,10 @@ impl Painter {
         let current_height = terminal_size.height;
         let current_width = terminal_size.width;
 
-        if self.height == 0 && self.width == 0 {
-            self.height = current_height;
-            self.width = current_width;
-        } else if self.height != current_height || self.width != current_width {
-            app_state.is_resized = true;
+        if (self.height == 0 && self.width == 0)
+            || (self.height != current_height || self.width != current_width)
+        {
+            app_state.is_force_redraw = true;
             self.height = current_height;
             self.width = current_width;
         }
@@ -434,7 +451,7 @@ impl Painter {
                 }
             } else {
                 // Draws using the passed in (or default) layout.  NOT basic so far.
-                if self.derived_widget_draw_locs.is_empty() || app_state.is_resized {
+                if self.derived_widget_draw_locs.is_empty() || app_state.is_force_redraw {
                     let row_draw_locs = Layout::default()
                         .margin(0)
                         .constraints(self.row_constraints.as_ref())
@@ -531,7 +548,7 @@ impl Painter {
             }
         })?;
 
-        app_state.is_resized = false;
+        app_state.is_force_redraw = false;
 
         Ok(())
     }

--- a/src/canvas/dialogs/help_dialog.rs
+++ b/src/canvas/dialogs/help_dialog.rs
@@ -1,4 +1,5 @@
 use std::cmp::max;
+use unicode_width::UnicodeWidthStr;
 
 use tui::{
     backend::Backend,
@@ -7,12 +8,9 @@ use tui::{
     widgets::{Block, Borders, Paragraph},
 };
 
-use crate::{
-    app::{App, AppHelpCategory},
-    canvas::Painter,
-};
+use crate::{app::App, canvas::Painter, constants};
 
-const HELP_BASE: &str = " Help ── 1: General ─── 2: Processes ─── 3: Search ─── Esc to close ";
+const HELP_BASE: &str = " Help ── Esc to close ";
 
 pub trait HelpDialog {
     fn draw_help_dialog<B: Backend>(
@@ -28,31 +26,107 @@ impl HelpDialog for Painter {
             0,
             draw_loc.width as i32 - HELP_BASE.chars().count() as i32 - 2,
         );
-        let help_title = format!(
-            " Help ─{}─ 1: General ─── 2: Processes ─── 3: Search ─── Esc to close ",
-            "─".repeat(repeat_num as usize)
-        );
+        let help_title = format!(" Help ─{}─ Esc to close ", "─".repeat(repeat_num as usize));
+
+        if app_state.is_force_redraw {
+            // We must also recalculate how many lines are wrapping to properly get scrolling to work on
+            // small terminal sizes... oh joy.
+
+            // TODO: Make this more automated and easier to add.
+
+            let mut overflow_buffer = 0;
+            let paragraph_width = draw_loc.width - 2;
+            constants::HELP_CONTENTS_TEXT.iter().for_each(|text_line| {
+                overflow_buffer +=
+                    UnicodeWidthStr::width(*text_line).saturating_sub(1) as u16 / paragraph_width;
+            });
+
+            // General
+            app_state.help_dialog_state.general_index =
+                constants::HELP_CONTENTS_TEXT.len() as u16 + 1 + overflow_buffer;
+            constants::GENERAL_HELP_TEXT.iter().for_each(|text_line| {
+                overflow_buffer +=
+                    UnicodeWidthStr::width(*text_line).saturating_sub(1) as u16 / paragraph_width;
+            });
+
+            // Processes
+            app_state.help_dialog_state.process_index =
+                (constants::HELP_CONTENTS_TEXT.len() + constants::GENERAL_HELP_TEXT.len()) as u16
+                    + 2
+                    + overflow_buffer;
+            constants::PROCESS_HELP_TEXT.iter().for_each(|text_line| {
+                overflow_buffer +=
+                    UnicodeWidthStr::width(*text_line).saturating_sub(1) as u16 / paragraph_width;
+            });
+
+            // Search
+            app_state.help_dialog_state.search_index = (constants::HELP_CONTENTS_TEXT.len()
+                + constants::GENERAL_HELP_TEXT.len()
+                + constants::PROCESS_HELP_TEXT.len())
+                as u16
+                + 3
+                + overflow_buffer;
+            constants::SEARCH_HELP_TEXT.iter().for_each(|text_line| {
+                overflow_buffer +=
+                    UnicodeWidthStr::width(*text_line).saturating_sub(1) as u16 / paragraph_width;
+            });
+
+            // Battery
+            app_state.help_dialog_state.battery_index = (constants::HELP_CONTENTS_TEXT.len()
+                + constants::GENERAL_HELP_TEXT.len()
+                + constants::PROCESS_HELP_TEXT.len()
+                + constants::SEARCH_HELP_TEXT.len())
+                as u16
+                + 4
+                + overflow_buffer;
+            constants::BATTERY_HELP_TEXT.iter().for_each(|text_line| {
+                overflow_buffer +=
+                    UnicodeWidthStr::width(*text_line).saturating_sub(1) as u16 / paragraph_width;
+            });
+
+            app_state.help_dialog_state.scroll_state.max_scroll_index =
+                (self.styled_help_text.len() as u16
+                    + (constants::NUM_CATEGORIES - 1)
+                    + overflow_buffer)
+                    .saturating_sub(draw_loc.height + 1);
+
+            // Fix if over-scrolled
+            if app_state
+                .help_dialog_state
+                .scroll_state
+                .current_scroll_index
+                >= app_state.help_dialog_state.scroll_state.max_scroll_index
+            {
+                app_state
+                    .help_dialog_state
+                    .scroll_state
+                    .current_scroll_index = app_state
+                    .help_dialog_state
+                    .scroll_state
+                    .max_scroll_index
+                    .saturating_sub(1);
+            }
+        }
 
         f.render_widget(
-            Paragraph::new(
-                match app_state.help_dialog_state.current_category {
-                    AppHelpCategory::General => &self.styled_general_help_text,
-                    AppHelpCategory::Process => &self.styled_process_help_text,
-                    AppHelpCategory::Search => &self.styled_search_help_text,
-                }
-                .iter(),
-            )
-            .block(
-                Block::default()
-                    .title(&help_title)
-                    .title_style(self.colours.border_style)
-                    .style(self.colours.border_style)
-                    .borders(Borders::ALL)
-                    .border_style(self.colours.border_style),
-            )
-            .style(self.colours.text_style)
-            .alignment(Alignment::Left)
-            .wrap(true),
+            Paragraph::new(self.styled_help_text.iter())
+                .block(
+                    Block::default()
+                        .title(&help_title)
+                        .title_style(self.colours.border_style)
+                        .style(self.colours.border_style)
+                        .borders(Borders::ALL)
+                        .border_style(self.colours.border_style),
+                )
+                .style(self.colours.text_style)
+                .alignment(Alignment::Left)
+                .wrap(true)
+                .scroll(
+                    app_state
+                        .help_dialog_state
+                        .scroll_state
+                        .current_scroll_index,
+                ),
             draw_loc,
         );
     }

--- a/src/canvas/dialogs/help_dialog.rs
+++ b/src/canvas/dialogs/help_dialog.rs
@@ -49,11 +49,23 @@ impl HelpDialog for Painter {
                     UnicodeWidthStr::width(*text_line).saturating_sub(1) as u16 / paragraph_width;
             });
 
-            // Processes
-            app_state.help_dialog_state.process_index =
+            // CPU
+            app_state.help_dialog_state.cpu_index =
                 (constants::HELP_CONTENTS_TEXT.len() + constants::GENERAL_HELP_TEXT.len()) as u16
                     + 2
                     + overflow_buffer;
+            constants::CPU_HELP_TEXT.iter().for_each(|text_line| {
+                overflow_buffer +=
+                    UnicodeWidthStr::width(*text_line).saturating_sub(1) as u16 / paragraph_width;
+            });
+
+            // Processes
+            app_state.help_dialog_state.process_index = (constants::HELP_CONTENTS_TEXT.len()
+                + constants::GENERAL_HELP_TEXT.len()
+                + constants::CPU_HELP_TEXT.len())
+                as u16
+                + 3
+                + overflow_buffer;
             constants::PROCESS_HELP_TEXT.iter().for_each(|text_line| {
                 overflow_buffer +=
                     UnicodeWidthStr::width(*text_line).saturating_sub(1) as u16 / paragraph_width;
@@ -62,9 +74,10 @@ impl HelpDialog for Painter {
             // Search
             app_state.help_dialog_state.search_index = (constants::HELP_CONTENTS_TEXT.len()
                 + constants::GENERAL_HELP_TEXT.len()
+                + constants::CPU_HELP_TEXT.len()
                 + constants::PROCESS_HELP_TEXT.len())
                 as u16
-                + 3
+                + 4
                 + overflow_buffer;
             constants::SEARCH_HELP_TEXT.iter().for_each(|text_line| {
                 overflow_buffer +=
@@ -74,10 +87,11 @@ impl HelpDialog for Painter {
             // Battery
             app_state.help_dialog_state.battery_index = (constants::HELP_CONTENTS_TEXT.len()
                 + constants::GENERAL_HELP_TEXT.len()
+                + constants::CPU_HELP_TEXT.len()
                 + constants::PROCESS_HELP_TEXT.len()
                 + constants::SEARCH_HELP_TEXT.len())
                 as u16
-                + 4
+                + 5
                 + overflow_buffer;
             constants::BATTERY_HELP_TEXT.iter().for_each(|text_line| {
                 overflow_buffer +=
@@ -86,9 +100,9 @@ impl HelpDialog for Painter {
 
             app_state.help_dialog_state.scroll_state.max_scroll_index =
                 (self.styled_help_text.len() as u16
-                    + (constants::NUM_CATEGORIES - 1)
+                    + (constants::NUM_CATEGORIES - 3)
                     + overflow_buffer)
-                    .saturating_sub(draw_loc.height + 1);
+                    .saturating_sub(draw_loc.height);
 
             // Fix if over-scrolled
             if app_state

--- a/src/canvas/drawing_utils.rs
+++ b/src/canvas/drawing_utils.rs
@@ -78,9 +78,9 @@ pub fn get_variable_intrinsic_widths(
 
 pub fn get_search_start_position(
     num_columns: usize, cursor_direction: &app::CursorDirection, cursor_bar: &mut usize,
-    current_cursor_position: usize, is_resized: bool,
+    current_cursor_position: usize, is_force_redraw: bool,
 ) -> usize {
-    if is_resized {
+    if is_force_redraw {
         *cursor_bar = 0;
     }
 
@@ -118,9 +118,9 @@ pub fn get_search_start_position(
 
 pub fn get_start_position(
     num_rows: u64, scroll_direction: &app::ScrollDirection, scroll_position_bar: &mut u64,
-    currently_selected_position: u64, is_resized: bool,
+    currently_selected_position: u64, is_force_redraw: bool,
 ) -> u64 {
-    if is_resized {
+    if is_force_redraw {
         *scroll_position_bar = 0;
     }
 

--- a/src/canvas/drawing_utils.rs
+++ b/src/canvas/drawing_utils.rs
@@ -1,6 +1,7 @@
 use crate::app;
 use itertools::izip;
 
+// TODO: Reverse intrinsic?
 /// A somewhat jury-rigged solution to simulate a variable intrinsic layout for
 /// table widths.  Note that this will do one main pass to try to properly
 /// allocate widths.  This will thus potentially cut off latter elements

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -224,7 +224,7 @@ impl CpuGraphWidget for Painter {
                 &cpu_widget_state.scroll_state.scroll_direction,
                 &mut cpu_widget_state.scroll_state.previous_scroll_position,
                 cpu_widget_state.scroll_state.current_scroll_position,
-                app_state.is_resized,
+                app_state.is_force_redraw,
             );
             let is_on_widget = widget_id == app_state.current_widget.widget_id;
 

--- a/src/canvas/widgets/disk_table.rs
+++ b/src/canvas/widgets/disk_table.rs
@@ -45,7 +45,7 @@ impl DiskTableWidget for Painter {
                 &disk_widget_state.scroll_state.scroll_direction,
                 &mut disk_widget_state.scroll_state.previous_scroll_position,
                 disk_widget_state.scroll_state.current_scroll_position,
-                app_state.is_resized,
+                app_state.is_force_redraw,
             );
             let is_on_widget = app_state.current_widget.widget_id == widget_id;
             let disk_table_state = &mut disk_widget_state.scroll_state.table_state;

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -91,7 +91,7 @@ impl ProcessTableWidget for Painter {
                     &proc_widget_state.scroll_state.scroll_direction,
                     &mut proc_widget_state.scroll_state.previous_scroll_position,
                     proc_widget_state.scroll_state.current_scroll_position,
-                    app_state.is_resized,
+                    app_state.is_force_redraw,
                 );
 
                 // Sanity check
@@ -370,7 +370,7 @@ impl ProcessTableWidget for Painter {
                     .search_state
                     .cursor_bar,
                 current_cursor_position,
-                app_state.is_resized,
+                app_state.is_force_redraw,
             );
 
             let query = proc_widget_state.get_current_search_query().as_str();

--- a/src/canvas/widgets/temp_table.rs
+++ b/src/canvas/widgets/temp_table.rs
@@ -46,7 +46,7 @@ impl TempTableWidget for Painter {
                 &temp_widget_state.scroll_state.scroll_direction,
                 &mut temp_widget_state.scroll_state.previous_scroll_position,
                 temp_widget_state.scroll_state.current_scroll_position,
-                app_state.is_resized,
+                app_state.is_force_redraw,
             );
             let is_on_widget = widget_id == app_state.current_widget.widget_id;
             let temp_table_state = &mut temp_widget_state.scroll_state.table_state;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -36,17 +36,27 @@ lazy_static! {
 }
 
 // Help text
+pub const NUM_CATEGORIES: u16 = 5;
+
+pub const HELP_CONTENTS_TEXT: [&str; 5] = [
+    "Press the corresponding numbers to jump to the section:\n",
+    "1 - General Keybindings\n",
+    "2 - Process Keybindings\n",
+    "3 - Search Keybindings\n",
+    "4 - Battery Keybindings",
+];
+
 pub const GENERAL_HELP_TEXT: [&str; 18] = [
-    "General Keybindings\n\n",
+    "1 - General Keybindings\n",
     "q, Ctrl-c      Quit bottom\n",
     "Esc            Close filters, dialog boxes, etc.\n",
     "Ctrl-r         Reset all data\n",
     "f              Freeze display\n",
-    "Ctrl-Arrow     Change your selected widget\n",
+    "Ctrl-Arrow     \n",
     "Shift-Arrow    Change your selected widget\n",
-    "H/J/K/L        Change your selected widget up/down/left/right\n",
-    "Up, k          Move cursor up\n",
-    "Down, j        Move cursor down\n",
+    "H/J/K/L        \n",
+    "Up, k          Scroll up\n",
+    "Down, j        Scroll down\n",
     "?              Open the help screen\n",
     "gg             Skip to the first entry of a list\n",
     "G              Skip to the last entry of a list\n",
@@ -54,22 +64,22 @@ pub const GENERAL_HELP_TEXT: [&str; 18] = [
     "/              Filter out graph lines (only CPU at the moment)\n",
     "+              Zoom in (decrease time range)\n",
     "-              Zoom out (increase time range)\n",
-    "=              Reset zoom\n",
+    "=              Reset zoom",
 ];
 
 pub const PROCESS_HELP_TEXT: [&str; 8] = [
-    "Process Keybindings\n\n",
+    "2 - Process Keybindings\n",
     "dd, Delete     Kill the highlighted process\n",
     "c              Sort by CPU usage\n",
     "m              Sort by memory usage\n",
     "p              Sort by PID\n",
     "n              Sort by process name\n",
     "Tab            Group together processes with the same name\n",
-    "Ctrl-f, /      Open up the search widget\n",
+    "Ctrl-f, /      Open up the search widget",
 ];
 
 pub const SEARCH_HELP_TEXT: [&str; 13] = [
-    "Search Keybindings\n\n",
+    "3 - Search Keybindings\n",
     "Tab            Toggle between searching for PID and name.\n",
     "Esc            Close search widget\n",
     "Ctrl-a         Skip to the start of search widget\n",
@@ -81,7 +91,13 @@ pub const SEARCH_HELP_TEXT: [&str; 13] = [
     "Right          Move cursor right\n",
     "Alt-c/F1       Toggle whether to ignore case\n",
     "Alt-w/F2       Toggle whether to match the whole word\n",
-    "Alt-r/F3       Toggle whether to use regex\n",
+    "Alt-r/F3       Toggle whether to use regex",
+];
+
+pub const BATTERY_HELP_TEXT: [&str; 3] = [
+    "4 - Battery Keybindings\n",
+    "Left           Go to previous battery\n",
+    "Right          Go to next battery",
 ];
 
 // Config and flags

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -36,66 +36,74 @@ lazy_static! {
 }
 
 // Help text
-pub const NUM_CATEGORIES: u16 = 5;
+pub const NUM_CATEGORIES: u16 = 6;
 
-pub const HELP_CONTENTS_TEXT: [&str; 5] = [
-    "Press the corresponding numbers to jump to the section:\n",
-    "1 - General Keybindings\n",
-    "2 - Process Keybindings\n",
-    "3 - Search Keybindings\n",
-    "4 - Battery Keybindings",
+pub const HELP_CONTENTS_TEXT: [&str; 6] = [
+    "Press the corresponding numbers to jump to the section, or scroll:\n",
+    "1 - General bindings\n",
+    "2 - CPU bindings\n",
+    "3 - Process bindings\n",
+    "4 - Process search bindings\n",
+    "5 - Battery bindings",
 ];
 
 pub const GENERAL_HELP_TEXT: [&str; 18] = [
-    "1 - General Keybindings\n",
-    "q, Ctrl-c      Quit bottom\n",
-    "Esc            Close filters, dialog boxes, etc.\n",
-    "Ctrl-r         Reset all data\n",
-    "f              Freeze display\n",
+    "1 - General bindings\n",
+    "q, Ctrl-c      Quit\n",
+    "Esc            Close dialog windows, search, widgets, or exit maximized mode\n",
+    "Ctrl-r         Reset display and any collected data\n",
+    "f              Freeze/unfreeze updating with new data\n",
     "Ctrl-Arrow     \n",
-    "Shift-Arrow    Change your selected widget\n",
+    "Shift-Arrow    Move to a different widget\n",
     "H/J/K/L        \n",
     "Up, k          Scroll up\n",
     "Down, j        Scroll down\n",
-    "?              Open the help screen\n",
-    "gg             Skip to the first entry of a list\n",
-    "G              Skip to the last entry of a list\n",
+    "?              Open help menu\n",
+    "gg             Jump to the first entry\n",
+    "G              Jump to the last entry\n",
     "Enter          Maximize the currently selected widget\n",
-    "/              Filter out graph lines (only CPU at the moment)\n",
-    "+              Zoom in (decrease time range)\n",
-    "-              Zoom out (increase time range)\n",
-    "=              Reset zoom",
+    "+              Zoom in on chart (decrease time range)\n",
+    "-              Zoom out on chart (increase time range)\n",
+    "=              Reset zoom\n",
+    "Mouse scroll   Scroll through the tables or zoom in/out of charts by scrolling up/down",
+];
+
+pub const CPU_HELP_TEXT: [&str; 4] = [
+    "2 - CPU bindings\n",
+    "/              Open filtering for showing certain CPU cores\n",
+    "Space          Toggle enabled/disabled cores\n",
+    "Esc            Exit filtering mode",
 ];
 
 pub const PROCESS_HELP_TEXT: [&str; 8] = [
-    "2 - Process Keybindings\n",
-    "dd, Delete     Kill the highlighted process\n",
-    "c              Sort by CPU usage\n",
+    "3 - Process bindings\n",
+    "dd             Kill the selected process\n",
+    "c              Sort by memory usage, press again to reverse sorting order\n",
     "m              Sort by memory usage\n",
-    "p              Sort by PID\n",
-    "n              Sort by process name\n",
-    "Tab            Group together processes with the same name\n",
-    "Ctrl-f, /      Open up the search widget",
+    "p              Sort by PID name, press again to reverse sorting order\n",
+    "n              Sort by process name, press again to reverse sorting order\n",
+    "Tab            Group/un-group processes with the same name\n",
+    "Ctrl-f, /      Open process search widget",
 ];
 
 pub const SEARCH_HELP_TEXT: [&str; 13] = [
-    "3 - Search Keybindings\n",
-    "Tab            Toggle between searching for PID and name.\n",
-    "Esc            Close search widget\n",
-    "Ctrl-a         Skip to the start of search widget\n",
-    "Ctrl-e         Skip to the end of search widget\n",
+    "4 - Process search bindings\n",
+    "Tab            Toggle between searching for PID and name\n",
+    "Esc            Close the search widget (retains the filter)\n",
+    "Ctrl-a         Skip to the start of the search query\n",
+    "Ctrl-e         Skip to the end of the search query\n",
     "Ctrl-u         Clear the current search query\n",
     "Backspace      Delete the character behind the cursor\n",
     "Delete         Delete the character at the cursor\n",
+    "Alt-c/F1       Toggle matching case\n",
+    "Alt-w/F2       Toggle matching the entire word\n",
+    "Alt-r/F3       Toggle using regex\n",
     "Left           Move cursor left\n",
-    "Right          Move cursor right\n",
-    "Alt-c/F1       Toggle whether to ignore case\n",
-    "Alt-w/F2       Toggle whether to match the whole word\n",
-    "Alt-r/F3       Toggle whether to use regex",
+    "Right          Move cursor right",
 ];
 
 pub const BATTERY_HELP_TEXT: [&str; 3] = [
-    "4 - Battery Keybindings\n",
+    "5 - Battery bindings\n",
     "Left           Go to previous battery\n",
     "Right          Go to next battery",
 ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,17 +114,6 @@ fn main() -> error::Result<()> {
     painter.colours.generate_remaining_cpu_colours();
     painter.complete_painter_init();
 
-    // Set up up tui and crossterm
-    let mut stdout_val = stdout();
-    execute!(stdout_val, EnterAlternateScreen, EnableMouseCapture)?;
-    enable_raw_mode()?;
-
-    let mut terminal = Terminal::new(CrosstermBackend::new(stdout_val))?;
-    terminal.hide_cursor()?;
-
-    // Set panic hook
-    panic::set_hook(Box::new(|info| panic_hook(info)));
-
     // Set up input handling
     let (tx, rx) = mpsc::channel();
     create_input_thread(tx.clone());
@@ -150,6 +139,17 @@ fn main() -> error::Result<()> {
         app.app_config_fields.show_average_cpu,
         app.used_widgets.clone(),
     );
+
+    // Set up up tui and crossterm
+    let mut stdout_val = stdout();
+    execute!(stdout_val, EnterAlternateScreen, EnableMouseCapture)?;
+    enable_raw_mode()?;
+
+    let mut terminal = Terminal::new(CrosstermBackend::new(stdout_val))?;
+    terminal.hide_cursor()?;
+
+    // Set panic hook
+    panic::set_hook(Box::new(|info| panic_hook(info)));
 
     let mut first_run = true;
     loop {


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Adds scrolling to the help menu to make it easier to add to and not have to deal with text overflowing.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _New feature (non-breaking change which adds functionality)_

## Test methodology

_Please state how this was tested:_

_Please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_Please ensure all are ticked (and actually done):_

- [x] _Change has been tested to work_
- [x] _Areas your change affects have been linted using rustfmt_
- [x] _Code has been self-reviewed_
- [x] _Code has been tested and no new breakage is introduced unless intended_
- [x] _Documentation has been added/updated if needed_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
