### PR TITLE
feature: add tree flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#220](https://github.com/ClementTsang/bottom/pull/220): Add ability to hide specific temperature and disk entries via config.
 
-- [#223](https://github.com/ClementTsang/bottom/pull/223): Add tree mode for processes.
+- [#223](https://github.com/ClementTsang/bottom/pull/223): Add tree mode for processes. [#312](https://github.com/ClementTsang/bottom/pull/312) also adds a `tree` flag to default to the tree mode.
 
 - [#269](https://github.com/ClementTsang/bottom/pull/269): Add simple indicator for when data updating is frozen.
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Run using `btm`.
 
 ### Flags
 
+Use `btm --help` for more information.
+
 ```
         --autohide_time                        Temporarily shows the time scale in graphs.
     -b, --basic                                Hides graphs and uses a more basic look.
@@ -237,6 +239,7 @@ Run using `btm`.
     -r, --rate <MS>                            Sets a refresh rate in ms.
     -R, --regex                                Enables regex by default.
     -d, --time_delta <MS>                      The amount in ms changed upon zooming.
+    -T, --tree                                 Defaults to showing the process widget in tree mode.
         --use_old_network_legend               DEPRECATED - uses the older network legend.
     -V, --version                              Prints version information.
     -W, --whole_word                           Enables whole-word matching by default.
@@ -549,6 +552,7 @@ These are the following supported flag config values, which correspond to the fl
 | `disable_click`          | Boolean                                                                               |
 | `color`                  | String (one of ["default", "default-light", "gruvbox", "gruvbox-light"])              |
 | `mem_as_value`           | Boolean                                                                               |
+| `tree`                   | Boolean                                                                               |
 
 #### Theming
 

--- a/src/app/states.rs
+++ b/src/app/states.rs
@@ -391,9 +391,10 @@ pub struct ProcWidgetState {
 impl ProcWidgetState {
     pub fn init(
         is_case_sensitive: bool, is_match_whole_word: bool, is_use_regex: bool, is_grouped: bool,
-        show_memory_as_values: bool,
+        show_memory_as_values: bool, is_tree_mode: bool,
     ) -> Self {
         let mut process_search_state = ProcessSearchState::default();
+
         if is_case_sensitive {
             // By default it's off
             process_search_state.search_toggle_ignore_case();
@@ -405,7 +406,11 @@ impl ProcWidgetState {
             process_search_state.search_toggle_regex();
         }
 
-        let process_sorting_type = processes::ProcessSorting::CpuPercent;
+        let (process_sorting_type, is_process_sort_descending) = if is_tree_mode {
+            (processes::ProcessSorting::Pid, false)
+        } else {
+            (processes::ProcessSorting::CpuPercent, true)
+        };
 
         // TODO: If we add customizable columns, this should pull from config
         let mut columns = ProcColumn::default();
@@ -426,12 +431,12 @@ impl ProcWidgetState {
             is_grouped,
             scroll_state: AppScrollWidgetState::default(),
             process_sorting_type,
-            is_process_sort_descending: true,
+            is_process_sort_descending,
             is_using_command: false,
             current_column_index: 0,
             is_sort_open: false,
             columns,
-            is_tree_mode: false,
+            is_tree_mode,
             table_width_state: CanvasTableWidthState::default(),
             requires_redraw: false,
         }

--- a/src/canvas/screens/config_screen.rs
+++ b/src/canvas/screens/config_screen.rs
@@ -23,7 +23,7 @@ impl ConfigScreen for Painter {
         &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect,
     ) {
         let config_block = Block::default()
-            .title(" Config ") // FIXME: [Config] missing title styling
+            .title(Span::styled(" Config ", self.colours.widget_title_style))
             .style(self.colours.border_style)
             .borders(Borders::ALL)
             .border_style(self.colours.border_style);

--- a/src/clap.rs
+++ b/src/clap.rs
@@ -232,7 +232,8 @@ Defaults to \"default\".
         .help("Defaults to showing process memory usage by value.")
         .long_help(
             "\
-Defaults to showing process memory usage by value.  Otherwise, it defaults to showing it by percentage.\n\n",
+Defaults to showing process memory usage by value.  Otherwise,
+it defaults to showing it by percentage.\n\n",
         );
     let default_time_value = Arg::with_name("default_time_value")
         .short("t")
@@ -332,6 +333,15 @@ The amount of time in milliseconds changed when zooming in/out.
 The minimum is 1s (1000), and defaults to 15s (15000).\n\n\n",
         );
 
+    let tree = Arg::with_name("tree")
+        .short("T")
+        .long("tree")
+        .help("Defaults to showing the process widget in tree mode.")
+        .long_help(
+            "\
+Defaults to showing the process widget in tree mode.\n\n",
+        );
+
     App::new(crate_name!())
         .setting(AppSettings::UnifiedHelpMessage)
         .version(crate_version!())
@@ -367,6 +377,7 @@ The minimum is 1s (1000), and defaults to 15s (15000).\n\n\n",
         .arg(rate)
         .arg(regex)
         .arg(time_delta)
+        .arg(tree)
         .arg(current_usage)
         .arg(use_old_network_legend)
         .arg(whole_word)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -416,7 +416,9 @@ pub const OLD_CONFIG_TEXT: &str = r##"# This is a default config file for bottom
 # Built-in themes.  Valid values are "default", "default-light", "gruvbox", "gruvbox-light"
 #color = "default"
 # Show memory values in the processes widget as values by default
-# mem_as_value = false
+#mem_as_value = false
+# Show tree mode by default in the processes widget.
+#tree = false
 
 # These are all the components that support custom theming.  Note that colour support
 # will depend on terminal support.

--- a/src/options.rs
+++ b/src/options.rs
@@ -144,6 +144,9 @@ pub struct ConfigFlags {
 
     #[builder(default, setter(strip_option))]
     pub mem_as_value: Option<bool>,
+
+    #[builder(default, setter(strip_option))]
+    pub tree: Option<bool>,
 }
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
@@ -235,6 +238,7 @@ pub fn build_app(
     let mut used_widget_set = HashSet::new();
 
     let show_memory_as_values = get_mem_as_value(matches, config);
+    let is_default_tree = get_is_default_tree(matches, config);
 
     for row in &widget_layout.rows {
         for col in &row.children {
@@ -302,6 +306,7 @@ pub fn build_app(
                                     is_use_regex,
                                     is_grouped,
                                     show_memory_as_values,
+                                    is_default_tree,
                                 ),
                             );
                         }
@@ -933,6 +938,17 @@ fn get_mem_as_value(matches: &clap::ArgMatches<'static>, config: &Config) -> boo
     } else if let Some(flags) = &config.flags {
         if let Some(mem_as_value) = flags.mem_as_value {
             return mem_as_value;
+        }
+    }
+    false
+}
+
+fn get_is_default_tree(matches: &clap::ArgMatches<'static>, config: &Config) -> bool {
+    if matches.is_present("tree") {
+        return true;
+    } else if let Some(flags) = &config.flags {
+        if let Some(tree) = flags.tree {
+            return tree;
         }
     }
     false


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Adds a `--tree` flag that defaults to tree mode for the process widget.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _New feature (non-breaking change which adds functionality)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes Travis tests (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
