### PR TITLE
bug: fix incorrect CPU colour offset

### DIFF
--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -364,10 +364,10 @@ impl CpuGraphWidget for Painter {
                         cpu_string_row.into_iter(),
                         if itx == offset_scroll_index {
                             self.colours.currently_selected_text_style
-                        } else if itx == ALL_POSITION {
+                        } else if itx + start_position == ALL_POSITION {
                             self.colours.all_colour_style
                         } else if show_avg_cpu {
-                            if itx == AVG_POSITION {
+                            if itx + start_position == AVG_POSITION {
                                 self.colours.avg_colour_style
                             } else {
                                 self.colours.cpu_colour_styles[itx + start_position


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes an incorrect offset affecting the CPU colour when scrolling.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Change has been tested to work, and does not cause new breakage unless intended_
- [ ] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes Travis tests (clippy check and `cargo test` check)_
- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
