### PR TITLE
refactor: reduce unchecked type conversions to usize

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -713,12 +713,12 @@ impl App {
                 .get(&self.current_widget.widget_id)
             {
                 if proc_widget_state.scroll_state.current_scroll_position
-                    < corresponding_filtered_process_list.len() as u64
+                    < corresponding_filtered_process_list.len()
                 {
                     let current_process: (String, Vec<u32>);
                     if self.is_grouped(self.current_widget.widget_id) {
                         if let Some(process) = &corresponding_filtered_process_list
-                            .get(proc_widget_state.scroll_state.current_scroll_position as usize)
+                            .get(proc_widget_state.scroll_state.current_scroll_position)
                         {
                             current_process = (process.name.to_string(), process.group_pids.clone())
                         } else {
@@ -726,7 +726,7 @@ impl App {
                         }
                     } else {
                         let process = corresponding_filtered_process_list
-                            [proc_widget_state.scroll_state.current_scroll_position as usize]
+                            [proc_widget_state.scroll_state.current_scroll_position]
                             .clone();
                         current_process = (process.name.clone(), vec![process.pid])
                     };
@@ -1455,7 +1455,7 @@ impl App {
                         {
                             if !self.canvas_data.finalized_process_data_map.is_empty() {
                                 proc_widget_state.scroll_state.current_scroll_position =
-                                    finalized_process_data.len() as u64 - 1;
+                                    finalized_process_data.len() - 1;
                                 proc_widget_state.scroll_state.scroll_direction =
                                     ScrollDirection::DOWN;
                             }
@@ -1470,7 +1470,7 @@ impl App {
                     {
                         if !self.canvas_data.temp_sensor_data.is_empty() {
                             temp_widget_state.scroll_state.current_scroll_position =
-                                self.canvas_data.temp_sensor_data.len() as u64 - 1;
+                                self.canvas_data.temp_sensor_data.len() - 1;
                             temp_widget_state.scroll_state.scroll_direction = ScrollDirection::DOWN;
                         }
                     }
@@ -1483,7 +1483,7 @@ impl App {
                     {
                         if !self.canvas_data.disk_data.is_empty() {
                             disk_widget_state.scroll_state.current_scroll_position =
-                                self.canvas_data.disk_data.len() as u64 - 1;
+                                self.canvas_data.disk_data.len() - 1;
                             disk_widget_state.scroll_state.scroll_direction = ScrollDirection::DOWN;
                         }
                     }
@@ -1494,7 +1494,7 @@ impl App {
                         .widget_states
                         .get_mut(&(self.current_widget.widget_id - 1))
                     {
-                        let cap = self.canvas_data.cpu_data.len() as u64;
+                        let cap = self.canvas_data.cpu_data.len();
                         if cap > 0 {
                             cpu_widget_state.scroll_state.current_scroll_position = cap - 1;
                             cpu_widget_state.scroll_state.scroll_direction = ScrollDirection::DOWN;
@@ -1550,7 +1550,7 @@ impl App {
                 && current_posn as i64 + num_to_change_by < cap as i64
             {
                 cpu_widget_state.scroll_state.current_scroll_position =
-                    (current_posn as i64 + num_to_change_by) as u64;
+                    (current_posn as i64 + num_to_change_by) as usize;
             }
 
             if num_to_change_by < 0 {
@@ -1578,7 +1578,7 @@ impl App {
                     && current_posn as i64 + num_to_change_by < finalized_process_data.len() as i64
                 {
                     proc_widget_state.scroll_state.current_scroll_position =
-                        (current_posn as i64 + num_to_change_by) as u64;
+                        (current_posn as i64 + num_to_change_by) as usize;
                 }
             }
 
@@ -1603,7 +1603,7 @@ impl App {
                     < self.canvas_data.temp_sensor_data.len() as i64
             {
                 temp_widget_state.scroll_state.current_scroll_position =
-                    (current_posn as i64 + num_to_change_by) as u64;
+                    (current_posn as i64 + num_to_change_by) as usize;
             }
 
             if num_to_change_by < 0 {
@@ -1626,7 +1626,7 @@ impl App {
                 && current_posn as i64 + num_to_change_by < self.canvas_data.disk_data.len() as i64
             {
                 disk_widget_state.scroll_state.current_scroll_position =
-                    (current_posn as i64 + num_to_change_by) as u64;
+                    (current_posn as i64 + num_to_change_by) as usize;
             }
 
             if num_to_change_by < 0 {

--- a/src/app/states.rs
+++ b/src/app/states.rs
@@ -33,8 +33,8 @@ pub enum CursorDirection {
 /// AppScrollWidgetState deals with fields for a scrollable app's current state.
 #[derive(Default)]
 pub struct AppScrollWidgetState {
-    pub current_scroll_position: u64,
-    pub previous_scroll_position: u64,
+    pub current_scroll_position: usize,
+    pub previous_scroll_position: usize,
     pub scroll_direction: ScrollDirection,
     pub table_state: TableState,
 }

--- a/src/canvas/canvas_colours.rs
+++ b/src/canvas/canvas_colours.rs
@@ -130,7 +130,7 @@ impl CanvasColours {
     }
 
     pub fn set_cpu_colours(&mut self, colours: &[String]) -> error::Result<()> {
-        let max_amount = std::cmp::min(colours.len(), NUM_COLOURS as usize);
+        let max_amount = std::cmp::min(colours.len(), NUM_COLOURS);
         for (itx, colour) in colours.iter().enumerate() {
             if itx >= max_amount {
                 break;
@@ -141,7 +141,7 @@ impl CanvasColours {
     }
 
     pub fn generate_remaining_cpu_colours(&mut self) {
-        let remaining_num_colours = NUM_COLOURS - self.cpu_colour_styles.len() as i32;
+        let remaining_num_colours = NUM_COLOURS.saturating_sub(self.cpu_colour_styles.len());
         self.cpu_colour_styles
             .extend(gen_n_styles(remaining_num_colours));
     }

--- a/src/canvas/canvas_colours/colour_utils.rs
+++ b/src/canvas/canvas_colours/colour_utils.rs
@@ -42,7 +42,7 @@ lazy_static! {
 
 /// Generates random colours.  Strategy found from
 /// https://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/
-pub fn gen_n_styles(num_to_gen: i32) -> Vec<Style> {
+pub fn gen_n_styles(num_to_gen: usize) -> Vec<Style> {
     fn gen_hsv(h: f32) -> f32 {
         let new_val = h + GOLDEN_RATIO;
         if new_val > 1.0 {

--- a/src/canvas/drawing_utils.rs
+++ b/src/canvas/drawing_utils.rs
@@ -117,9 +117,9 @@ pub fn get_search_start_position(
 }
 
 pub fn get_start_position(
-    num_rows: u64, scroll_direction: &app::ScrollDirection, scroll_position_bar: &mut u64,
-    currently_selected_position: u64, is_force_redraw: bool,
-) -> u64 {
+    num_rows: usize, scroll_direction: &app::ScrollDirection, scroll_position_bar: &mut usize,
+    currently_selected_position: usize, is_force_redraw: bool,
+) -> usize {
     if is_force_redraw {
         *scroll_position_bar = 0;
     }

--- a/src/canvas/widgets/basic_table_arrows.rs
+++ b/src/canvas/widgets/basic_table_arrows.rs
@@ -54,9 +54,8 @@ impl BasicTableArrows for Painter {
         let left_name = left_table.get_pretty_name();
         let right_name = right_table.get_pretty_name();
 
-        let num_spaces = usize::from(draw_loc.width)
-            .saturating_sub(6 + left_name.len() + right_name.len())
-            as usize;
+        let num_spaces =
+            usize::from(draw_loc.width).saturating_sub(6 + left_name.len() + right_name.len());
 
         let arrow_text = vec![
             Text::Styled(format!("\n◄ {}", left_name).into(), self.colours.text_style),

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -69,7 +69,8 @@ impl BatteryDisplayWidget for Painter {
                 .get(battery_widget_state.currently_selected_battery_index)
             {
                 // Assuming a 50/50 split in width
-                let bar_length = (draw_loc.width.saturating_sub(2) / 2).saturating_sub(8) as usize;
+                let bar_length =
+                    usize::from((draw_loc.width.saturating_sub(2) / 2).saturating_sub(8));
                 let charge_percentage = battery_details.charge_percentage;
                 let num_bars = calculate_basic_use_bars(charge_percentage, bar_length);
                 let bars = format!(

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -47,7 +47,7 @@ impl CpuBasicWidget for Painter {
 
         let num_cpus = cpu_data.len();
         if draw_loc.height > 0 {
-            let remaining_height = draw_loc.height as usize;
+            let remaining_height = usize::from(draw_loc.height);
             const REQUIRED_COLUMNS: usize = 4;
 
             let chunk_vec =
@@ -60,8 +60,7 @@ impl CpuBasicWidget for Painter {
             // +9 due to 3 + 4 + 2 columns for the name & space + percentage + bar bounds
             const MARGIN_SPACE: usize = 2;
             let remaining_width = usize::from(draw_loc.width)
-                .saturating_sub((9 + MARGIN_SPACE) * REQUIRED_COLUMNS - MARGIN_SPACE)
-                as usize;
+                .saturating_sub((9 + MARGIN_SPACE) * REQUIRED_COLUMNS - MARGIN_SPACE);
 
             let bar_length = remaining_width / REQUIRED_COLUMNS;
 
@@ -112,7 +111,7 @@ impl CpuBasicWidget for Painter {
                             Text::Styled(
                                 (&cpu_bars[cpu_index]).into(),
                                 self.colours.cpu_colour_styles
-                                    [cpu_index as usize % self.colours.cpu_colour_styles.len()],
+                                    [cpu_index % self.colours.cpu_colour_styles.len()],
                             )
                         })
                         .collect::<Vec<_>>();

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -185,7 +185,6 @@ impl CpuGraphWidget for Painter {
                             self.colours.cpu_colour_styles[cpu_widget_state
                                 .scroll_state
                                 .current_scroll_position
-                                as usize
                                 % self.colours.cpu_colour_styles.len()]
                         })
                         .data(&cpu.cpu_data[..])
@@ -235,7 +234,7 @@ impl CpuGraphWidget for Painter {
             let cpu_data: &mut [ConvertedCpuData] = &mut app_state.canvas_data.cpu_data;
 
             let start_position = get_start_position(
-                draw_loc.height.saturating_sub(self.table_height_offset) as u64,
+                usize::from(draw_loc.height.saturating_sub(self.table_height_offset)),
                 &cpu_widget_state.scroll_state.scroll_direction,
                 &mut cpu_widget_state.scroll_state.previous_scroll_position,
                 cpu_widget_state.scroll_state.current_scroll_position,
@@ -243,10 +242,10 @@ impl CpuGraphWidget for Painter {
             );
             let is_on_widget = widget_id == app_state.current_widget.widget_id;
 
-            let sliced_cpu_data = &cpu_data[start_position as usize..];
+            let sliced_cpu_data = &cpu_data[start_position..];
 
             let mut offset_scroll_index =
-                (cpu_widget_state.scroll_state.current_scroll_position - start_position) as usize;
+                cpu_widget_state.scroll_state.current_scroll_position - start_position;
             let show_avg_cpu = app_state.app_config_fields.show_average_cpu;
 
             let cpu_rows = sliced_cpu_data.iter().enumerate().filter_map(|(itx, cpu)| {
@@ -269,12 +268,12 @@ impl CpuGraphWidget for Painter {
                             if itx == AVG_POSITION {
                                 self.colours.avg_colour_style
                             } else {
-                                self.colours.cpu_colour_styles[itx + start_position as usize
+                                self.colours.cpu_colour_styles[itx + start_position
                                     - AVG_POSITION
                                     - 1 % self.colours.cpu_colour_styles.len()]
                             }
                         } else {
-                            self.colours.cpu_colour_styles[itx + start_position as usize
+                            self.colours.cpu_colour_styles[itx + start_position
                                 - ALL_POSITION
                                 - 1 % self.colours.cpu_colour_styles.len()]
                         },

--- a/src/canvas/widgets/disk_table.rs
+++ b/src/canvas/widgets/disk_table.rs
@@ -40,7 +40,7 @@ impl DiskTableWidget for Painter {
         if let Some(disk_widget_state) = app_state.disk_state.widget_states.get_mut(&widget_id) {
             let disk_data: &mut [Vec<String>] = &mut app_state.canvas_data.disk_data;
             let start_position = get_start_position(
-                draw_loc.height.saturating_sub(self.table_height_offset) as u64,
+                usize::from(draw_loc.height.saturating_sub(self.table_height_offset)),
                 &disk_widget_state.scroll_state.scroll_direction,
                 &mut disk_widget_state.scroll_state.previous_scroll_position,
                 disk_widget_state.scroll_state.current_scroll_position,
@@ -49,9 +49,9 @@ impl DiskTableWidget for Painter {
             let is_on_widget = app_state.current_widget.widget_id == widget_id;
             let disk_table_state = &mut disk_widget_state.scroll_state.table_state;
             disk_table_state.select(Some(
-                (disk_widget_state.scroll_state.current_scroll_position - start_position) as usize,
+                disk_widget_state.scroll_state.current_scroll_position - start_position,
             ));
-            let sliced_vec = &mut disk_data[start_position as usize..];
+            let sliced_vec = &mut disk_data[start_position..];
             let disk_rows = sliced_vec.iter().map(|disk| Row::Data(disk.iter()));
             let table_gap = if draw_loc.height < TABLE_GAP_HEIGHT_LIMIT {
                 0

--- a/src/canvas/widgets/mem_basic.rs
+++ b/src/canvas/widgets/mem_basic.rs
@@ -39,7 +39,7 @@ impl MemBasicWidget for Painter {
         }
 
         // +9 due to 3 + 4 + 2 + 2 columns for the name & space + percentage + bar bounds + margin spacing
-        let bar_length = draw_loc.width.saturating_sub(11) as usize;
+        let bar_length = usize::from(draw_loc.width.saturating_sub(11));
         let ram_use_percentage = if let Some(mem) = mem_data.last() {
             mem.1
         } else {

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -84,7 +84,7 @@ impl ProcessTableWidget for Painter {
                 let is_on_widget = widget_id == app_state.current_widget.widget_id;
 
                 let position = get_start_position(
-                    draw_loc.height.saturating_sub(self.table_height_offset) as u64,
+                    usize::from(draw_loc.height.saturating_sub(self.table_height_offset)),
                     &proc_widget_state.scroll_state.scroll_direction,
                     &mut proc_widget_state.scroll_state.previous_scroll_position,
                     proc_widget_state.scroll_state.current_scroll_position,
@@ -92,17 +92,16 @@ impl ProcessTableWidget for Painter {
                 );
 
                 // Sanity check
-                let start_position = if position >= process_data.len() as u64 {
-                    process_data.len().saturating_sub(1) as u64
+                let start_position = if position >= process_data.len() {
+                    process_data.len().saturating_sub(1)
                 } else {
                     position
                 };
 
-                let sliced_vec = &process_data[start_position as usize..];
+                let sliced_vec = &process_data[start_position..];
                 let proc_table_state = &mut proc_widget_state.scroll_state.table_state;
                 proc_table_state.select(Some(
-                    (proc_widget_state.scroll_state.current_scroll_position - start_position)
-                        as usize,
+                    proc_widget_state.scroll_state.current_scroll_position - start_position,
                 ));
                 let table_gap = if draw_loc.height < TABLE_GAP_HEIGHT_LIMIT {
                     0
@@ -321,7 +320,7 @@ impl ProcessTableWidget for Painter {
             app_state.proc_state.widget_states.get_mut(&(widget_id - 1))
         {
             let is_on_widget = widget_id == app_state.current_widget.widget_id;
-            let num_columns = draw_loc.width as usize;
+            let num_columns = usize::from(draw_loc.width);
             let search_title = "> ";
 
             let num_chars_for_text = search_title.len();

--- a/src/canvas/widgets/temp_table.rs
+++ b/src/canvas/widgets/temp_table.rs
@@ -41,7 +41,7 @@ impl TempTableWidget for Painter {
             let temp_sensor_data: &mut [Vec<String>] = &mut app_state.canvas_data.temp_sensor_data;
 
             let start_position = get_start_position(
-                draw_loc.height.saturating_sub(self.table_height_offset) as u64,
+                usize::from(draw_loc.height.saturating_sub(self.table_height_offset)),
                 &temp_widget_state.scroll_state.scroll_direction,
                 &mut temp_widget_state.scroll_state.previous_scroll_position,
                 temp_widget_state.scroll_state.current_scroll_position,
@@ -50,9 +50,9 @@ impl TempTableWidget for Painter {
             let is_on_widget = widget_id == app_state.current_widget.widget_id;
             let temp_table_state = &mut temp_widget_state.scroll_state.table_state;
             temp_table_state.select(Some(
-                (temp_widget_state.scroll_state.current_scroll_position - start_position) as usize,
+                temp_widget_state.scroll_state.current_scroll_position - start_position,
             ));
-            let sliced_vec = &temp_sensor_data[start_position as usize..];
+            let sliced_vec = &temp_sensor_data[start_position..];
             let temperature_rows = sliced_vec.iter().map(|temp_row| Row::Data(temp_row.iter()));
             let table_gap = if draw_loc.height < TABLE_GAP_HEIGHT_LIMIT {
                 0

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -17,7 +17,7 @@ pub const TICK_RATE_IN_MILLISECONDS: u64 = 200;
 pub const DEFAULT_REFRESH_RATE_IN_MILLISECONDS: u64 = 1000;
 pub const MAX_KEY_TIMEOUT_IN_MILLISECONDS: u64 = 1000;
 // Number of colours to generate for the CPU chart/table
-pub const NUM_COLOURS: i32 = 256;
+pub const NUM_COLOURS: usize = 256;
 
 // Canvas stuff
 // The minimum threshold when resizing tables

--- a/src/main.rs
+++ b/src/main.rs
@@ -633,12 +633,10 @@ fn update_final_process_list(app: &mut App, widget_id: u64) {
         let mut resulting_processes = filtered_process_data;
         sort_process_data(&mut resulting_processes, proc_widget_state);
 
-        if proc_widget_state.scroll_state.current_scroll_position
-            >= resulting_processes.len() as u64
-        {
+        if proc_widget_state.scroll_state.current_scroll_position >= resulting_processes.len() {
             proc_widget_state.scroll_state.current_scroll_position =
                 if resulting_processes.len() > 1 {
-                    resulting_processes.len() as u64 - 1
+                    resulting_processes.len() - 1
                 } else {
                     0
                 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -635,11 +635,7 @@ fn update_final_process_list(app: &mut App, widget_id: u64) {
 
         if proc_widget_state.scroll_state.current_scroll_position >= resulting_processes.len() {
             proc_widget_state.scroll_state.current_scroll_position =
-                if resulting_processes.len() > 1 {
-                    resulting_processes.len() - 1
-                } else {
-                    0
-                };
+                resulting_processes.len().saturating_sub(1);
             proc_widget_state.scroll_state.previous_scroll_position = 0;
             proc_widget_state.scroll_state.scroll_direction = app::ScrollDirection::DOWN;
         }


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Minor refactor change, removes a lot of `as usize` conversions and just makes some types natively usize.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Refactoring (some change that doesn't change functionality; if relevant state what was changed)_

## Test methodology

_If required, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

Seems to still work as before.  No regressions AFAIK.

## Checklist

_If relevant, see if the following have been met:_

- [x] _Change has been tested to work_
- [x] _Areas your change affects have been linted using rustfmt_
- [x] _Code has been self-reviewed_
- [x] _Code has been tested and no new breakage is introduced unless intended_
- [ ] _Passes CI tests_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
