### PR TITLE
Autohide time on small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- [#114](https://github.com/ClementTsang/bottom/pull/114): Process state per process (originally in 0.4.0, moved to later).
+- ~~[#114](https://github.com/ClementTsang/bottom/pull/114): Process state per process (originally in 0.4.0, moved to later).~~
+
+- Moving down the CPU list will show only the corresponding graph.
+
+### Changes
+
+- Automatically hide time axis labels if the window gets too small.
+
+### Bug Fixes
+
+- The `<Space>` character can be used as an "AND" again (properly) in queries. For example:
+
+```bash
+(btm cpu > 0) (discord mem > 0)
+```
+
+is equivalent to:
+
+```bash
+(btm AND cpu > 0) AND (discord AND mem > 0)
+```
 
 ## [0.4.1] - 2020-05-05
 

--- a/README.md
+++ b/README.md
@@ -555,3 +555,5 @@ Thanks to all contributors ([emoji key](https://allcontributors.org/docs/en/emoj
 - This application was written with many, _many_ libraries, and built on the
   work of many talented people. This application would be impossible
   without their work.
+
+- And of course, thanks to all contributors!

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -123,6 +123,8 @@ impl CpuGraphWidget for Painter {
                     cpu_widget_state.autohide_timer = None;
                     Axis::default().bounds([-(cpu_widget_state.current_display_time as f64), 0.0])
                 }
+            } else if draw_loc.height < 7 {
+                Axis::default().bounds([-(cpu_widget_state.current_display_time as f64), 0.0])
             } else {
                 Axis::default()
                     .bounds([-(cpu_widget_state.current_display_time as f64), 0.0])

--- a/src/canvas/widgets/mem_graph.rs
+++ b/src/canvas/widgets/mem_graph.rs
@@ -44,6 +44,8 @@ impl MemGraphWidget for Painter {
                     mem_widget_state.autohide_timer = None;
                     Axis::default().bounds([-(mem_widget_state.current_display_time as f64), 0.0])
                 }
+            } else if draw_loc.height < 7 {
+                Axis::default().bounds([-(mem_widget_state.current_display_time as f64), 0.0])
             } else {
                 Axis::default()
                     .bounds([-(mem_widget_state.current_display_time as f64), 0.0])

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -94,6 +94,8 @@ impl NetworkGraphWidget for Painter {
                     Axis::default()
                         .bounds([-(network_widget_state.current_display_time as f64), 0.0])
                 }
+            } else if draw_loc.height < 7 {
+                Axis::default().bounds([-(network_widget_state.current_display_time as f64), 0.0])
             } else {
                 Axis::default()
                     .bounds([-(network_widget_state.current_display_time as f64), 0.0])


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Automatically hides the time labels on the X axis if the graph draw height is too small.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Other (something else - please specify if relevant)_

## Test methodology

_If required, please state how this was tested:_

Run through on a variety of small and large console sizes.  Kitty was used.

![image](https://user-images.githubusercontent.com/34804052/81482470-42b6f600-9205-11ea-9e9e-0df29f63e77c.png)
![image](https://user-images.githubusercontent.com/34804052/81482472-45b1e680-9205-11ea-9db0-c16924a63be0.png)


_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, see if the following have been met:_

- [x] _Change has been tested to work_
- [x] _Areas your change affects have been linted using rustfmt_
- [x] _Code has been self-reviewed_
- [x] _Code has been tested and no new breakage is introduced unless intended_
- [ ] _Passes CI tests_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
