### PR TITLE
bug: fix incorrect basic cpu spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#290](https://github.com/ClementTsang/bottom/pull/290): Fixed an incorrect offset affecting the CPU colour when scrolling.
 
+- [#291](https://github.com/ClementTsang/bottom/pull/291): Fixed spacing problems in basic CPU mode.
+
 ## [0.4.7] - 2020-08-26
 
 ### Bug Fixes

--- a/src/app.rs
+++ b/src/app.rs
@@ -1404,7 +1404,7 @@ impl App {
     /// Call this whenever the config value is updated!
     fn update_config_file(&mut self) -> anyhow::Result<()> {
         if self.app_config_fields.no_write {
-            debug!("No write enabled.  Config will not be written.");
+            // debug!("No write enabled.  Config will not be written.");
             // Don't write!
             // FIXME: [CONFIG] This should be made VERY clear to the user... make a thing saying "it will not write due to no_write option"
             Ok(())

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -26,7 +26,7 @@ impl CpuBasicWidget for Painter {
         &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         // Skip the first element, it's the "all" element
-        if !app_state.canvas_data.cpu_data.is_empty() {
+        if app_state.canvas_data.cpu_data.len() > 1 {
             let cpu_data: &[ConvertedCpuData] = &app_state.canvas_data.cpu_data[1..];
 
             // This is a bit complicated, but basically, we want to draw SOME number
@@ -64,7 +64,7 @@ impl CpuBasicWidget for Painter {
                 // +9 due to 3 + 4 + 2 columns for the name & space + percentage + bar bounds
                 const MARGIN_SPACE: usize = 2;
                 let remaining_width = usize::from(draw_loc.width)
-                    .saturating_sub((9 + MARGIN_SPACE) * REQUIRED_COLUMNS - MARGIN_SPACE);
+                    .saturating_sub((9 + MARGIN_SPACE) * REQUIRED_COLUMNS);
 
                 let bar_length = remaining_width / REQUIRED_COLUMNS;
 
@@ -100,7 +100,8 @@ impl CpuBasicWidget for Painter {
                 let mut row_counter = num_cpus;
                 let mut start_index = 0;
                 for (itx, chunk) in chunks.iter().enumerate() {
-                    // Explicitly check... don't want an accidental DBZ or underflow
+                    // Explicitly check... don't want an accidental DBZ or underflow, this ensures
+                    // to_divide is > 0
                     if REQUIRED_COLUMNS > itx {
                         let to_divide = REQUIRED_COLUMNS - itx;
                         let how_many_cpus = min(
@@ -110,6 +111,7 @@ impl CpuBasicWidget for Painter {
                         );
                         row_counter -= how_many_cpus;
                         let end_index = min(start_index + how_many_cpus, num_cpus);
+
                         let cpu_column = (start_index..end_index)
                             .map(|cpu_index| {
                                 Spans::from(Span {


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes a bug with CPU spacing on basic mode.

Before:
![image](https://user-images.githubusercontent.com/34804052/97946474-8d4ea080-1d58-11eb-8926-9923acdcfb87.png)

After:
![image](https://user-images.githubusercontent.com/34804052/97946485-963f7200-1d58-11eb-9705-f8450d4ea23f.png)



## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Change has been tested to work, and does not cause new breakage unless intended_
- [ ] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes Travis tests (clippy check and `cargo test` check)_
- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
