### PR TITLE
change: hide table gap if widget height is small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- ~~[#114](https://github.com/ClementTsang/bottom/pull/114): Process state per process (originally in 0.4.0, moved to later).~~
+- TODO: ~~[#114](https://github.com/ClementTsang/bottom/pull/114): Process state per process (originally in 0.4.0, moved to later).~~
 
-- Moving down the CPU list will show only the corresponding graph.
+- TODO: ~~Moving down the CPU list will show only the corresponding graph.~~
 
 ### Changes
 
-- Automatically hide time axis labels if the window gets too small.
+- Automatically hide time axis labels if the widget gets too small.
+
+- Automatically hide table gap if the widget gets too small.
 
 ### Bug Fixes
 

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -123,7 +123,7 @@ impl CpuGraphWidget for Painter {
                     cpu_widget_state.autohide_timer = None;
                     Axis::default().bounds([-(cpu_widget_state.current_display_time as f64), 0.0])
                 }
-            } else if draw_loc.height < 7 {
+            } else if draw_loc.height < TIME_LABEL_HEIGHT_LIMIT {
                 Axis::default().bounds([-(cpu_widget_state.current_display_time as f64), 0.0])
             } else {
                 Axis::default()

--- a/src/canvas/widgets/disk_table.rs
+++ b/src/canvas/widgets/disk_table.rs
@@ -51,9 +51,13 @@ impl DiskTableWidget for Painter {
             disk_table_state.select(Some(
                 (disk_widget_state.scroll_state.current_scroll_position - start_position) as usize,
             ));
-
             let sliced_vec = &mut disk_data[start_position as usize..];
             let disk_rows = sliced_vec.iter().map(|disk| Row::Data(disk.iter()));
+            let table_gap = if draw_loc.height < TABLE_GAP_HEIGHT_LIMIT {
+                0
+            } else {
+                app_state.app_config_fields.table_gap
+            };
 
             // Calculate widths
             // TODO: [PRETTY] Ellipsis on strings?
@@ -123,7 +127,7 @@ impl DiskTableWidget for Painter {
                             .map(|calculated_width| Constraint::Length(*calculated_width as u16))
                             .collect::<Vec<_>>()),
                     )
-                    .header_gap(app_state.app_config_fields.table_gap),
+                    .header_gap(table_gap),
                 margined_draw_loc[0],
                 disk_table_state,
             );

--- a/src/canvas/widgets/mem_graph.rs
+++ b/src/canvas/widgets/mem_graph.rs
@@ -44,7 +44,7 @@ impl MemGraphWidget for Painter {
                     mem_widget_state.autohide_timer = None;
                     Axis::default().bounds([-(mem_widget_state.current_display_time as f64), 0.0])
                 }
-            } else if draw_loc.height < 7 {
+            } else if draw_loc.height < TIME_LABEL_HEIGHT_LIMIT {
                 Axis::default().bounds([-(mem_widget_state.current_display_time as f64), 0.0])
             } else {
                 Axis::default()

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -94,7 +94,7 @@ impl NetworkGraphWidget for Painter {
                     Axis::default()
                         .bounds([-(network_widget_state.current_display_time as f64), 0.0])
                 }
-            } else if draw_loc.height < 7 {
+            } else if draw_loc.height < TIME_LABEL_HEIGHT_LIMIT {
                 Axis::default().bounds([-(network_widget_state.current_display_time as f64), 0.0])
             } else {
                 Axis::default()

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -104,6 +104,11 @@ impl ProcessTableWidget for Painter {
                     (proc_widget_state.scroll_state.current_scroll_position - start_position)
                         as usize,
                 ));
+                let table_gap = if draw_loc.height < TABLE_GAP_HEIGHT_LIMIT {
+                    0
+                } else {
+                    app_state.app_config_fields.table_gap
+                };
 
                 // Draw!
                 let is_proc_widget_grouped = proc_widget_state.is_grouped;
@@ -253,7 +258,7 @@ impl ProcessTableWidget for Painter {
                                 })
                                 .collect::<Vec<_>>()),
                         )
-                        .header_gap(app_state.app_config_fields.table_gap),
+                        .header_gap(table_gap),
                     margined_draw_loc[0],
                     proc_table_state,
                 );

--- a/src/canvas/widgets/temp_table.rs
+++ b/src/canvas/widgets/temp_table.rs
@@ -52,9 +52,13 @@ impl TempTableWidget for Painter {
             temp_table_state.select(Some(
                 (temp_widget_state.scroll_state.current_scroll_position - start_position) as usize,
             ));
-
             let sliced_vec = &temp_sensor_data[start_position as usize..];
             let temperature_rows = sliced_vec.iter().map(|temp_row| Row::Data(temp_row.iter()));
+            let table_gap = if draw_loc.height < TABLE_GAP_HEIGHT_LIMIT {
+                0
+            } else {
+                app_state.app_config_fields.table_gap
+            };
 
             // Calculate widths
             let width = f64::from(draw_loc.width);
@@ -123,7 +127,7 @@ impl TempTableWidget for Painter {
                             .map(|calculated_width| Constraint::Length(*calculated_width as u16))
                             .collect::<Vec<_>>()),
                     )
-                    .header_gap(app_state.app_config_fields.table_gap),
+                    .header_gap(table_gap),
                 margined_draw_loc[0],
                 temp_table_state,
             );

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -23,6 +23,10 @@ pub const NUM_COLOURS: i32 = 256;
 // The minimum threshold when resizing tables
 pub const FORCE_MIN_THRESHOLD: usize = 5;
 
+// Limits for when we should stop showing table gaps/labels (anything less means not shown)
+pub const TABLE_GAP_HEIGHT_LIMIT: u16 = 7;
+pub const TIME_LABEL_HEIGHT_LIMIT: u16 = 7;
+
 // Side borders
 lazy_static! {
     pub static ref SIDE_BORDERS: tui::widgets::Borders =


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Hide the table gap (if there is one) if the widget height is too small.

A bit of a followup to #149.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Other (something else - please specify if relevant)_

## Test methodology

_If required, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, see if the following have been met:_

- [x] _Change has been tested to work_
- [x] _Areas your change affects have been linted using rustfmt_
- [x] _Code has been self-reviewed_
- [x] _Code has been tested and no new breakage is introduced unless intended_
- [ ] _Passes CI tests_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
