### PR TITLE
feature: Add simple indicator for when data updating is frozen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#223](https://github.com/ClementTsang/bottom/pull/223): Add tree mode for processes.
 
+- [#269](https://github.com/ClementTsang/bottom/pull/269): Add simple indicator for when data updating is frozen.
+
 ### Changes
 
 - [#213](https://github.com/ClementTsang/bottom/pull/213), [#214](https://github.com/ClementTsang/bottom/pull/214): Updated help descriptions, added auto-complete generation.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1229,7 +1229,6 @@ impl App {
             'k' => self.on_up_key(),
             'j' => self.on_down_key(),
             'f' => {
-                // FIXME: [FROZEN] Add an indicator if frozen!
                 self.is_frozen = !self.is_frozen;
                 if self.is_frozen {
                     self.data_collection.set_frozen_time();

--- a/src/canvas/screens/config_screen.rs
+++ b/src/canvas/screens/config_screen.rs
@@ -29,30 +29,5 @@ impl ConfigScreen for Painter {
             .border_style(self.colours.border_style);
 
         f.render_widget(config_block, draw_loc);
-
-        // let margined_draw_locs = Layout::default()
-        //     .margin(2)
-        //     .direction(Direction::Horizontal)
-        //     .constraints(
-        //         [
-        //             Constraint::Percentage(33),
-        //             Constraint::Percentage(34),
-        //             Constraint::Percentage(33),
-        //         ]
-        //     )
-        //     .split(draw_loc)
-        //     .into_iter()
-        //     .map(|loc| {
-        //         // Required to properly margin in *between* the rectangles.
-        //         Layout::default()
-        //             .horizontal_margin(1)
-        //             .constraints([Constraint::Percentage(100)])
-        //             .split(loc)[0]
-        //     })
-        //     .collect::<Vec<Rect>>();
-
-        // for dl in margined_draw_locs {
-        //     f.render_widget(Block::default().borders(Borders::ALL), dl);
-        // }
     }
 }


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Adds a simple indicator to help users know when they've frozen data updating using `f`.  For example:

![image](https://user-images.githubusercontent.com/34804052/96357419-8291db80-10c9-11eb-86db-687232b140a2.png)

![image](https://user-images.githubusercontent.com/34804052/96357421-87568f80-10c9-11eb-9e41-e5e9d2ccce44.png)

![image](https://user-images.githubusercontent.com/34804052/96357425-8de50700-10c9-11eb-91e9-3010734a1212.png)


## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _New feature (non-breaking change which adds functionality)_

## Test methodology

_If relevant, please state how this was tested:_

- Tested on Linux for basic, expanded, and normal modes, where it *should* show up.
- It should *not* show up for the dd and help dialogs.

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _Passes Travis tests (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
