### PR TITLE
refactor: avoid using max checks, use saturating_sub instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -423,7 +423,7 @@ dependencies = [
  "proc-macro-hack 0.5.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1064,7 +1064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1103,7 +1103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1192,7 +1192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "vec_map"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1424,7 +1424,7 @@ dependencies = [
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
+"checksum syn 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "e8e5aa70697bb26ee62214ae3288465ecec0000f05182f039b477001f08f5ae7"
 "checksum sysinfo 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d070254b7172eee9eb3990bea8f72aeabfe1226c40bf71a52e4fe75777812e9a"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
@@ -1440,7 +1440,7 @@ dependencies = [
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum uom 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4cec796ec5f7ac557631709079168286056205c51c60aac33f51764bdc7b8dc4"
 "checksum uom 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51fc04fb44bcb7806da71885872cb15d123b681e459a476ef8a0bab287bee0cd"
-"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use std::{cmp::max, collections::HashMap, time::Instant};
+use std::{collections::HashMap, time::Instant};
 
 use unicode_segmentation::GraphemeCursor;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
@@ -166,7 +166,7 @@ impl App {
                             >= cpu_widget_state.num_cpus_shown as u64
                         {
                             let new_position =
-                                max(0, cpu_widget_state.num_cpus_shown as i64 - 1) as u64;
+                                cpu_widget_state.num_cpus_shown.saturating_sub(1) as u64;
                             cpu_widget_state.scroll_state.current_scroll_position = new_position;
                             cpu_widget_state.scroll_state.previous_scroll_position = 0;
                         }
@@ -184,7 +184,7 @@ impl App {
                             >= cpu_widget_state.num_cpus_shown as u64
                         {
                             let new_position =
-                                max(0, cpu_widget_state.num_cpus_shown as i64 - 1) as u64;
+                                cpu_widget_state.num_cpus_shown.saturating_sub(1) as u64;
                             cpu_widget_state.scroll_state.current_scroll_position = new_position;
                             cpu_widget_state.scroll_state.previous_scroll_position = 0;
                         }

--- a/src/app/query.rs
+++ b/src/app/query.rs
@@ -412,7 +412,7 @@ impl ProcessQuery for ProcWidgetState {
 
 #[derive(Debug)]
 pub struct Query {
-    /// Remember, AND > OR, but and must come after or then.
+    /// Remember, AND > OR, but AND must come after OR when we parse.
     pub query: And,
 }
 

--- a/src/app/states.rs
+++ b/src/app/states.rs
@@ -205,7 +205,7 @@ impl ProcWidgetState {
             self.process_search_state.search_state.error_message = None;
         } else {
             let parsed_query = self.parse_query();
-            debug!("PQ: {:#?}", parsed_query);
+            // debug!("PQ: {:#?}", parsed_query);
 
             if let Ok(parsed_query) = parsed_query {
                 self.process_search_state.search_state.query = Some(parsed_query);

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,5 +1,4 @@
 use itertools::izip;
-use std::cmp::max;
 use std::collections::HashMap;
 
 use tui::{
@@ -66,7 +65,7 @@ pub struct Painter {
     layout_constraints: Vec<Vec<Vec<Vec<Constraint>>>>,
     widget_layout: BottomLayout,
     derived_widget_draw_locs: Vec<Vec<Vec<Vec<Rect>>>>,
-    table_height_offset: i64,
+    table_height_offset: u16,
 }
 
 impl Painter {
@@ -150,7 +149,7 @@ impl Painter {
             layout_constraints,
             widget_layout,
             derived_widget_draw_locs: Vec::new(),
-            table_height_offset: 4 + table_gap as i64,
+            table_height_offset: 4 + table_gap,
         }
     }
 
@@ -209,7 +208,7 @@ impl Painter {
         terminal.draw(|mut f| {
             if app_state.help_dialog_state.is_showing_help {
                 let gen_help_len = GENERAL_HELP_TEXT.len() as u16 + 3;
-                let border_len = (max(0, f.size().height as i64 - gen_help_len as i64)) as u16 / 2;
+                let border_len = f.size().height.saturating_sub(gen_help_len) / 2;
                 let vertical_dialog_chunk = Layout::default()
                     .direction(Direction::Vertical)
                     .constraints(
@@ -245,7 +244,7 @@ impl Painter {
 
                 self.draw_help_dialog(&mut f, app_state, middle_dialog_chunk[1]);
             } else if app_state.delete_dialog_state.is_showing_dd {
-                let bordering = (max(0, f.size().height as i64 - 7) as u16) / 2;
+                let bordering = f.size().height.saturating_sub(7) / 2;
                 let vertical_dialog_chunk = Layout::default()
                     .direction(Direction::Vertical)
                     .constraints(

--- a/src/canvas/dialogs/dd_dialog.rs
+++ b/src/canvas/dialogs/dd_dialog.rs
@@ -1,5 +1,3 @@
-use std::cmp::max;
-
 use tui::{
     backend::Backend,
     layout::{Alignment, Rect},
@@ -61,10 +59,8 @@ impl KillDialog for Painter {
                     },
                 ];
 
-                let repeat_num = max(
-                    0,
-                    draw_loc.width as i32 - DD_BASE.chars().count() as i32 - 2,
-                );
+                let repeat_num =
+                    usize::from(draw_loc.width).saturating_sub(DD_BASE.chars().count() + 2);
                 let dd_title = format!(
                     " Confirm Kill Process ─{}─ Esc to close ",
                     "─".repeat(repeat_num as usize)
@@ -102,10 +98,8 @@ impl KillDialog for Painter {
             dd_err
         ))];
 
-        let repeat_num = max(
-            0,
-            draw_loc.width as i32 - DD_ERROR_BASE.chars().count() as i32 - 2,
-        );
+        let repeat_num =
+            usize::from(draw_loc.width).saturating_sub(DD_ERROR_BASE.chars().count() + 2);
         let error_title = format!(" Error ─{}─ Esc to close ", "─".repeat(repeat_num as usize));
 
         f.render_widget(

--- a/src/canvas/dialogs/help_dialog.rs
+++ b/src/canvas/dialogs/help_dialog.rs
@@ -1,4 +1,3 @@
-use std::cmp::max;
 use unicode_width::UnicodeWidthStr;
 
 use tui::{
@@ -22,10 +21,7 @@ impl HelpDialog for Painter {
     fn draw_help_dialog<B: Backend>(
         &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect,
     ) {
-        let repeat_num = max(
-            0,
-            draw_loc.width as i32 - HELP_BASE.chars().count() as i32 - 2,
-        );
+        let repeat_num = usize::from(draw_loc.width).saturating_sub(HELP_BASE.chars().count() + 2);
         let help_title = format!(" Help ─{}─ Esc to close ", "─".repeat(repeat_num as usize));
 
         if app_state.is_force_redraw {

--- a/src/canvas/widgets/basic_table_arrows.rs
+++ b/src/canvas/widgets/basic_table_arrows.rs
@@ -1,5 +1,3 @@
-use std::cmp::max;
-
 use crate::{
     app::{
         layout_manager::{BottomWidget, BottomWidgetType},
@@ -56,10 +54,9 @@ impl BasicTableArrows for Painter {
         let left_name = left_table.get_pretty_name();
         let right_name = right_table.get_pretty_name();
 
-        let num_spaces = max(
-            0,
-            draw_loc.width as i64 - 2 - 4 - (left_name.len() + right_name.len()) as i64,
-        ) as usize;
+        let num_spaces = usize::from(draw_loc.width)
+            .saturating_sub(6 + left_name.len() + right_name.len())
+            as usize;
 
         let arrow_text = vec![
             Text::Styled(format!("\n◄ {}", left_name).into(), self.colours.text_style),

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -1,5 +1,3 @@
-use std::cmp::max;
-
 use crate::{
     app::App,
     canvas::{drawing_utils::calculate_basic_use_bars, Painter},
@@ -31,10 +29,8 @@ impl BatteryDisplayWidget for Painter {
             let is_on_widget = widget_id == app_state.current_widget.widget_id;
             let title = if app_state.is_expanded {
                 const TITLE_BASE: &str = " Battery ── Esc to go back ";
-                let repeat_num = max(
-                    0,
-                    draw_loc.width as i32 - TITLE_BASE.chars().count() as i32 - 2,
-                );
+                let repeat_num =
+                    usize::from(draw_loc.width).saturating_sub(TITLE_BASE.chars().count() + 2);
                 let result_title = format!(
                     " Battery ─{}─ Esc to go back ",
                     "─".repeat(repeat_num as usize)
@@ -74,7 +70,7 @@ impl BatteryDisplayWidget for Painter {
                 .get(battery_widget_state.currently_selected_battery_index)
             {
                 // Assuming a 50/50 split in width
-                let bar_length = max(0, (draw_loc.width as i64 - 2) / 2 - 8) as usize;
+                let bar_length = (draw_loc.width.saturating_sub(2) / 2).saturating_sub(8) as usize;
                 let charge_percentage = battery_details.charge_percentage;
                 let num_bars = calculate_basic_use_bars(charge_percentage, bar_length);
                 let bars = format!(

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -1,4 +1,4 @@
-use std::cmp::{max, min};
+use std::cmp::min;
 
 use crate::{
     app::App,
@@ -58,12 +58,10 @@ impl CpuBasicWidget for Painter {
                 .split(draw_loc);
 
             // +9 due to 3 + 4 + 2 columns for the name & space + percentage + bar bounds
-            let margin_space = 2;
-            let remaining_width = max(
-                0,
-                draw_loc.width as i64
-                    - ((9 + margin_space) * REQUIRED_COLUMNS - margin_space) as i64,
-            ) as usize;
+            const MARGIN_SPACE: usize = 2;
+            let remaining_width = usize::from(draw_loc.width)
+                .saturating_sub((9 + MARGIN_SPACE) * REQUIRED_COLUMNS - MARGIN_SPACE)
+                as usize;
 
             let bar_length = remaining_width / REQUIRED_COLUMNS;
 

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -170,10 +170,8 @@ impl CpuGraphWidget for Painter {
 
             let title = if app_state.is_expanded && !cpu_widget_state.is_showing_tray {
                 const TITLE_BASE: &str = " CPU ── Esc to go back ";
-                let repeat_num = max(
-                    0,
-                    draw_loc.width as i32 - TITLE_BASE.chars().count() as i32 - 2,
-                );
+                let repeat_num =
+                    usize::from(draw_loc.width).saturating_sub(TITLE_BASE.chars().count() + 2);
                 let result_title =
                     format!(" CPU ─{}─ Esc to go back ", "─".repeat(repeat_num as usize));
 
@@ -217,7 +215,7 @@ impl CpuGraphWidget for Painter {
             cpu_widget_state.is_legend_hidden = false;
             let cpu_data: &mut [ConvertedCpuData] = &mut app_state.canvas_data.cpu_data;
 
-            let num_rows = max(0, i64::from(draw_loc.height) - self.table_height_offset) as u64;
+            let num_rows = draw_loc.height.saturating_sub(self.table_height_offset) as u64;
             let start_position = get_start_position(
                 num_rows,
                 &cpu_widget_state.scroll_state.scroll_direction,
@@ -304,10 +302,8 @@ impl CpuGraphWidget for Painter {
 
             let title = if cpu_widget_state.is_showing_tray {
                 const TITLE_BASE: &str = " Esc to close ";
-                let repeat_num = max(
-                    0,
-                    draw_loc.width as i32 - TITLE_BASE.chars().count() as i32 - 2,
-                );
+                let repeat_num =
+                    usize::from(draw_loc.width).saturating_sub(TITLE_BASE.chars().count() + 2);
                 let result_title = format!("{} Esc to close ", "─".repeat(repeat_num as usize));
 
                 result_title

--- a/src/canvas/widgets/disk_table.rs
+++ b/src/canvas/widgets/disk_table.rs
@@ -39,7 +39,7 @@ impl DiskTableWidget for Painter {
     ) {
         if let Some(disk_widget_state) = app_state.disk_state.widget_states.get_mut(&widget_id) {
             let disk_data: &mut [Vec<String>] = &mut app_state.canvas_data.disk_data;
-            let num_rows = max(0, i64::from(draw_loc.height) - self.table_height_offset) as u64;
+            let num_rows = draw_loc.height.saturating_sub(self.table_height_offset) as u64;
             let start_position = get_start_position(
                 num_rows,
                 &disk_widget_state.scroll_state.scroll_direction,
@@ -66,10 +66,8 @@ impl DiskTableWidget for Painter {
 
             let title = if app_state.is_expanded {
                 const TITLE_BASE: &str = " Disk ── Esc to go back ";
-                let repeat_num = max(
-                    0,
-                    draw_loc.width as i32 - TITLE_BASE.chars().count() as i32 - 2,
-                );
+                let repeat_num =
+                    usize::from(draw_loc.width).saturating_sub(TITLE_BASE.chars().count() + 2);
                 let result_title = format!(
                     " Disk ─{}─ Esc to go back ",
                     "─".repeat(repeat_num as usize)

--- a/src/canvas/widgets/mem_basic.rs
+++ b/src/canvas/widgets/mem_basic.rs
@@ -1,5 +1,3 @@
-use std::cmp::max;
-
 use crate::{
     app::App,
     canvas::{drawing_utils::*, Painter},
@@ -41,7 +39,7 @@ impl MemBasicWidget for Painter {
         }
 
         // +9 due to 3 + 4 + 2 + 2 columns for the name & space + percentage + bar bounds + margin spacing
-        let bar_length = max(0, draw_loc.width as i64 - 11) as usize;
+        let bar_length = draw_loc.width.saturating_sub(11) as usize;
         let ram_use_percentage = if let Some(mem) = mem_data.last() {
             mem.1
         } else {

--- a/src/canvas/widgets/mem_graph.rs
+++ b/src/canvas/widgets/mem_graph.rs
@@ -1,5 +1,3 @@
-use std::cmp::max;
-
 use crate::{app::App, canvas::Painter, constants::*};
 
 use tui::{
@@ -93,10 +91,8 @@ impl MemGraphWidget for Painter {
 
             let title = if app_state.is_expanded {
                 const TITLE_BASE: &str = " Memory ── Esc to go back ";
-                let repeat_num = max(
-                    0,
-                    draw_loc.width as i32 - TITLE_BASE.chars().count() as i32 - 2,
-                );
+                let repeat_num =
+                    usize::from(draw_loc.width).saturating_sub(TITLE_BASE.chars().count() + 2);
                 let result_title = format!(
                     " Memory ─{}─ Esc to go back ",
                     "─".repeat(repeat_num as usize)

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -111,10 +111,8 @@ impl NetworkGraphWidget for Painter {
 
             let title = if app_state.is_expanded {
                 const TITLE_BASE: &str = " Network ── Esc to go back ";
-                let repeat_num = max(
-                    0,
-                    draw_loc.width as i32 - TITLE_BASE.chars().count() as i32 - 2,
-                );
+                let repeat_num =
+                    usize::from(draw_loc.width).saturating_sub(TITLE_BASE.chars().count() + 2);
                 let result_title = format!(
                     " Network ─{}─ Esc to go back ",
                     "─".repeat(repeat_num as usize)

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -1,5 +1,3 @@
-use std::cmp::max;
-
 use crate::{
     app::{self, App},
     canvas::{
@@ -83,7 +81,7 @@ impl ProcessTableWidget for Painter {
                 // hit the process we've currently scrolled to.
                 // We also need to move the list - we can
                 // do so by hiding some elements!
-                let num_rows = max(0, i64::from(draw_loc.height) - self.table_height_offset) as u64;
+                let num_rows = draw_loc.height.saturating_sub(self.table_height_offset) as u64;
                 let is_on_widget = widget_id == app_state.current_widget.widget_id;
 
                 let position = get_start_position(
@@ -96,7 +94,7 @@ impl ProcessTableWidget for Painter {
 
                 // Sanity check
                 let start_position = if position >= process_data.len() as u64 {
-                    std::cmp::max(0, process_data.len() as i64 - 1) as u64
+                    process_data.len().saturating_sub(1) as u64
                 } else {
                     position
                 };
@@ -195,10 +193,8 @@ impl ProcessTableWidget for Painter {
                             .is_enabled
                     {
                         const TITLE_BASE: &str = " Processes ── Esc to go back ";
-                        let repeat_num = max(
-                            0,
-                            draw_loc.width as i32 - TITLE_BASE.chars().count() as i32 - 2,
-                        );
+                        let repeat_num = usize::from(draw_loc.width)
+                            .saturating_sub(TITLE_BASE.chars().count() + 2);
                         let result_title = format!(
                             " Processes ─{}─ Esc to go back ",
                             "─".repeat(repeat_num as usize)
@@ -439,10 +435,8 @@ impl ProcessTableWidget for Painter {
             let title = if draw_border {
                 const TITLE_BASE: &str = " Esc to close ";
 
-                let repeat_num = max(
-                    0,
-                    draw_loc.width as i32 - TITLE_BASE.chars().count() as i32 - 2,
-                );
+                let repeat_num =
+                    usize::from(draw_loc.width).saturating_sub(TITLE_BASE.chars().count() + 2);
                 format!("{} Esc to close ", "─".repeat(repeat_num as usize))
             } else {
                 String::new()

--- a/src/canvas/widgets/temp_table.rs
+++ b/src/canvas/widgets/temp_table.rs
@@ -40,7 +40,7 @@ impl TempTableWidget for Painter {
         if let Some(temp_widget_state) = app_state.temp_state.widget_states.get_mut(&widget_id) {
             let temp_sensor_data: &mut [Vec<String>] = &mut app_state.canvas_data.temp_sensor_data;
 
-            let num_rows = max(0, i64::from(draw_loc.height) - self.table_height_offset) as u64;
+            let num_rows = draw_loc.height.saturating_sub(self.table_height_offset) as u64;
             let start_position = get_start_position(
                 num_rows,
                 &temp_widget_state.scroll_state.scroll_direction,
@@ -66,10 +66,8 @@ impl TempTableWidget for Painter {
 
             let title = if app_state.is_expanded {
                 const TITLE_BASE: &str = " Temperatures ── Esc to go back ";
-                let repeat_num = max(
-                    0,
-                    draw_loc.width as i32 - TITLE_BASE.chars().count() as i32 - 2,
-                );
+                let repeat_num =
+                    usize::from(draw_loc.width).saturating_sub(TITLE_BASE.chars().count() + 2);
                 let result_title = format!(
                     " Temperatures ─{}─ Esc to go back ",
                     "─".repeat(repeat_num as usize)


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Minor refactor change; use `saturating_sub` to deal with unsigned subtraction rather than casting to an i64 and using a `max` check with 0.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Refactoring (some change that doesn't change functionality; if relevant state what was changed)_

## Test methodology

_If required, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, see if the following have been met:_

- [ ] _Change has been tested to work_
- [ ] _Areas your change affects have been linted using rustfmt_
- [ ] _Code has been self-reviewed_
- [ ] _Code has been tested and no new breakage is introduced unless intended_
- [ ] _Passes CI tests_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
