### PR TITLE
change: Allow e to also close expanded widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   backwards compatibility's sake, for macOS, this will still check `.config` if it exists first,
   but otherwise, it will default to the new location.
 
+- Allow `e` to also escape expanded mode.
+
 ### Bug Fixes
 
 - [#183](https://github.com/ClementTsang/bottom/pull/183): Fixed bug in basic mode where the battery widget was placed incorrectly.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Run using `btm`.
 | `?`                                         | Open help menu                                                               |
 | `gg`, `Home`                                | Jump to the first entry                                                      |
 | `Shift-g`, `End`                            | Jump to the last entry                                                       |
-| `e`                                         | Expand the currently selected widget                                         |
+| `e`                                         | Toggle expanding the currently selected widget                               |
 | `+`                                         | Zoom in on chart (decrease time range)                                       |
 | `-`                                         | Zoom out on chart (increase time range)                                      |
 | `=`                                         | Reset zoom                                                                   |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1151,7 +1151,7 @@ impl App {
             '+' => self.zoom_in(),
             '-' => self.zoom_out(),
             '=' => self.reset_zoom(),
-            'e' => self.expand_widget(),
+            'e' => self.toggle_expand_widget(),
             's' => self.toggle_sort(),
             'I' => self.invert_sort(),
             '%' => self.toggle_percentages(),
@@ -1184,6 +1184,15 @@ impl App {
 
     pub fn get_to_delete_processes(&self) -> Option<(String, Vec<u32>)> {
         self.to_delete_process_list.clone()
+    }
+
+    fn toggle_expand_widget(&mut self) {
+        if self.is_expanded {
+            self.is_expanded = false;
+            self.is_force_redraw = true;
+        } else {
+            self.expand_widget();
+        }
     }
 
     fn expand_widget(&mut self) {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -78,7 +78,7 @@ pub const GENERAL_HELP_TEXT: [&str; 29] = [
     "?                Open help menu\n",
     "gg               Jump to the first entry\n",
     "G                Jump to the last entry\n",
-    "e                Expand the currently selected widget\n",
+    "e                Toggle expanding the currently selected widget\n",
     "+                Zoom in on chart (decrease time range)\n",
     "-                Zoom out on chart (increase time range)\n",
     "=                Reset zoom\n",


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Allow `e` to toggle expansion, rather than only allowing it to open.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _New feature (non-breaking change which adds functionality)_

## Test methodology

_If required, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, see if the following have been met:_

- [ ] _Change has been tested to work_
- [ ] _Areas your change affects have been linted using rustfmt_
- [ ] _Code has been self-reviewed_
- [ ] _Code has been tested and no new breakage is introduced unless intended_
- [ ] _Passes CI tests_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
