### PR TITLE
bug: Fix widget highlighting styling for dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#253](https://github.com/ClementTsang/bottom/pull/253): Fix highlighted entries being stuck in another colour when the widget is not selected.
 
-- [#253](https://github.com/ClementTsang/bottom/pull/253): Expanding a widget no longer overrides the widget title colour.
+- [#253](https://github.com/ClementTsang/bottom/pull/253), [#266](https://github.com/ClementTsang/bottom/pull/266): Expanding a widget no longer overrides the widget/dialog title colour.
 
 - [#261](https://github.com/ClementTsang/bottom/pull/261): Fixed process names occasionally showing up as truncated, due to only using `/proc/<PID>/stat` as our data source.
 

--- a/src/canvas/dialogs/dd_dialog.rs
+++ b/src/canvas/dialogs/dd_dialog.rs
@@ -63,26 +63,33 @@ impl KillDialog for Painter {
     ) -> bool {
         if let Some(dd_text) = dd_text {
             let dd_title = if app_state.dd_err.is_some() {
-                Span::styled(
-                    format!(
-                        " Error ─{}─ Esc to close ",
-                        "─".repeat(
-                            usize::from(draw_loc.width)
-                                .saturating_sub(DD_ERROR_BASE.chars().count() + 2)
-                        )
+                Spans::from(vec![
+                    Span::styled(" Error ", self.colours.widget_title_style),
+                    Span::styled(
+                        format!(
+                            "─{}─ Esc to close ",
+                            "─".repeat(
+                                usize::from(draw_loc.width)
+                                    .saturating_sub(DD_ERROR_BASE.chars().count() + 2)
+                            )
+                        ),
+                        self.colours.border_style,
                     ),
-                    self.colours.border_style,
-                )
+                ])
             } else {
-                Span::styled(
-                    format!(
-                        " Confirm Kill Process ─{}─ Esc to close ",
-                        "─".repeat(
-                            usize::from(draw_loc.width).saturating_sub(DD_BASE.chars().count() + 2)
-                        )
+                Spans::from(vec![
+                    Span::styled(" Confirm Kill Process ", self.colours.widget_title_style),
+                    Span::styled(
+                        format!(
+                            "─{}─ Esc to close ",
+                            "─".repeat(
+                                usize::from(draw_loc.width)
+                                    .saturating_sub(DD_BASE.chars().count() + 2)
+                            )
+                        ),
+                        self.colours.border_style,
                     ),
-                    self.colours.border_style,
-                )
+                ])
             };
 
             f.render_widget(

--- a/src/canvas/dialogs/help_dialog.rs
+++ b/src/canvas/dialogs/help_dialog.rs
@@ -6,6 +6,7 @@ use tui::{
     layout::{Alignment, Rect},
     terminal::Frame,
     text::Span,
+    text::Spans,
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 
@@ -22,15 +23,18 @@ impl HelpDialog for Painter {
     fn draw_help_dialog<B: Backend>(
         &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect,
     ) {
-        let help_title = Span::styled(
-            format!(
-                " Help ─{}─ Esc to close ",
-                "─".repeat(
-                    usize::from(draw_loc.width).saturating_sub(HELP_BASE.chars().count() + 2)
-                )
+        let help_title = Spans::from(vec![
+            Span::styled(" Help ", self.colours.widget_title_style),
+            Span::styled(
+                format!(
+                    "─{}─ Esc to close ",
+                    "─".repeat(
+                        usize::from(draw_loc.width).saturating_sub(HELP_BASE.chars().count() + 2)
+                    )
+                ),
+                self.colours.border_style,
             ),
-            self.colours.border_style,
-        );
+        ]);
 
         if app_state.should_get_widget_bounds() {
             // We must also recalculate how many lines are wrapping to properly get scrolling to work on


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes styling for dialog titles.  Cherry picked from commit 06573becfa3c089ac4b2a17c9443f84b6a5af3e8.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Change has been tested to work, and does not cause new breakage unless intended_
- [ ] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes Travis tests (clippy check and `cargo test` check)_
- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
