### PR TITLE
bug: fix incorrect offset for cpu list in cpu basic widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#262](https://github.com/ClementTsang/bottom/pull/262): Fixed missing thread termination steps as well as improper polling causing blocking in input thread.
 
+- [#289](https://github.com/ClementTsang/bottom/pull/289): Fixed the CPU basic widget showing incorrect data due to an incorrect offset when displaying the data.
+
+- [#290](https://github.com/ClementTsang/bottom/pull/290): Fixed an incorrect offset affecting the CPU colour when scrolling.
+
 ## [0.4.7] - 2020-08-26
 
 ### Bug Fixes

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -26,7 +26,7 @@ impl CpuBasicWidget for Painter {
         &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         // Skip the first element, it's the "all" element
-        if app_state.canvas_data.cpu_data.len() > 0 {
+        if !app_state.canvas_data.cpu_data.is_empty() {
             let cpu_data: &[ConvertedCpuData] = &app_state.canvas_data.cpu_data[1..];
 
             // This is a bit complicated, but basically, we want to draw SOME number

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -25,110 +25,114 @@ impl CpuBasicWidget for Painter {
     fn draw_basic_cpu<B: Backend>(
         &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
-        let cpu_data: &[ConvertedCpuData] = &app_state.canvas_data.cpu_data;
+        // Skip the first element, it's the "all" element
+        if app_state.canvas_data.cpu_data.len() > 0 {
+            let cpu_data: &[ConvertedCpuData] = &app_state.canvas_data.cpu_data[1..];
 
-        // This is a bit complicated, but basically, we want to draw SOME number
-        // of columns to draw all CPUs.  Ideally, as well, we want to not have
-        // to ever scroll.
-        // **General logic** - count number of elements in cpu_data.  Then see how
-        // many rows and columns we have in draw_loc (-2 on both sides for border?).
-        // I think what we can do is try to fit in as many in one column as possible.
-        // If not, then add a new column.
-        // Then, from this, split the row space across ALL columns.  From there, generate
-        // the desired lengths.
+            // This is a bit complicated, but basically, we want to draw SOME number
+            // of columns to draw all CPUs.  Ideally, as well, we want to not have
+            // to ever scroll.
+            // **General logic** - count number of elements in cpu_data.  Then see how
+            // many rows and columns we have in draw_loc (-2 on both sides for border?).
+            // I think what we can do is try to fit in as many in one column as possible.
+            // If not, then add a new column.
+            // Then, from this, split the row space across ALL columns.  From there, generate
+            // the desired lengths.
 
-        if app_state.current_widget.widget_id == widget_id {
-            f.render_widget(
-                Block::default()
-                    .borders(*SIDE_BORDERS)
-                    .border_style(self.colours.highlighted_border_style),
-                draw_loc,
-            );
-        }
+            if app_state.current_widget.widget_id == widget_id {
+                f.render_widget(
+                    Block::default()
+                        .borders(*SIDE_BORDERS)
+                        .border_style(self.colours.highlighted_border_style),
+                    draw_loc,
+                );
+            }
 
-        let num_cpus = cpu_data.len();
-        if draw_loc.height > 0 {
-            let remaining_height = usize::from(draw_loc.height);
-            const REQUIRED_COLUMNS: usize = 4;
+            let num_cpus = cpu_data.len();
 
-            let chunk_vec =
-                vec![Constraint::Percentage((100 / REQUIRED_COLUMNS) as u16); REQUIRED_COLUMNS];
-            let chunks = Layout::default()
-                .constraints(chunk_vec)
-                .direction(Direction::Horizontal)
-                .split(draw_loc);
+            if draw_loc.height > 0 {
+                let remaining_height = usize::from(draw_loc.height);
+                const REQUIRED_COLUMNS: usize = 4;
 
-            // +9 due to 3 + 4 + 2 columns for the name & space + percentage + bar bounds
-            const MARGIN_SPACE: usize = 2;
-            let remaining_width = usize::from(draw_loc.width)
-                .saturating_sub((9 + MARGIN_SPACE) * REQUIRED_COLUMNS - MARGIN_SPACE);
+                let chunk_vec =
+                    vec![Constraint::Percentage((100 / REQUIRED_COLUMNS) as u16); REQUIRED_COLUMNS];
+                let chunks = Layout::default()
+                    .constraints(chunk_vec)
+                    .direction(Direction::Horizontal)
+                    .split(draw_loc);
 
-            let bar_length = remaining_width / REQUIRED_COLUMNS;
+                // +9 due to 3 + 4 + 2 columns for the name & space + percentage + bar bounds
+                const MARGIN_SPACE: usize = 2;
+                let remaining_width = usize::from(draw_loc.width)
+                    .saturating_sub((9 + MARGIN_SPACE) * REQUIRED_COLUMNS - MARGIN_SPACE);
 
-            // CPU (and RAM) percent bars are, uh, "heavily" inspired from htop.
-            let cpu_bars = (0..num_cpus)
-                .map(|cpu_index| {
-                    let use_percentage =
-                        if let Some(cpu_usage) = cpu_data[cpu_index].cpu_data.last() {
-                            cpu_usage.1
-                        } else {
-                            0.0
-                        };
+                let bar_length = remaining_width / REQUIRED_COLUMNS;
 
-                    let num_bars = calculate_basic_use_bars(use_percentage, bar_length);
-                    format!(
-                        "{:3}[{}{}{:3.0}%]",
-                        if app_state.app_config_fields.show_average_cpu {
-                            if cpu_index == 0 {
-                                "AVG".to_string()
+                // CPU (and RAM) percent bars are, uh, "heavily" inspired from htop.
+                let cpu_bars = (0..num_cpus)
+                    .map(|cpu_index| {
+                        let use_percentage =
+                            if let Some(cpu_usage) = cpu_data[cpu_index].cpu_data.last() {
+                                cpu_usage.1
                             } else {
-                                (cpu_index - 1).to_string()
-                            }
-                        } else {
-                            cpu_index.to_string()
-                        },
-                        "|".repeat(num_bars),
-                        " ".repeat(bar_length - num_bars),
-                        use_percentage.round(),
-                    )
-                })
-                .collect::<Vec<_>>();
+                                0.0
+                            };
 
-            let mut row_counter = num_cpus;
-            let mut start_index = 0;
-            for (itx, chunk) in chunks.iter().enumerate() {
-                // Explicitly check... don't want an accidental DBZ or underflow
-                if REQUIRED_COLUMNS > itx {
-                    let to_divide = REQUIRED_COLUMNS - itx;
-                    let how_many_cpus = min(
-                        remaining_height,
-                        (row_counter / to_divide)
-                            + (if row_counter % to_divide == 0 { 0 } else { 1 }),
-                    );
-                    row_counter -= how_many_cpus;
-                    let end_index = min(start_index + how_many_cpus, num_cpus);
-                    let cpu_column = (start_index..end_index)
-                        .map(|cpu_index| {
-                            Spans::from(Span {
-                                content: (&cpu_bars[cpu_index]).into(),
-                                style: self.colours.cpu_colour_styles
-                                    [cpu_index % self.colours.cpu_colour_styles.len()],
+                        let num_bars = calculate_basic_use_bars(use_percentage, bar_length);
+                        format!(
+                            "{:3}[{}{}{:3.0}%]",
+                            if app_state.app_config_fields.show_average_cpu {
+                                if cpu_index == 0 {
+                                    "AVG".to_string()
+                                } else {
+                                    (cpu_index - 1).to_string()
+                                }
+                            } else {
+                                cpu_index.to_string()
+                            },
+                            "|".repeat(num_bars),
+                            " ".repeat(bar_length - num_bars),
+                            use_percentage.round(),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+
+                let mut row_counter = num_cpus;
+                let mut start_index = 0;
+                for (itx, chunk) in chunks.iter().enumerate() {
+                    // Explicitly check... don't want an accidental DBZ or underflow
+                    if REQUIRED_COLUMNS > itx {
+                        let to_divide = REQUIRED_COLUMNS - itx;
+                        let how_many_cpus = min(
+                            remaining_height,
+                            (row_counter / to_divide)
+                                + (if row_counter % to_divide == 0 { 0 } else { 1 }),
+                        );
+                        row_counter -= how_many_cpus;
+                        let end_index = min(start_index + how_many_cpus, num_cpus);
+                        let cpu_column = (start_index..end_index)
+                            .map(|cpu_index| {
+                                Spans::from(Span {
+                                    content: (&cpu_bars[cpu_index]).into(),
+                                    style: self.colours.cpu_colour_styles
+                                        [cpu_index % self.colours.cpu_colour_styles.len()],
+                                })
                             })
-                        })
-                        .collect::<Vec<_>>();
+                            .collect::<Vec<_>>();
 
-                    start_index += how_many_cpus;
+                        start_index += how_many_cpus;
 
-                    let margined_loc = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .constraints([Constraint::Percentage(100)])
-                        .horizontal_margin(1)
-                        .split(*chunk)[0];
+                        let margined_loc = Layout::default()
+                            .direction(Direction::Horizontal)
+                            .constraints([Constraint::Percentage(100)])
+                            .horizontal_margin(1)
+                            .split(*chunk)[0];
 
-                    f.render_widget(
-                        Paragraph::new(cpu_column).block(Block::default()),
-                        margined_loc,
-                    );
+                        f.render_widget(
+                            Paragraph::new(cpu_column).block(Block::default()),
+                            margined_loc,
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes the CPU basic widget showing incorrect data due to an incorrect offset when displaying the data.

## Issue

_If applicable, what issue does this address?_

Closes: #288

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes Travis tests (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
