### PR TITLE
bug: fix bug where you could move down in basic proc when search was disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- [211](https://github.com/ClementTsang/bottom/pull/211): Fixes a bug where you could move down in the process widget even if the process widget search was closed.
+
 ## [0.4.7] - 2020-08-26
 
 ### Bug Fixes

--- a/src/app/layout_manager.rs
+++ b/src/app/layout_manager.rs
@@ -561,6 +561,7 @@ impl BottomLayout {
                                     .left_neighbour(Some(4))
                                     .right_neighbour(Some(DEFAULT_WIDGET_ID))
                                     .width_ratio(1)
+                                    .parent_reflector(Some((WidgetDirection::Right, 2)))
                                     .build(),
                                 BottomWidget::builder()
                                     .canvas_handle_width(true)
@@ -583,6 +584,7 @@ impl BottomLayout {
                                 .up_neighbour(Some(DEFAULT_WIDGET_ID))
                                 .left_neighbour(Some(4))
                                 .right_neighbour(Some(7))
+                                .parent_reflector(Some((WidgetDirection::Up, 1)))
                                 .build()])
                             .build(),
                     ])
@@ -646,6 +648,7 @@ impl BottomLayout {
                                     .down_neighbour(Some(DEFAULT_WIDGET_ID + 1))
                                     .left_neighbour(Some(4))
                                     .right_neighbour(Some(DEFAULT_WIDGET_ID))
+                                    .parent_reflector(Some((WidgetDirection::Right, 2)))
                                     .build(),
                                 BottomWidget::builder()
                                     .canvas_handle_width(true)
@@ -667,6 +670,7 @@ impl BottomLayout {
                                 .up_neighbour(Some(DEFAULT_WIDGET_ID))
                                 .left_neighbour(Some(4))
                                 .right_neighbour(Some(7))
+                                .parent_reflector(Some((WidgetDirection::Up, 1)))
                                 .build()])
                             .build(),
                     ])


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes a bug where you could move down in a process widget even if search was disabled while in basic mode.

## Issue

_If applicable, what issue does this address?_

Closes: #210

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If required, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, see if the following have been met:_

- [x] _Change has been tested to work_
- [x] _Areas your change affects have been linted using rustfmt_
- [x] _Code has been self-reviewed_
- [x] _Code has been tested and no new breakage is introduced unless intended_
- [x] _Passes CI tests_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
