### PR TITLE
clippy: fix unwrap_or_else usage

### DIFF
--- a/src/canvas/widgets/basic_table_arrows.rs
+++ b/src/canvas/widgets/basic_table_arrows.rs
@@ -51,15 +51,15 @@ impl BasicTableArrows for Painter {
                                                     },
                                                 )
                                             })
-                                            .unwrap_or_else(|| Some(&BottomWidgetType::Temp))
-                                            .unwrap_or_else(|| &BottomWidgetType::Temp)
+                                            .unwrap_or(Some(&BottomWidgetType::Temp))
+                                            .unwrap_or(&BottomWidgetType::Temp)
                                     } else {
                                         &left_widget.widget_type
                                     }
                                 })
-                                .unwrap_or_else(|| &BottomWidgetType::Temp)
+                                .unwrap_or(&BottomWidgetType::Temp)
                         })
-                        .unwrap_or_else(|| &BottomWidgetType::Temp)
+                        .unwrap_or(&BottomWidgetType::Temp)
                 },
                 {
                     current_table
@@ -80,15 +80,15 @@ impl BasicTableArrows for Painter {
                                                         &right_right_widget.widget_type
                                                     })
                                             })
-                                            .unwrap_or_else(|| Some(&BottomWidgetType::Disk))
-                                            .unwrap_or_else(|| &BottomWidgetType::Disk)
+                                            .unwrap_or(Some(&BottomWidgetType::Disk))
+                                            .unwrap_or(&BottomWidgetType::Disk)
                                     } else {
                                         &right_widget.widget_type
                                     }
                                 })
-                                .unwrap_or_else(|| &BottomWidgetType::Disk)
+                                .unwrap_or(&BottomWidgetType::Disk)
                         })
-                        .unwrap_or_else(|| &BottomWidgetType::Disk)
+                        .unwrap_or(&BottomWidgetType::Disk)
                 },
             );
 


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Removes some `unwrap_or_else` calls when `unwrap_or` would suffice that were caught by clippy nightly.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Refactoring (a change that doesn't change application functionality)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Change has been tested to work, and does not cause new breakage unless intended_
- [ ] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes Travis tests (clippy check and `cargo test` check)_
- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
