### PR TITLE
bug: fix or statement in queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where bottom would incorrectly read the wrong values to calculate the read/write columns for processes in Linux.
 
+- Fixed a bug where OR operations in the process query wouldn't work for process names.
+
 ## [0.4.3] - 2020-05-15
 
 ### Other

--- a/src/app/states.rs
+++ b/src/app/states.rs
@@ -205,7 +205,7 @@ impl ProcWidgetState {
             self.process_search_state.search_state.error_message = None;
         } else {
             let parsed_query = self.parse_query();
-            debug!("Parsed query: {:?}", parsed_query);
+            // debug!("Parsed query: {:#?}", parsed_query);
 
             if let Ok(parsed_query) = parsed_query {
                 self.process_search_state.search_state.query = Some(parsed_query);

--- a/src/app/states.rs
+++ b/src/app/states.rs
@@ -205,7 +205,7 @@ impl ProcWidgetState {
             self.process_search_state.search_state.error_message = None;
         } else {
             let parsed_query = self.parse_query();
-            // debug!("PQ: {:#?}", parsed_query);
+            debug!("Parsed query: {:?}", parsed_query);
 
             if let Ok(parsed_query) = parsed_query {
                 self.process_search_state.search_state.query = Some(parsed_query);


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes `or` being read as a prefix rather than a keyword.

Furthermore, updated how we process various query parts to make it work a bit better.  Key points are:

- AND using spaces is way less... weird.  Especially within a bracket.
- Updated some error messages to be more descriptive.
- Better catch some errors - some of them would just fall through to the most general error message.
- Made things like `()` an error.

## Issue

_If applicable, what issue does this address?_

Closes: #165 

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If required, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

Tested queries:

`discord`
![image](https://user-images.githubusercontent.com/34804052/82622546-1eb3c700-9bac-11ea-8eb0-a312b9c395bd.png)

`(discord)`
![image](https://user-images.githubusercontent.com/34804052/82622563-25dad500-9bac-11ea-87b1-fdd6c8ca6177.png)

`(discord) cpu > 0`
![image](https://user-images.githubusercontent.com/34804052/82622576-2e331000-9bac-11ea-9787-3a93f8f4ea69.png)

`(discord cpu > 0 mem > 0)`
![image](https://user-images.githubusercontent.com/34804052/82622536-19567c80-9bac-11ea-8bcc-20bd11660128.png)

`(discord) cpu < 1 mem > 0`
![image](https://user-images.githubusercontent.com/34804052/82622604-4145e000-9bac-11ea-9812-f0261d3ba4f5.png)

`(discord or btm) cpu > 0 mem >= 0`
![image](https://user-images.githubusercontent.com/34804052/82622688-689cad00-9bac-11ea-9aea-ba43684a826b.png)

`cpu > 0 mem > 0`
![image](https://user-images.githubusercontent.com/34804052/82622705-718d7e80-9bac-11ea-9540-c292e4a7a826.png)

`cpu > 0 mem > 0 firefox`
![image](https://user-images.githubusercontent.com/34804052/82622719-794d2300-9bac-11ea-9b9f-0d3220f5f65f.png)

`btm and cpu > 0 and mem <= 0`
![image](https://user-images.githubusercontent.com/34804052/82622859-cf21cb00-9bac-11ea-8160-f795c7cf3a06.png)

`(btm and (cpu > 0 and mem <= 0))`
![image](https://user-images.githubusercontent.com/34804052/82622874-d9dc6000-9bac-11ea-8884-88138ab0247e.png)

## Checklist

_If relevant, see if the following have been met:_

- [x] _Change has been tested to work_
- [x] _Areas your change affects have been linted using rustfmt_
- [x] _Code has been self-reviewed_
- [x] _Code has been tested and no new breakage is introduced unless intended_
- [ ] _Passes CI tests_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
