### PR TITLE
other: Use tmp_dir rather than /tmp/ for debug flag

### DIFF
--- a/src/app/data_harvester/processes.rs
+++ b/src/app/data_harvester/processes.rs
@@ -262,7 +262,7 @@ fn read_proc<S: core::hash::BuildHasher>(
         .ok_or(BottomError::MinorError)?
         .to_string();
     let command = {
-        let cmd = read_path_contents(&pid_stat.proc_cmdline_path)?;
+        let cmd = read_path_contents(&pid_stat.proc_cmdline_path)?; // FIXME: [PROC] Use full proc name all the time
         if cmd.trim().is_empty() {
             format!("[{}]", name)
         } else {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -7,6 +7,7 @@ use bottom::{canvas, constants::*, data_conversion::*, options::*, *};
 
 use std::{
     boxed::Box,
+    ffi::OsStr,
     io::{stdout, Write},
     panic,
     sync::{
@@ -29,11 +30,13 @@ fn main() -> Result<()> {
     let matches = clap::get_matches();
     let is_debug = matches.is_present("debug");
     if is_debug {
-        utils::logging::init_logger(log::LevelFilter::Trace, "/tmp/bottom_debug.log")?;
+        let mut tmp_dir = std::env::temp_dir();
+        tmp_dir.push("bottom_debug.log");
+        utils::logging::init_logger(log::LevelFilter::Trace, tmp_dir.as_os_str())?;
     } else {
         #[cfg(debug_assertions)]
         {
-            utils::logging::init_logger(log::LevelFilter::Debug, "debug.log")?;
+            utils::logging::init_logger(log::LevelFilter::Debug, OsStr::new("debug.log"))?;
         }
     }
 

--- a/src/clap.rs
+++ b/src/clap.rs
@@ -86,7 +86,7 @@ When searching for a process, enables case sensitivity by default.\n\n",
         .help("Enables debug logging.")
         .long_help(
             "\
-Enables debug logging to /tmp/bottom_debug.log.",
+Enables debug logging.  The program will print where it logged to after running.",
         );
     let disable_click = Arg::with_name("disable_click")
         .long("disable_click")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,9 @@ pub fn cleanup_terminal(
     terminal.show_cursor()?;
 
     if is_debug {
-        println!("Your debug file is located at \"/tmp/bottom_debug.log\".",);
+        let mut tmp_dir = std::env::temp_dir();
+        tmp_dir.push("bottom_debug.log");
+        println!("Your debug file is located at {:?}", tmp_dir.as_os_str());
     }
 
     Ok(())

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -1,5 +1,7 @@
+use std::ffi::OsStr;
+
 pub fn init_logger(
-    min_level: log::LevelFilter, debug_file_name: &str,
+    min_level: log::LevelFilter, debug_file_name: &OsStr,
 ) -> Result<(), fern::InitError> {
     fern::Dispatch::new()
         .format(|out, message, record| {


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Uses a less hard-coded method of writing to /tmp/.  Mainly because that doesn't work for Windows.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Other (something else - please specify)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [x] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Change has been tested to work, and does not cause new breakage unless intended_
- [ ] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes Travis tests (clippy check and `cargo test` check)_
- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
