### PR TITLE
feature: add back states to unmerged processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- TODO: ~~[#114](https://github.com/ClementTsang/bottom/pull/114): Process state per process (originally in 0.4.0, moved to later).~~
+- [#114](https://github.com/ClementTsang/bottom/pull/114): Show process state per process (originally in 0.4.0, moved to later). This only
+  shows if the processes are not merged together; I couldn't think of a nice way to show it when grouped together, unfortunately.
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ As yet _another_ process/system visualization and management application, bottom
 
 - Display temperatures from sensors
 
-- Display information regarding processes, like CPU, memory, and I/O usage
+- Display information regarding processes, like CPU, memory, I/O usage, and process state
 
 - Process management (process killing _is_ all you need, right?)
 

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -146,7 +146,7 @@ impl ProcessTableWidget for Painter {
                 let wps = "W/s".to_string();
                 let total_read = "Read".to_string();
                 let total_write = "Write".to_string();
-                // let process_state = "State".to_string();
+                let process_state = "State".to_string();
 
                 let direction_val = if proc_widget_state.process_sorting_reverse {
                     "▼".to_string()
@@ -161,17 +161,30 @@ impl ProcessTableWidget for Painter {
                     ProcessSorting::NAME => name += &direction_val,
                 };
 
-                let process_headers = [
-                    pid_or_name,
-                    name,
-                    cpu,
-                    mem,
-                    rps,
-                    wps,
-                    total_read,
-                    total_write,
-                    // process_state,
-                ];
+                let process_headers = if proc_widget_state.is_grouped {
+                    vec![
+                        pid_or_name,
+                        name,
+                        cpu,
+                        mem,
+                        rps,
+                        wps,
+                        total_read,
+                        total_write,
+                    ]
+                } else {
+                    vec![
+                        pid_or_name,
+                        name,
+                        cpu,
+                        mem,
+                        rps,
+                        wps,
+                        total_read,
+                        total_write,
+                        process_state,
+                    ]
+                };
                 let process_headers_lens: Vec<usize> = process_headers
                     .iter()
                     .map(|entry| entry.len())
@@ -179,7 +192,11 @@ impl ProcessTableWidget for Painter {
 
                 // Calculate widths
                 let width = f64::from(draw_loc.width);
-                let width_ratios = [0.1, 0.2, 0.1, 0.1, 0.1, 0.1, 0.15, 0.15];
+                let width_ratios = if proc_widget_state.is_grouped {
+                    vec![0.1, 0.2, 0.1, 0.1, 0.1, 0.1, 0.15, 0.15]
+                } else {
+                    vec![0.1, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+                };
                 let variable_intrinsic_results = get_variable_intrinsic_widths(
                     width as u16,
                     &width_ratios,

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -383,7 +383,6 @@ pub fn convert_process_data(
         (*entry).write_per_sec += process.write_bytes_per_sec;
         (*entry).total_read += process.total_read_bytes;
         (*entry).total_write += process.total_write_bytes;
-        (*entry).process_state.push(process.process_state_char);
 
         let converted_rps = get_exact_byte_values(process.read_bytes_per_sec, false);
         let converted_wps = get_exact_byte_values(process.write_bytes_per_sec, false);


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Adds process state back to the process widget.

![image](https://user-images.githubusercontent.com/34804052/82378080-93db9c80-99f2-11ea-9fe3-7fcd1f2fcb64.png)


## Issue

_If applicable, what issue does this address?_

Closes: #160  

## Type of change

_Remove the irrelevant ones:_

- [x] _New feature (non-breaking change which adds functionality)_

## Test methodology

_If required, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, see if the following have been met:_

- [x] _Change has been tested to work_
- [x] _Areas your change affects have been linted using rustfmt_
- [ ] _Code has been self-reviewed_
- [x] _Code has been tested and no new breakage is introduced unless intended_
- [ ] _Passes CI tests_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
