### PR TITLE
bug: Fix inverted battery colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2020-11-26
+
+## Bug Fixes
+
+- [#331](https://github.com/ClementTsang/bottom/pull/331): Fixes custom battery colour levels being inverted.
+
 ## [0.5.2] - 2020-11-25
 
 ## Bug Fixes

--- a/src/canvas/canvas_colours.rs
+++ b/src/canvas/canvas_colours.rs
@@ -23,8 +23,9 @@ pub struct CanvasColours {
     pub text_style: Style,
     pub widget_title_style: Style,
     pub graph_style: Style,
-    // Full, Medium, Low
-    pub battery_bar_styles: Vec<Style>,
+    pub high_battery_colour: Style,
+    pub medium_battery_colour: Style,
+    pub low_battery_colour: Style,
     pub invalid_query_style: Style,
     pub disabled_text_style: Style,
 }
@@ -65,18 +66,9 @@ impl Default for CanvasColours {
             text_style: Style::default().fg(text_colour),
             widget_title_style: Style::default().fg(text_colour),
             graph_style: Style::default().fg(text_colour),
-            battery_bar_styles: vec![
-                Style::default().fg(Color::Red),
-                Style::default().fg(Color::Yellow),
-                Style::default().fg(Color::Yellow),
-                Style::default().fg(Color::Yellow),
-                Style::default().fg(Color::Green),
-                Style::default().fg(Color::Green),
-                Style::default().fg(Color::Green),
-                Style::default().fg(Color::Green),
-                Style::default().fg(Color::Green),
-                Style::default().fg(Color::Green),
-            ],
+            high_battery_colour: Style::default().fg(Color::Green),
+            medium_battery_colour: Style::default().fg(Color::Yellow),
+            low_battery_colour: Style::default().fg(Color::Red),
             invalid_query_style: Style::default().fg(tui::style::Color::Red),
             disabled_text_style: Style::default().fg(Color::DarkGray),
         }
@@ -293,26 +285,17 @@ impl CanvasColours {
     }
 
     pub fn set_high_battery_color(&mut self, colour: &str) -> error::Result<()> {
-        let style = get_style_from_config(colour)?;
-        self.battery_bar_styles[9] = style;
-        self.battery_bar_styles[8] = style;
-        self.battery_bar_styles[7] = style;
-        self.battery_bar_styles[6] = style;
-        self.battery_bar_styles[5] = style;
-        self.battery_bar_styles[4] = style;
+        self.high_battery_colour = get_style_from_config(colour)?;
         Ok(())
     }
 
     pub fn set_medium_battery_color(&mut self, colour: &str) -> error::Result<()> {
-        let style = get_style_from_config(colour)?;
-        self.battery_bar_styles[3] = style;
-        self.battery_bar_styles[2] = style;
-        self.battery_bar_styles[1] = style;
+        self.medium_battery_colour = get_style_from_config(colour)?;
         Ok(())
     }
 
     pub fn set_low_battery_color(&mut self, colour: &str) -> error::Result<()> {
-        self.battery_bar_styles[0] = get_style_from_config(colour)?;
+        self.low_battery_colour = get_style_from_config(colour)?;
         Ok(())
     }
 }

--- a/src/canvas/canvas_colours.rs
+++ b/src/canvas/canvas_colours.rs
@@ -294,25 +294,25 @@ impl CanvasColours {
 
     pub fn set_high_battery_color(&mut self, colour: &str) -> error::Result<()> {
         let style = get_style_from_config(colour)?;
-        self.battery_bar_styles[0] = style;
-        self.battery_bar_styles[1] = style;
-        self.battery_bar_styles[2] = style;
-        self.battery_bar_styles[3] = style;
-        self.battery_bar_styles[4] = style;
+        self.battery_bar_styles[9] = style;
+        self.battery_bar_styles[8] = style;
+        self.battery_bar_styles[7] = style;
+        self.battery_bar_styles[6] = style;
         self.battery_bar_styles[5] = style;
+        self.battery_bar_styles[4] = style;
         Ok(())
     }
 
     pub fn set_medium_battery_color(&mut self, colour: &str) -> error::Result<()> {
         let style = get_style_from_config(colour)?;
-        self.battery_bar_styles[6] = style;
-        self.battery_bar_styles[7] = style;
-        self.battery_bar_styles[8] = style;
+        self.battery_bar_styles[3] = style;
+        self.battery_bar_styles[2] = style;
+        self.battery_bar_styles[1] = style;
         Ok(())
     }
 
     pub fn set_low_battery_color(&mut self, colour: &str) -> error::Result<()> {
-        self.battery_bar_styles[9] = get_style_from_config(colour)?;
+        self.battery_bar_styles[0] = get_style_from_config(colour)?;
         Ok(())
     }
 }

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -138,22 +138,15 @@ impl BatteryDisplayWidget for Painter {
                     ["Health %", &battery_details.health],
                 ];
 
-                let battery_rows = battery_items.iter().enumerate().map(|(itx, item)| {
+                let battery_rows = battery_items.iter().map(|item| {
                     Row::StyledData(
                         item.iter(),
-                        if itx == 0 {
-                            let colour_index = ((charge_percentage
-                                * self.colours.battery_bar_styles.len() as f64)
-                                / 100.0)
-                                .ceil() as usize
-                                - 1;
-                            *self
-                                .colours
-                                .battery_bar_styles
-                                .get(colour_index)
-                                .unwrap_or(&self.colours.text_style)
+                        if charge_percentage < 10.0 {
+                            self.colours.low_battery_colour
+                        } else if charge_percentage < 50.0 {
+                            self.colours.medium_battery_colour
                         } else {
-                            self.colours.text_style
+                            self.colours.high_battery_colour
                         },
                     )
                 });

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -114,7 +114,7 @@ impl BatteryDisplayWidget for Painter {
             {
                 // Assuming a 50/50 split in width
                 let bar_length =
-                    usize::from((draw_loc.width.saturating_sub(2) / 2).saturating_sub(6));
+                    usize::from((draw_loc.width.saturating_sub(2) / 2).saturating_sub(8));
                 let charge_percentage = battery_details.charge_percentage;
                 let num_bars = calculate_basic_use_bars(charge_percentage, bar_length);
                 let bars = format!(

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -114,7 +114,7 @@ impl BatteryDisplayWidget for Painter {
             {
                 // Assuming a 50/50 split in width
                 let bar_length =
-                    usize::from((draw_loc.width.saturating_sub(2) / 2).saturating_sub(8));
+                    usize::from((draw_loc.width.saturating_sub(2) / 2).saturating_sub(6));
                 let charge_percentage = battery_details.charge_percentage;
                 let num_bars = calculate_basic_use_bars(charge_percentage, bar_length);
                 let bars = format!(


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes colour theming for batteries being flipped.

## Issue

_If applicable, what issue does this address?_

Closes: #330

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [x] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Change has been tested to work, and does not cause new breakage unless intended_
- [ ] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
