### PR TITLE
feature: Allow Ctrl-F and / to work in sort

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -333,8 +333,10 @@ impl App {
                             .set_to_sorted_index(&proc_widget_state.process_sorting_type);
                         self.move_widget_selection(&WidgetDirection::Left);
                     } else {
-                        // Otherwise, move right
-                        self.move_widget_selection(&WidgetDirection::Right);
+                        // Otherwise, move right if currently on the sort widget
+                        if let BottomWidgetType::ProcSort = self.current_widget.widget_type {
+                            self.move_widget_selection(&WidgetDirection::Right);
+                        }
                     }
                 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -287,20 +287,25 @@ impl App {
 
     pub fn on_slash(&mut self) {
         if !self.is_in_dialog() {
-            // FIXME: Add ProcSort too, it's annoying
-            if let BottomWidgetType::Proc = self.current_widget.widget_type {
-                // Toggle on
-                if let Some(proc_widget_state) = self
-                    .proc_state
-                    .get_mut_widget_state(self.current_widget.widget_id)
-                {
-                    proc_widget_state
-                        .process_search_state
-                        .search_state
-                        .is_enabled = true;
-                    self.move_widget_selection(&WidgetDirection::Down);
-                    self.is_force_redraw = true;
+            match &self.current_widget.widget_type {
+                BottomWidgetType::Proc | BottomWidgetType::ProcSort => {
+                    // Toggle on
+                    if let Some(proc_widget_state) = self.proc_state.get_mut_widget_state(
+                        self.current_widget.widget_id
+                            - match &self.current_widget.widget_type {
+                                BottomWidgetType::ProcSort => 2,
+                                _ => 0,
+                            },
+                    ) {
+                        proc_widget_state
+                            .process_search_state
+                            .search_state
+                            .is_enabled = true;
+                        self.move_widget_selection(&WidgetDirection::Down);
+                        self.is_force_redraw = true;
+                    }
                 }
+                _ => {}
             }
         }
     }

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -198,6 +198,7 @@ impl BatteryDisplayWidget for Painter {
                 //         .map(|battery| Spans::from(battery.battery_name.clone())))
                 //     .collect::<Vec<_>>(),
                 // )
+                // FIXME: [MOUSE] Support mouse for the tabs?
                 Tabs::default()
                     .titles(
                         app_state


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Allows `Ctrl-F` and `/` to work in the sort widget.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _New feature (non-breaking change which adds functionality)_

## Test methodology

_If required, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, see if the following have been met:_

- [x] _Change has been tested to work_
- [x] _Areas your change affects have been linted using rustfmt_
- [x] _Code has been self-reviewed_
- [x] _Code has been tested and no new breakage is introduced unless intended_
- [ ] _Passes CI tests_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
