### PR TITLE
bug: use cmdline for Linux proc name if >=15 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#253](https://github.com/ClementTsang/bottom/pull/253): Expanding a widget no longer overrides the widget title colour.
 
+- [#261](https://github.com/ClementTsang/bottom/pull/261): Fixed process names occasionally showing up as truncated, due to only using `/proc/<PID>/stat` as our data source.
+
 ## [0.4.7] - 2020-08-26
 
 ### Bug Fixes

--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -122,8 +122,10 @@ impl Default for DataCollector {
 impl DataCollector {
     pub fn init(&mut self) {
         self.mem_total_kb = self.sys.get_total_memory();
+        trace!("Total memory in KB: {}", self.mem_total_kb);
 
         if self.widgets_to_harvest.use_battery {
+            trace!("First run battery vec creation.");
             if let Ok(battery_manager) = Manager::new() {
                 if let Ok(batteries) = battery_manager.batteries() {
                     let battery_list: Vec<Battery> = batteries.filter_map(Result::ok).collect();

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -42,8 +42,10 @@ fn main() -> Result<()> {
 
     let config_path = read_config(matches.value_of("config_location"))
         .context("Unable to access the given config file location.")?;
+    trace!("Config path: {:?}", config_path);
     let mut config: Config = create_or_get_config(&config_path)
         .context("Unable to properly parse or create the config file.")?;
+    trace!("Current config: {:#?}", config);
 
     // Get widget layout separately
     let (widget_layout, default_widget_id, default_widget_type_option) =
@@ -75,13 +77,17 @@ fn main() -> Result<()> {
     // Cleaning loop
     {
         let cleaning_sender = sender.clone();
+        trace!("Initializing cleaning thread...");
         thread::spawn(move || loop {
             thread::sleep(Duration::from_millis(
                 constants::STALE_MAX_MILLISECONDS + 5000,
             ));
+            trace!("Sending cleaning signal...");
             if cleaning_sender.send(BottomEvent::Clean).is_err() {
+                trace!("Failed to send cleaning signal.  Halting cleaning thread loop.");
                 break;
             }
+            trace!("Cleaning signal sent without errors.");
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,17 +615,23 @@ pub fn create_collection_thread(
     thread::spawn(move || {
         trace!("Spawned collection thread.");
         let mut data_state = data_harvester::DataCollector::default();
+        trace!("Created initial data state.");
         data_state.set_collected_data(used_widget_set);
+        trace!("Set collected data.");
         data_state.set_temperature_type(temp_type);
+        trace!("Set initial temp type.");
         data_state.set_use_current_cpu_total(use_current_cpu_total);
+        trace!("Set current CPU total.");
         data_state.set_show_average_cpu(show_average_cpu);
+        trace!("Set showing average CPU.");
 
         data_state.init();
+        trace!("Data state is now fully initialized.");
         loop {
             trace!("Collecting...");
             let mut update_time = update_rate_in_milliseconds;
             if let Ok(message) = reset_receiver.try_recv() {
-                trace!("Received message: {:?}", message);
+                trace!("Received message in collection thread: {:?}", message);
                 match message {
                     CollectionThreadEvent::Reset => {
                         data_state.data.cleanup();
@@ -650,6 +656,7 @@ pub fn create_collection_thread(
             trace!("Collection thread done updating.  Sending data now...");
             data_state.data = data_harvester::Data::default();
             if sender.send(event).is_err() {
+                trace!("Error sending from collection thread...");
                 break;
             }
             trace!("No problem sending from collection thread!");

--- a/src/options.rs
+++ b/src/options.rs
@@ -20,7 +20,7 @@ pub mod layout_options;
 
 use anyhow::{Context, Result};
 
-#[derive(Clone, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Config {
     pub flags: Option<ConfigFlags>,
     pub colors: Option<ConfigColours>,
@@ -154,7 +154,7 @@ impl WidgetIdEnabled {
     }
 }
 
-#[derive(Clone, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ConfigColours {
     pub table_header_color: Option<String>,
     pub all_cpu_color: Option<String>,
@@ -176,7 +176,7 @@ pub struct ConfigColours {
     pub battery_colors: Option<Vec<String>>,
 }
 
-#[derive(Clone, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct IgnoreList {
     pub is_list_ignored: bool,
     pub list: Vec<String>,


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Change inspired by https://github.com/heim-rs/heim/issues/154.  This was the cause of some process names getting cut off and looking weird for Linux (and Linux only, I'm not directly responsible for the other OSes).

This also adds spaces in between command line flags.  Before, they were usually separated by either spaces (which looked fine) or null terminators (which meant it looked like something was broken).

Before on left, after on right.

![image](https://user-images.githubusercontent.com/34804052/94771640-b78df680-0385-11eb-8c78-71336e8d8e57.png)

![image](https://user-images.githubusercontent.com/34804052/94771730-eefca300-0385-11eb-86ed-cbd4066d3aa7.png)


## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _Passes Travis tests (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
