### PR TITLE
bug: Fix incorrect cpu colour matching again in all position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Bug Fixes
 
+## [0.5.5] - Unreleased
+
+## Bug Fixes
+
+- [#349](https://github.com/ClementTsang/bottom/pull/349): Fixed CPU graph colours not matching the legend in the "all" state.
+
 ## [0.5.4] - 2020-12-10
 
 ## Changes

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -199,9 +199,16 @@ impl CpuGraphWidget for Painter {
                             })
                             .style(if show_avg_cpu && itx == AVG_POSITION {
                                 self.colours.avg_colour_style
+                            } else if itx == ALL_POSITION {
+                                self.colours.all_colour_style
                             } else {
-                                self.colours.cpu_colour_styles
-                                    [itx % self.colours.cpu_colour_styles.len()]
+                                self.colours.cpu_colour_styles[(itx - 1 // Because of the all position
+                                        - (if show_avg_cpu {
+                                            AVG_POSITION
+                                        } else {
+                                            0
+                                        }))
+                                    % self.colours.cpu_colour_styles.len()]
                             })
                             .data(&cpu.cpu_data[..])
                             .graph_type(tui::widgets::GraphType::Line)


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Turns out there was yet another bug with the CPU colour allocation.  I had forgotten to use the same index calculation for the "all" position.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
