### PR TITLE
bug: Use correct labels for sensors in Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#211](https://github.com/ClementTsang/bottom/pull/211): Fixes a bug where you could move down in the process widget even if the process widget search was closed.
 
+- [#215](https://github.com/ClementTsang/bottom/pull/215): Add labels to Linux temperature values.
+
 ## [0.4.7] - 2020-08-26
 
 ### Bug Fixes

--- a/src/app/data_harvester/temperature.rs
+++ b/src/app/data_harvester/temperature.rs
@@ -39,7 +39,11 @@ pub async fn get_temperature_data(
             if let Ok(sensor) = sensor {
                 temperature_vec.push(TempHarvest {
                     component_name: Some(sensor.unit().to_string()),
-                    component_label: Some(sensor.label().unwrap_or("").to_string()),
+                    component_label: if let Some(label) = sensor.label() {
+                        Some(label.to_string())
+                    } else {
+                        None
+                    },
                     temperature: match temp_type {
                         TemperatureType::Celsius => sensor
                             .current()

--- a/src/app/data_harvester/temperature.rs
+++ b/src/app/data_harvester/temperature.rs
@@ -80,6 +80,7 @@ pub async fn get_temperature_data(
     }
 
     // By default, sort temperature, then by alphabetically!
+    // TODO: [TEMPS] Allow users to control this.
 
     // Note we sort in reverse here; we want greater temps to be higher priority.
     temperature_vec.sort_by(|a, b| match a.temperature.partial_cmp(&b.temperature) {

--- a/src/app/data_harvester/temperature.rs
+++ b/src/app/data_harvester/temperature.rs
@@ -6,7 +6,8 @@ use sysinfo::{ComponentExt, System, SystemExt};
 
 #[derive(Default, Debug, Clone)]
 pub struct TempHarvest {
-    pub component_name: String,
+    pub component_name: Option<String>,
+    pub component_label: Option<String>,
     pub temperature: f32,
 }
 
@@ -37,7 +38,8 @@ pub async fn get_temperature_data(
         while let Some(sensor) = sensor_data.next().await {
             if let Ok(sensor) = sensor {
                 temperature_vec.push(TempHarvest {
-                    component_name: sensor.unit().to_string(),
+                    component_name: Some(sensor.unit().to_string()),
+                    component_label: Some(sensor.label().unwrap_or("").to_string()),
                     temperature: match temp_type {
                         TemperatureType::Celsius => sensor
                             .current()
@@ -58,7 +60,8 @@ pub async fn get_temperature_data(
         let sensor_data = sys.get_components();
         for component in sensor_data {
             temperature_vec.push(TempHarvest {
-                component_name: component.get_label().to_string(),
+                component_name: None,
+                component_label: Some(component.get_label().to_string()),
                 temperature: match temp_type {
                     TemperatureType::Celsius => component.get_temperature(),
                     TemperatureType::Kelvin => {

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -93,7 +93,12 @@ pub fn convert_temp_row(app: &App) -> Vec<Vec<String>> {
     } else {
         for sensor in &current_data.temp_harvest {
             sensor_vector.push(vec![
-                sensor.component_name.to_string(),
+                match (&sensor.component_name, &sensor.component_label) {
+                    (Some(name), Some(label)) => format!("{}: {}", name, label),
+                    (None, Some(label)) => label.to_string(),
+                    (Some(name), None) => name.to_string(),
+                    (None, None) => String::default(),
+                },
                 (sensor.temperature.ceil() as u64).to_string()
                     + match temp_type {
                         data_harvester::temperature::TemperatureType::Celsius => "C",


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Update temperature sensors in Linux to use labels + names rather than just names.

Note that this change does cause some of the names to be rather large... for example, the sensor known before as `edge` is now `amdgpu: edge`.  I plan to address this later since I want to rewrite how column widths are done.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If required, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, see if the following have been met:_

- [x] _Change has been tested to work_
- [x] _Areas your change affects have been linted using rustfmt_
- [x] _Code has been self-reviewed_
- [x] _Code has been tested and no new breakage is introduced unless intended_
- [ ] _Passes CI tests_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
