### PR TITLE
Fix bug w/ parsing  file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [186](https://github.com/ClementTsang/bottom/pull/186): Fixed a bug caused by hitting `Enter` when a process kill fails, breaking future process kills.
 
+- [](): Fix bug caused by incorrectly reading the `/proc/{pid}/stats` file.
+
 ## [0.4.5] - 2020-07-08
 
 - No changes here, just an uptick for Crates.io using the wrong Cargo.lock.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- [179](https://github.com/ClementTsang/bottom/pull/179): Show full command/process path as an option.
+- [#179](https://github.com/ClementTsang/bottom/pull/179): Show full command/process path as an option.
 
-- [183](https://github.com/ClementTsang/bottom/pull/183): Added sorting capabilities to any column.
+- [#183](https://github.com/ClementTsang/bottom/pull/183): Added sorting capabilities to any column.
 
 ### Changes
 
@@ -27,11 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- [183](https://github.com/ClementTsang/bottom/pull/183): Fixed bug in basic mode where the battery widget was placed incorrectly.
+- [#183](https://github.com/ClementTsang/bottom/pull/183): Fixed bug in basic mode where the battery widget was placed incorrectly.
 
-- [186](https://github.com/ClementTsang/bottom/pull/186): Fixed a bug caused by hitting `Enter` when a process kill fails, breaking future process kills.
+- [#186](https://github.com/ClementTsang/bottom/pull/186): Fixed a bug caused by hitting `Enter` when a process kill fails, breaking future process kills.
 
-- [](): Fix bug caused by incorrectly reading the `/proc/{pid}/stats` file.
+- [#187](https://github.com/ClementTsang/bottom/pull/187): Fix bug caused by incorrectly reading the `/proc/{pid}/stats` file.
 
 ## [0.4.5] - 2020-07-08
 

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -432,6 +432,7 @@ impl ProcessTableWidget for Painter {
                 ),
             ];
 
+            search_text.push(Text::raw("\n"));
             search_text.push(Text::styled(
                 if let Some(err) = &proc_widget_state
                     .process_search_state


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes a bug caused by incorrectly reading the `/proc/{pid}/stats` file.  Due to splitting by whitespace, the string parsing was read incorrectly if the process also contained spaces.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If required, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, see if the following have been met:_

- [x] _Change has been tested to work_
- [x] _Areas your change affects have been linted using rustfmt_
- [x] _Code has been self-reviewed_
- [x] _Code has been tested and no new breakage is introduced unless intended_
- [ ] _Passes CI tests_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
