### PR TITLE
refactor: Remove redundant `as_ref()` calls

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -357,35 +357,29 @@ impl Painter {
                 let border_len = terminal_height.saturating_sub(gen_help_len) / 2;
                 let vertical_dialog_chunk = Layout::default()
                     .direction(Direction::Vertical)
-                    .constraints(
-                        [
-                            Constraint::Length(border_len),
-                            Constraint::Length(gen_help_len),
-                            Constraint::Length(border_len),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(border_len),
+                        Constraint::Length(gen_help_len),
+                        Constraint::Length(border_len),
+                    ])
                     .split(terminal_size);
 
                 let middle_dialog_chunk = Layout::default()
                     .direction(Direction::Horizontal)
-                    .constraints(
-                        if terminal_width < 100 {
-                            // TODO: [REFACTOR] The point we start changing size at currently hard-coded in.
-                            [
-                                Constraint::Percentage(0),
-                                Constraint::Percentage(100),
-                                Constraint::Percentage(0),
-                            ]
-                        } else {
-                            [
-                                Constraint::Percentage(20),
-                                Constraint::Percentage(60),
-                                Constraint::Percentage(20),
-                            ]
-                        }
-                        .as_ref(),
-                    )
+                    .constraints(if terminal_width < 100 {
+                        // TODO: [REFACTOR] The point we start changing size at currently hard-coded in.
+                        [
+                            Constraint::Percentage(0),
+                            Constraint::Percentage(100),
+                            Constraint::Percentage(0),
+                        ]
+                    } else {
+                        [
+                            Constraint::Percentage(20),
+                            Constraint::Percentage(60),
+                            Constraint::Percentage(20),
+                        ]
+                    })
                     .split(vertical_dialog_chunk[1]);
 
                 self.draw_help_dialog(&mut f, app_state, middle_dialog_chunk[1]);
@@ -440,27 +434,21 @@ impl Painter {
                 let vertical_bordering = terminal_height.saturating_sub(text_height) / 2;
                 let vertical_dialog_chunk = Layout::default()
                     .direction(Direction::Vertical)
-                    .constraints(
-                        [
-                            Constraint::Length(vertical_bordering),
-                            Constraint::Length(text_height),
-                            Constraint::Length(vertical_bordering),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(vertical_bordering),
+                        Constraint::Length(text_height),
+                        Constraint::Length(vertical_bordering),
+                    ])
                     .split(terminal_size);
 
                 let horizontal_bordering = terminal_width.saturating_sub(text_width) / 2;
                 let middle_dialog_chunk = Layout::default()
                     .direction(Direction::Horizontal)
-                    .constraints(
-                        [
-                            Constraint::Length(horizontal_bordering),
-                            Constraint::Length(text_width),
-                            Constraint::Length(horizontal_bordering),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(horizontal_bordering),
+                        Constraint::Length(text_width),
+                        Constraint::Length(horizontal_bordering),
+                    ])
                     .split(vertical_dialog_chunk[1]);
 
                 // This is a bit nasty, but it works well... I guess.
@@ -469,7 +457,7 @@ impl Painter {
             } else if app_state.is_expanded {
                 let rect = Layout::default()
                     .margin(0)
-                    .constraints([Constraint::Percentage(100)].as_ref())
+                    .constraints([Constraint::Percentage(100)])
                     .split(terminal_size);
                 match &app_state.current_widget.widget_type {
                     Cpu => self.draw_cpu(
@@ -533,7 +521,7 @@ impl Painter {
             } else if app_state.is_config_open {
                 let rect = Layout::default()
                     .margin(0)
-                    .constraints([Constraint::Percentage(100)].as_ref())
+                    .constraints([Constraint::Percentage(100)])
                     .split(f.size())[0];
 
                 self.draw_config_screen(&mut f, app_state, rect)
@@ -543,28 +531,25 @@ impl Painter {
 
                 let vertical_chunks = Layout::default()
                     .direction(Direction::Vertical)
-                    .constraints(
-                        [
-                            Constraint::Length(
-                                (app_state.canvas_data.cpu_data.len() / 4) as u16
-                                    + (if app_state.canvas_data.cpu_data.len() % 4 == 0 {
-                                        0
-                                    } else {
-                                        1
-                                    }),
-                            ),
-                            Constraint::Length(1),
-                            Constraint::Length(2),
-                            Constraint::Length(2),
-                            Constraint::Min(5),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(
+                            (app_state.canvas_data.cpu_data.len() / 4) as u16
+                                + (if app_state.canvas_data.cpu_data.len() % 4 == 0 {
+                                    0
+                                } else {
+                                    1
+                                }),
+                        ),
+                        Constraint::Length(1),
+                        Constraint::Length(2),
+                        Constraint::Length(2),
+                        Constraint::Min(5),
+                    ])
                     .split(terminal_size);
 
                 let middle_chunks = Layout::default()
                     .direction(Direction::Horizontal)
-                    .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                    .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
                     .split(vertical_chunks[2]);
                 self.draw_basic_cpu(&mut f, app_state, vertical_chunks[0], 1);
                 self.draw_basic_memory(&mut f, app_state, middle_chunks[0], 2);

--- a/src/canvas/dialogs/dd_dialog.rs
+++ b/src/canvas/dialogs/dd_dialog.rs
@@ -110,14 +110,11 @@ impl KillDialog for Painter {
             // Now draw buttons if needed...
             let split_draw_loc = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints(
-                    if app_state.dd_err.is_some() {
-                        vec![Constraint::Percentage(100)]
-                    } else {
-                        vec![Constraint::Min(0), Constraint::Length(3)]
-                    }
-                    .as_ref(),
-                )
+                .constraints(if app_state.dd_err.is_some() {
+                    vec![Constraint::Percentage(100)]
+                } else {
+                    vec![Constraint::Min(0), Constraint::Length(3)]
+                })
                 .split(draw_loc);
 
             // This being true implies that dd_err is none.
@@ -136,14 +133,11 @@ impl KillDialog for Painter {
 
                 let button_layout = Layout::default()
                     .direction(Direction::Horizontal)
-                    .constraints(
-                        [
-                            Constraint::Percentage(35),
-                            Constraint::Percentage(30),
-                            Constraint::Percentage(35),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Percentage(35),
+                        Constraint::Percentage(30),
+                        Constraint::Percentage(35),
+                    ])
                     .split(*button_draw_loc);
 
                 f.render_widget(

--- a/src/canvas/screens/config_screen.rs
+++ b/src/canvas/screens/config_screen.rs
@@ -39,7 +39,6 @@ impl ConfigScreen for Painter {
         //             Constraint::Percentage(34),
         //             Constraint::Percentage(33),
         //         ]
-        //         .as_ref(),
         //     )
         //     .split(draw_loc)
         //     .into_iter()
@@ -47,7 +46,7 @@ impl ConfigScreen for Painter {
         //         // Required to properly margin in *between* the rectangles.
         //         Layout::default()
         //             .horizontal_margin(1)
-        //             .constraints([Constraint::Percentage(100)].as_ref())
+        //             .constraints([Constraint::Percentage(100)])
         //             .split(loc)[0]
         //     })
         //     .collect::<Vec<Rect>>();

--- a/src/canvas/widgets/basic_table_arrows.rs
+++ b/src/canvas/widgets/basic_table_arrows.rs
@@ -116,14 +116,11 @@ impl BasicTableArrows for Painter {
 
             let margined_draw_loc = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints(
-                    [
-                        Constraint::Length(2 + left_name.len() as u16),
-                        Constraint::Length(num_spaces as u16),
-                        Constraint::Length(2 + right_name.len() as u16),
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::Length(2 + left_name.len() as u16),
+                    Constraint::Length(num_spaces as u16),
+                    Constraint::Length(2 + right_name.len() as u16),
+                ])
                 .horizontal_margin(1)
                 .split(draw_loc);
 

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -78,14 +78,11 @@ impl BatteryDisplayWidget for Painter {
                 .collect::<Vec<_>>();
 
             let tab_draw_loc = Layout::default()
-                .constraints(
-                    [
-                        Constraint::Length(1),
-                        Constraint::Length(2),
-                        Constraint::Min(0),
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::Length(1),
+                    Constraint::Length(2),
+                    Constraint::Min(0),
+                ])
                 .direction(Direction::Vertical)
                 .split(draw_loc)[1];
 
@@ -105,7 +102,7 @@ impl BatteryDisplayWidget for Painter {
             );
 
             let margined_draw_loc = Layout::default()
-                .constraints([Constraint::Percentage(100)].as_ref())
+                .constraints([Constraint::Percentage(100)])
                 .horizontal_margin(if is_on_widget || draw_border { 0 } else { 1 })
                 .direction(Direction::Horizontal)
                 .split(draw_loc)[0];
@@ -166,7 +163,7 @@ impl BatteryDisplayWidget for Painter {
                     Table::new([""].iter(), battery_rows)
                         .block(battery_block)
                         .header_style(self.colours.table_header_style)
-                        .widths([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref()),
+                        .widths(&[Constraint::Percentage(50), Constraint::Percentage(50)]),
                     margined_draw_loc,
                 );
             } else {

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -54,7 +54,7 @@ impl CpuBasicWidget for Painter {
             let chunk_vec =
                 vec![Constraint::Percentage((100 / REQUIRED_COLUMNS) as u16); REQUIRED_COLUMNS];
             let chunks = Layout::default()
-                .constraints(chunk_vec.as_ref())
+                .constraints(chunk_vec)
                 .direction(Direction::Horizontal)
                 .split(draw_loc);
 
@@ -121,7 +121,7 @@ impl CpuBasicWidget for Painter {
 
                     let margined_loc = Layout::default()
                         .direction(Direction::Horizontal)
-                        .constraints([Constraint::Percentage(100)].as_ref())
+                        .constraints([Constraint::Percentage(100)])
                         .horizontal_margin(1)
                         .split(*chunk)[0];
 

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -90,7 +90,7 @@ impl CpuGraphWidget for Painter {
             let partitioned_draw_loc = Layout::default()
                 .margin(0)
                 .direction(Direction::Horizontal)
-                .constraints(constraints.as_ref())
+                .constraints(constraints)
                 .split(draw_loc);
 
             self.draw_cpu_graph(f, app_state, partitioned_draw_loc[graph_index], widget_id);

--- a/src/canvas/widgets/disk_table.rs
+++ b/src/canvas/widgets/disk_table.rs
@@ -196,7 +196,7 @@ impl DiskTableWidget for Painter {
             };
 
             let margined_draw_loc = Layout::default()
-                .constraints([Constraint::Percentage(100)].as_ref())
+                .constraints([Constraint::Percentage(100)])
                 .horizontal_margin(if is_on_widget || draw_border { 0 } else { 1 })
                 .direction(Direction::Horizontal)
                 .split(draw_loc)[0];

--- a/src/canvas/widgets/mem_basic.rs
+++ b/src/canvas/widgets/mem_basic.rs
@@ -27,7 +27,7 @@ impl MemBasicWidget for Painter {
         let swap_data: &[(f64, f64)] = &app_state.canvas_data.swap_data;
 
         let margined_loc = Layout::default()
-            .constraints([Constraint::Percentage(100)].as_ref())
+            .constraints([Constraint::Percentage(100)])
             .horizontal_margin(1)
             .split(draw_loc);
 

--- a/src/canvas/widgets/network_basic.rs
+++ b/src/canvas/widgets/network_basic.rs
@@ -4,7 +4,7 @@ use tui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     terminal::Frame,
-    text::{Span, Spans, },
+    text::{Span, Spans},
     widgets::{Block, Paragraph},
 };
 
@@ -20,18 +20,18 @@ impl NetworkBasicWidget for Painter {
     ) {
         let divided_loc = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
             .split(draw_loc);
 
         let net_loc = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(100)].as_ref())
+            .constraints([Constraint::Percentage(100)])
             .horizontal_margin(1)
             .split(divided_loc[0]);
 
         let total_loc = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(100)].as_ref())
+            .constraints([Constraint::Percentage(100)])
             .horizontal_margin(1)
             .split(divided_loc[1]);
 

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -51,13 +51,10 @@ impl NetworkGraphWidget for Painter {
             let network_chunk = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(0)
-                .constraints(
-                    [
-                        Constraint::Length(max(draw_loc.height as i64 - 5, 0) as u16),
-                        Constraint::Length(5),
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::Length(max(draw_loc.height as i64 - 5, 0) as u16),
+                    Constraint::Length(5),
+                ])
                 .split(draw_loc);
 
             self.draw_network_graph(f, app_state, network_chunk[0], widget_id, true);

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -71,7 +71,7 @@ impl ProcessTableWidget for Painter {
             if process_widget_state.is_search_enabled() {
                 let processes_chunk = Layout::default()
                     .direction(Direction::Vertical)
-                    .constraints([Constraint::Min(0), Constraint::Length(search_height)].as_ref())
+                    .constraints([Constraint::Min(0), Constraint::Length(search_height)])
                     .split(draw_loc);
                 proc_draw_loc = processes_chunk[0];
 
@@ -87,7 +87,7 @@ impl ProcessTableWidget for Painter {
             if is_sort_open {
                 let processes_chunk = Layout::default()
                     .direction(Direction::Horizontal)
-                    .constraints([Constraint::Length(header_len + 4), Constraint::Min(0)].as_ref())
+                    .constraints([Constraint::Length(header_len + 4), Constraint::Min(0)])
                     .split(proc_draw_loc);
                 proc_draw_loc = processes_chunk[1];
 
@@ -118,7 +118,7 @@ impl ProcessTableWidget for Painter {
 
             let is_on_widget = widget_id == app_state.current_widget.widget_id;
             let margined_draw_loc = Layout::default()
-                .constraints([Constraint::Percentage(100)].as_ref())
+                .constraints([Constraint::Percentage(100)])
                 .horizontal_margin(if is_on_widget || draw_border { 0 } else { 1 })
                 .direction(Direction::Horizontal)
                 .split(draw_loc)[0];
@@ -647,7 +647,7 @@ impl ProcessTableWidget for Painter {
             };
 
             let margined_draw_loc = Layout::default()
-                .constraints([Constraint::Percentage(100)].as_ref())
+                .constraints([Constraint::Percentage(100)])
                 .horizontal_margin(if is_on_widget || draw_border { 0 } else { 1 })
                 .direction(Direction::Horizontal)
                 .split(draw_loc)[0];
@@ -764,7 +764,7 @@ impl ProcessTableWidget for Painter {
             };
 
             let margined_draw_loc = Layout::default()
-                .constraints([Constraint::Percentage(100)].as_ref())
+                .constraints([Constraint::Percentage(100)])
                 .horizontal_margin(if is_on_widget || draw_border { 0 } else { 1 })
                 .direction(Direction::Horizontal)
                 .split(draw_loc)[0];

--- a/src/canvas/widgets/temp_table.rs
+++ b/src/canvas/widgets/temp_table.rs
@@ -187,7 +187,7 @@ impl TempTableWidget for Painter {
             };
 
             let margined_draw_loc = Layout::default()
-                .constraints([Constraint::Percentage(100)].as_ref())
+                .constraints([Constraint::Percentage(100)])
                 .horizontal_margin(if is_on_widget || draw_border { 0 } else { 1 })
                 .direction(Direction::Horizontal)
                 .split(draw_loc)[0];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 #[macro_use]
 extern crate log;
 
+// TODO: Deny unused imports.
+
 use std::{
     boxed::Box,
     fs,


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Minor refactor to remove redundant `as_ref()` calls.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Refactoring (a change that doesn't change application functionality)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes Travis tests (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
