### PR TITLE
bug: fix being able to click widgets when dd-dialog was open

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,7 @@
         "WASD",
         "Wojnarowski",
         "andys",
+        "armhf",
         "armv",
         "atim",
         "choco",

--- a/src/app.rs
+++ b/src/app.rs
@@ -880,6 +880,7 @@ impl App {
 
                     self.to_delete_process_list = Some(current_process);
                     self.delete_dialog_state.is_showing_dd = true;
+                    self.is_determining_widget_boundary = true;
                 }
             }
         }

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -67,6 +67,7 @@ impl NetworkGraphWidget for Painter {
             // Update draw loc in widget map
             // Note that in both cases, we always go to the same widget id so it's fine to do it like
             // this lol.
+            debug!("!@#!@");
             if let Some(network_widget) = app_state.widget_map.get_mut(&widget_id) {
                 network_widget.top_left_corner = Some((draw_loc.x, draw_loc.y));
                 network_widget.bottom_right_corner =


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes a bug where you could click on a widget when dd's dialog was open.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If required, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, see if the following have been met:_

- [x] _Change has been tested to work_
- [x] _Areas your change affects have been linted using rustfmt_
- [x] _Code has been self-reviewed_
- [x] _Code has been tested and no new breakage is introduced unless intended_
- [ ] _Passes CI tests_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information:_
