### PR TITLE
ci: Fix post-deploy step to actually use the correct files

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -230,7 +230,7 @@ jobs:
           asset_name: ${{ env.ASSET }}
           asset_content_type: application/octet-stream
 
-      - name: Add download asset URL to artifact if required
+      - name: Add download asset to artifact if required
         if: matrix.triple.target == 'x86_64-unknown-linux-gnu' || matrix.triple.target == 'x86_64-pc-windows-msvc' || matrix.triple.target == 'i686-pc-windows-msvc' || matrix.triple.target == 'x86_64-apple-darwin'
         run: cp ${{ env.ASSET }} artifacts/
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -348,13 +348,16 @@ jobs:
 
           linux="$(cat ./artifacts/x86_64-unknown-linux-gnu)"
           echo "LINUX=$linux" >> $GITHUB_ENV
+
           macos="$(cat ./artifacts/x86_64-apple-darwin)"
           echo "MACOS=$macos" >> $GITHUB_ENV
+
+          dos2unix ./artifacts/i686-pc-windows-msvc
           win_32="$(cat ./artifacts/i686-pc-windows-msvc)"
-          win_32=${win_32%$'\r'}
           echo "WINDOWS_32=$win_32" >> $GITHUB_ENV
+
+          dos2unix ./artifacts/x86_64-pc-windows-msvc
           win_64="$(cat ./artifacts/x86_64-pc-windows-msvc)"
-          win_64=${win64%$'\r'}
           echo "WINDOWS_64=$win_64" >> $GITHUB_ENV
 
       - name: Validate release environment variables

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -330,7 +330,7 @@ jobs:
           name: artifacts
           path: artifacts
 
-      - name: Set release upload URL and release version
+      - name: Set release upload URL, download URL and version
         shell: bash
         run: |
           release_download_url="$(cat ./artifacts/release-download-url)"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -232,7 +232,7 @@ jobs:
 
       - name: Add download asset URL to artifact if required
         if: matrix.triple.target == 'x86_64-unknown-linux-gnu' || matrix.triple.target == 'x86_64-pc-windows-msvc' || matrix.triple.target == 'i686-pc-windows-msvc' || matrix.triple.target == 'x86_64-apple-darwin'
-        run: echo "${{ steps.upload.outputs.browser_download_url }}" > artifacts/${{ matrix.triple.target }}
+        run: cp ${{ env.ASSET }} artifacts/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
@@ -349,42 +349,21 @@ jobs:
           release_version="$(cat ./artifacts/release-version)"
           echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
 
-          linux="$(cat ./artifacts/x86_64-unknown-linux-gnu)"
-          echo "LINUX=$linux" >> $GITHUB_ENV
-
-          macos="$(cat ./artifacts/x86_64-apple-darwin)"
-          echo "MACOS=$macos" >> $GITHUB_ENV
-
-          dos2unix ./artifacts/i686-pc-windows-msvc
-          win_32="$(cat ./artifacts/i686-pc-windows-msvc)"
-          echo "WINDOWS_32=$win_32" >> $GITHUB_ENV
-
-          dos2unix ./artifacts/x86_64-pc-windows-msvc
-          win_64="$(cat ./artifacts/x86_64-pc-windows-msvc)"
-          echo "WINDOWS_64=$win_64" >> $GITHUB_ENV
-
       - name: Validate release environment variables
         run: |
           echo "Release upload url: ${{ env.RELEASE_UPLOAD_URL }}"
           echo "Release version: ${{ env.RELEASE_VERSION }}"
 
-      - name: Validate download URLs
-        run: |
-          echo "Linux download url: ${{ env.LINUX }}"
-          echo "macOS download url: ${{ env.MACOS }}"
-          echo "Windows 32-bit download url: ${{ env.WINDOWS_32 }}"
-          echo "Windows 64-bit download url: ${{ env.WINDOWS_64 }}"
-
       - name: Download packages
         run: |
-          curl -LO "${{ env.LINUX }}";
-          curl -LO "${{ env.MACOS }}";
-          curl -LO "${{ env.WINDOWS_32 }}";
-          curl -LO "${{ env.WINDOWS_64 }}";
+          curl -LO "${{ env.LINUX }}"
+          curl -LO "${{ env.MACOS }}"
+          curl -LO "${{ env.WINDOWS_32 }}"
+          curl -LO "${{ env.WINDOWS_64 }}"
 
       - name: Execute choco packaging script
         run: |
-          python "./deployment/windows/choco/choco_packager.py" "bottom_i686-pc-windows-msvc.zip" "bottom_x86_64-pc-windows-msvc.zip" ${{ env.RELEASE_VERSION }} "./deployment/windows/choco/bottom.nuspec.template" "./deployment/windows/choco/chocolateyinstall.ps1.template" "bottom.nuspec" "tools/chocolateyinstall.ps1" "tools/"
+          python "./deployment/windows/choco/choco_packager.py" "./artifacts/bottom_i686-pc-windows-msvc.zip" "./artifacts/bottom_x86_64-pc-windows-msvc.zip" ${{ env.RELEASE_VERSION }} "./deployment/windows/choco/bottom.nuspec.template" "./deployment/windows/choco/chocolateyinstall.ps1.template" "bottom.nuspec" "tools/chocolateyinstall.ps1" "tools/"
           zip -r choco.zip "bottom.nuspec" "tools"
 
       - name: Upload choco.zip to release
@@ -399,7 +378,7 @@ jobs:
 
       - name: Execute Homebrew packaging script
         run: |
-          python "./deployment/packager.py" ${{ env.RELEASE_VERSION }} "./deployment/macos/homebrew/bottom.rb.template" "./bottom.rb" "SHA256" "./bottom_x86_64-apple-darwin.tar.gz" "./bottom_x86_64-unknown-linux-gnu.tar.gz";
+          python "./deployment/packager.py" ${{ env.RELEASE_VERSION }} "./deployment/macos/homebrew/bottom.rb.template" "./bottom.rb" "SHA256" "./artifacts/bottom_x86_64-apple-darwin.tar.gz" "./artifacts/bottom_x86_64-unknown-linux-gnu.tar.gz";
 
       - name: Upload bottom.rb to release
         uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -354,13 +354,6 @@ jobs:
           echo "Release upload url: ${{ env.RELEASE_UPLOAD_URL }}"
           echo "Release version: ${{ env.RELEASE_VERSION }}"
 
-      - name: Download packages
-        run: |
-          curl -LO "${{ env.LINUX }}"
-          curl -LO "${{ env.MACOS }}"
-          curl -LO "${{ env.WINDOWS_32 }}"
-          curl -LO "${{ env.WINDOWS_64 }}"
-
       - name: Execute choco packaging script
         run: |
           python "./deployment/windows/choco/choco_packager.py" "./artifacts/bottom_i686-pc-windows-msvc.zip" "./artifacts/bottom_x86_64-pc-windows-msvc.zip" ${{ env.RELEASE_VERSION }} "./deployment/windows/choco/bottom.nuspec.template" "./deployment/windows/choco/chocolateyinstall.ps1.template" "bottom.nuspec" "tools/chocolateyinstall.ps1" "tools/"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -53,9 +53,6 @@ jobs:
       - name: Save version number to artifact
         run: echo "${{ env.VERSION }}" > artifacts/release-version
 
-      - name: Save download upload URL to artifact
-        run: echo "${{ steps.release.outputs.html_url }}" > artifacts/release-download-url
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -224,6 +221,7 @@ jobs:
 
       - name: Upload main release
         uses: actions/upload-release-asset@v1.0.1
+        id: upload
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -231,6 +229,16 @@ jobs:
           asset_path: ${{ env.ASSET }}
           asset_name: ${{ env.ASSET }}
           asset_content_type: application/octet-stream
+
+      - name: Add download asset URL to artifact if required
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' || matrix.triple.target == 'x86_64-pc-windows-msvc' || matrix.triple.target == 'i686-pc-windows-msvc' || matrix.triple.target == 'x86_64-apple-darwin'
+        run: echo "${{ steps.upload.outputs.browser_download_url }}" > artifacts/${{ matrix.triple.target }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: artifacts
+          path: artifacts
 
       - name: Build msi file (Windows x86-64 MSVC)
         if: matrix.triple.target == 'x86_64-pc-windows-msvc'
@@ -333,25 +341,31 @@ jobs:
       - name: Set release upload URL, download URL and version
         shell: bash
         run: |
-          release_download_url="$(cat ./artifacts/release-download-url)"
-          echo "RELEASE_DOWNLOAD_URL=$release_download_url" >> $GITHUB_ENV
           release_upload_url="$(cat ./artifacts/release-upload-url)"
           echo "RELEASE_UPLOAD_URL=$release_upload_url" >> $GITHUB_ENV
           release_version="$(cat ./artifacts/release-version)"
           echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
 
+          linux="$(cat ./artifacts/x86_64-unknown-linux-gnu)"
+          echo "LINUX=$linux" >> $GITHUB_ENV
+          macos="$(cat ./artifacts/x86_64-apple-darwin)"
+          echo "MACOS=$macos" >> $GITHUB_ENV
+          win_32="$(cat ./artifacts/i686-pc-windows-msvc)"
+          echo "WINDOWS_32=$win_32" >> $GITHUB_ENV
+          win_64="$(cat ./artifacts/x86_64-pc-windows-msvc)"
+          echo "WINDOWS_64=$win_64" >> $GITHUB_ENV
+
       - name: Validate release environment variables
         run: |
-          echo "Release download url: ${{ env.RELEASE_DOWNLOAD_URL }}"
           echo "Release upload url: ${{ env.RELEASE_UPLOAD_URL }}"
           echo "Release version: ${{ env.RELEASE_VERSION }}"
 
       - name: Download packages
         run: |
-          curl -LO "${{ env.RELEASE_DOWNLOAD_URL }}/bottom_x86_64-unknown-linux-gnu.tar.gz";
-          curl -LO "${{ env.RELEASE_DOWNLOAD_URL }}/bottom_x86_64-apple-darwin.tar.gz";
-          curl -LO "${{ env.RELEASE_DOWNLOAD_URL }}/bottom_i686-pc-windows-msvc.zip";
-          curl -LO "${{ env.RELEASE_DOWNLOAD_URL }}/bottom_x86_64-pc-windows-msvc.zip";
+          curl -LO "${{ env.LINUX }}";
+          curl -LO "${{ env.MACOS }}";
+          curl -LO "${{ env.WINDOWS_32 }}";
+          curl -LO "${{ env.WINDOWS_64 }}";
 
       - name: Execute choco packaging script
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -332,9 +332,6 @@ jobs:
 
       - uses: actions/setup-python@v2
 
-      - name: Install dos2unix
-        run: sudo apt-get install dos2unix
-
       - name: Get release download URL
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Save version number to artifact
         run: echo "${{ env.VERSION }}" > artifacts/release-version
 
+      - name: Save download upload URL to artifact
+        run: echo "${{ steps.release.outputs.html_url }}" > artifacts/release-download-url
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -330,6 +333,8 @@ jobs:
       - name: Set release upload URL and release version
         shell: bash
         run: |
+          release_download_url="$(cat ./artifacts/release-download-url)"
+          echo "RELEASE_DOWNLOAD_URL=$release_download_url" >> $GITHUB_ENV
           release_upload_url="$(cat ./artifacts/release-upload-url)"
           echo "RELEASE_UPLOAD_URL=$release_upload_url" >> $GITHUB_ENV
           release_version="$(cat ./artifacts/release-version)"
@@ -337,15 +342,16 @@ jobs:
 
       - name: Validate release environment variables
         run: |
+          echo "Release download url: ${{ env.RELEASE_DOWNLOAD_URL }}"
           echo "Release upload url: ${{ env.RELEASE_UPLOAD_URL }}"
           echo "Release version: ${{ env.RELEASE_VERSION }}"
 
       - name: Download packages
         run: |
-          curl -LO "https://github.com/ClementTsang/bottom/releases/download/${{ env.RELEASE_VERSION }}/bottom_x86_64-unknown-linux-gnu.tar.gz";
-          curl -LO "https://github.com/ClementTsang/bottom/releases/download/${{ env.RELEASE_VERSION }}/bottom_x86_64-apple-darwin.tar.gz";
-          curl -LO "https://github.com/ClementTsang/bottom/releases/download/${{ env.RELEASE_VERSION }}/bottom_i686-pc-windows-msvc.zip";
-          curl -LO "https://github.com/ClementTsang/bottom/releases/download/${{ env.RELEASE_VERSION }}/bottom_x86_64-pc-windows-msvc.zip";
+          curl -LO "${{ env.RELEASE_DOWNLOAD_URL }}/bottom_x86_64-unknown-linux-gnu.tar.gz";
+          curl -LO "${{ env.RELEASE_DOWNLOAD_URL }}/bottom_x86_64-apple-darwin.tar.gz";
+          curl -LO "${{ env.RELEASE_DOWNLOAD_URL }}/bottom_i686-pc-windows-msvc.zip";
+          curl -LO "${{ env.RELEASE_DOWNLOAD_URL }}/bottom_x86_64-pc-windows-msvc.zip";
 
       - name: Execute choco packaging script
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -351,14 +351,23 @@ jobs:
           macos="$(cat ./artifacts/x86_64-apple-darwin)"
           echo "MACOS=$macos" >> $GITHUB_ENV
           win_32="$(cat ./artifacts/i686-pc-windows-msvc)"
+          win_32=${win_32%$'\r'}
           echo "WINDOWS_32=$win_32" >> $GITHUB_ENV
           win_64="$(cat ./artifacts/x86_64-pc-windows-msvc)"
+          win_64=${win64%$'\r'}
           echo "WINDOWS_64=$win_64" >> $GITHUB_ENV
 
       - name: Validate release environment variables
         run: |
           echo "Release upload url: ${{ env.RELEASE_UPLOAD_URL }}"
           echo "Release version: ${{ env.RELEASE_VERSION }}"
+
+      - name: Validate download URLs
+        run: |
+          echo "Linux download url: ${{ env.LINUX }}"
+          echo "macOS download url: ${{ env.MACOS }}"
+          echo "Windows 32-bit download url: ${{ env.WINDOWS_32 }}"
+          echo "Windows 64-bit download url: ${{ env.WINDOWS_64 }}"
 
       - name: Download packages
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -332,6 +332,9 @@ jobs:
 
       - uses: actions/setup-python@v2
 
+      - name: Install dos2unix
+        run: sudo apt-get install dos2unix
+
       - name: Get release download URL
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
Previously it was CURL-ing from a non-existent URL, giving the wrong SHA hashes.

Changed to upload the binaries as artifacts and using those directly.