### PR TITLE
Prefer explicit yay installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ cargo install bottom --locked
 ### AUR
 
 ```bash
-yay bottom
+yay -S bottom
 
 # If you instead want a pre-built binary:
-yay bottom-bin
+yay -S bottom-bin
 ```
 
 ### Debian


### PR DESCRIPTION
If you run `yay` without `-S` it'll perform a search instead of a direct match.