### PR TITLE
refactor: Cut out sysinfo from Linux builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -58,6 +58,6 @@ _CPU and number of cores:_
 
 _Check this with `rustc --version`. This is only relevant if your version of bottom isn't from a pre-built binary (i.e. Cargo). Otherwise, feel free to skip._
 
-### Additional context
+## Additional context
 
 _If anything hasn't been covered by the above categories, feel free to include it here:_

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -58,6 +58,6 @@ _CPU and number of cores:_
 
 _Check this with `rustc --version`. This is only relevant if your version of bottom isn't from a pre-built binary (i.e. Cargo). Otherwise, feel free to skip._
 
-## Additional context
+### Additional context
 
 _If anything hasn't been covered by the above categories, feel free to include it here:_

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,7 @@ dependencies = [
  "fern",
  "fnv",
  "futures",
+ "futures-timer",
  "heim",
  "indexmap",
  "itertools",
@@ -672,6 +673,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a653442b9bdd11a77d3753a60443c60c4437d3acac8e6c3d4a6a9acd7cceed"
 dependencies = [
  "heim-common",
+ "heim-cpu",
  "heim-disk",
  "heim-memory",
  "heim-net",
@@ -707,6 +715,25 @@ dependencies = [
  "nix 0.19.1",
  "pin-utils",
  "uom",
+ "winapi",
+]
+
+[[package]]
+name = "heim-cpu"
+version = "0.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba5fb13a3b90581d22b4edf99e87c54316444622ae123d36816a227a7caa6df"
+dependencies = [
+ "cfg-if 1.0.0",
+ "futures",
+ "glob",
+ "heim-common",
+ "heim-runtime",
+ "lazy_static",
+ "libc",
+ "mach",
+ "ntapi",
+ "smol",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,19 @@ typed-builder = "0.8.0"
 unicode-segmentation = "1.7.1"
 unicode-width = "0.1"
 
-# For debugging only...
+# For debugging only... disable on release builds with --no-default-target for no?  TODO: Redo this.
 fern = { version = "0.6.0", optional=true }
-log = { version="0.4.11", optional=true }
+log = { version = "0.4.11", optional=true }
 
-heim = { version = "0.1.0-rc.1", features = ["disk", "memory", "net", "sensors"] }
+[target.'cfg(target_os = "linux")'.dependencies]
+heim = { version = "0.1.0-rc.1", features = ["cpu", "disk", "memory", "net", "sensors"] }
+futures-timer = "3.0.2"
 
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
+heim = { version = "0.1.0-rc.1", features = ["disk", "memory", "net"] } 
+
+[target.'cfg(target_os = "windows")'.dependencies]
+heim = { version = "0.1.0-rc.1", features = ["disk", "memory"] }
 winapi = "0.3.9"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ fnv = "1.0.7"
 futures = "0.3.8"
 indexmap = "~1.6"
 itertools = "0.9.0"
-libc = "~0.2"
 once_cell = "1.5.2"
 regex = "1.4.2"
 serde = { version = "~1.0", features = ["derive"] }
@@ -57,6 +56,9 @@ unicode-width = "0.1"
 # For debugging only... disable on release builds with --no-default-target for no?  TODO: Redo this.
 fern = { version = "0.6.0", optional=true }
 log = { version = "0.4.11", optional=true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "~0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 heim = { version = "0.1.0-rc.1", features = ["cpu", "disk", "memory", "net", "sensors"] }

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ A cross-platform graphical process/system monitor with a customizable interface 
 Note that bottom is:
 
 - Built on the stable version of Rust
-- Officially tested and released for only `x86_64` (and `i686` for Windows)
+- Officially tested and released for only `x86_64` (and `i686` for Windows and Linux)
 - Developed mainly for macOS, Windows, and Linux
 
-Anything outside of this (i.e: ARM builds, building on Nightly, building on another OS) is currently not guaranteed, even if it does happen to work. For example, ARM is compiled on the CI pipeline and release builds will be provided, but not all features may work (such as R/s and W/s for disks).
+Anything outside of this (i.e: ARM builds, building on Nightly, building on another OS) is currently not guaranteed, even if it does happen to work. For example, ARM is compiled on the CI pipeline and release builds will be provided, but not all features may necessarily work.
 
 ### Manually
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Note that bottom is:
 - Officially tested and released for only `x86_64` (and `i686` for Windows and Linux)
 - Developed mainly for macOS, Windows, and Linux
 
-Anything outside of this (i.e: ARM builds, building on Nightly, building on another OS) is currently not guaranteed, even if it does happen to work. For example, ARM is compiled on the CI pipeline and release builds will be provided, but not all features may necessarily work.
+Anything outside of this (i.e: ARM builds, building on Nightly, building on another OS) is currently not guaranteed, even if it does happen to work. For example, ARM is compiled on the CI pipeline and release builds will be provided, but not all features may necessarily work. Feel free to file any ARM-related bugs, but know I might not be able to fix them.
 
 ### Manually
 

--- a/src/app/data_harvester/cpu.rs
+++ b/src/app/data_harvester/cpu.rs
@@ -12,7 +12,7 @@ pub type PastCpuTotal = f64;
 
 #[cfg(not(target_os = "linux"))]
 pub fn get_cpu_data_list(sys: &System, show_average_cpu: bool) -> CpuHarvest {
-    use sysinfo::{ProcessorExt, System, SystemExt};
+    use sysinfo::{ProcessorExt, System};
 
     let cpu_data = sys.get_processors();
     let avg_cpu_usage = sys.get_global_processor_info().get_cpu_usage();

--- a/src/app/data_harvester/cpu.rs
+++ b/src/app/data_harvester/cpu.rs
@@ -11,9 +11,10 @@ pub type PastCpuWork = f64;
 pub type PastCpuTotal = f64;
 
 #[cfg(not(target_os = "linux"))]
-pub fn get_cpu_data_list(sys: &System, show_average_cpu: bool) -> CpuHarvest {
-    use sysinfo::{ProcessorExt, System};
+use sysinfo::{ProcessorExt, System, SystemExt};
 
+#[cfg(not(target_os = "linux"))]
+pub fn get_cpu_data_list(sys: &System, show_average_cpu: bool) -> CpuHarvest {
     let cpu_data = sys.get_processors();
     let avg_cpu_usage = sys.get_global_processor_info().get_cpu_usage();
     let mut cpu_vec = vec![];

--- a/src/app/data_harvester/cpu.rs
+++ b/src/app/data_harvester/cpu.rs
@@ -1,5 +1,3 @@
-use sysinfo::{ProcessorExt, System, SystemExt};
-
 #[derive(Default, Debug, Clone)]
 pub struct CpuData {
     pub cpu_prefix: String,
@@ -9,7 +7,13 @@ pub struct CpuData {
 
 pub type CpuHarvest = Vec<CpuData>;
 
+pub type PastCpuWork = f64;
+pub type PastCpuTotal = f64;
+
+#[cfg(not(target_os = "linux"))]
 pub fn get_cpu_data_list(sys: &System, show_average_cpu: bool) -> CpuHarvest {
+    use sysinfo::{ProcessorExt, System, SystemExt};
+
     let cpu_data = sys.get_processors();
     let avg_cpu_usage = sys.get_global_processor_info().get_cpu_usage();
     let mut cpu_vec = vec![];
@@ -31,4 +35,222 @@ pub fn get_cpu_data_list(sys: &System, show_average_cpu: bool) -> CpuHarvest {
     }
 
     cpu_vec
+}
+
+#[cfg(target_os = "linux")]
+pub async fn get_cpu_data_list(
+    show_average_cpu: bool, previous_cpu_times: &mut Vec<(PastCpuWork, PastCpuTotal)>,
+    previous_average_cpu_time: &mut Option<(PastCpuWork, PastCpuTotal)>,
+) -> crate::error::Result<CpuHarvest> {
+    use futures::StreamExt;
+    use heim::cpu::os::linux::CpuTimeExt;
+    use std::collections::VecDeque;
+
+    // Get all CPU times...
+    let cpu_times = heim::cpu::times().await?;
+    futures::pin_mut!(cpu_times);
+
+    let mut cpu_deque: VecDeque<CpuData> = if previous_cpu_times.is_empty() {
+        // Must initialize ourselves.  Use a very quick timeout to calculate an initial.
+        futures_timer::Delay::new(std::time::Duration::from_millis(100)).await;
+
+        let second_cpu_times = heim::cpu::times().await?;
+        futures::pin_mut!(second_cpu_times);
+
+        let mut new_cpu_times: Vec<(PastCpuWork, PastCpuTotal)> = Vec::new();
+        let mut cpu_deque: VecDeque<CpuData> = VecDeque::new();
+
+        let mut collected_zip = cpu_times.zip(second_cpu_times).enumerate();
+
+        while let Some((itx, (past, present))) = collected_zip.next().await {
+            if let (Ok(past), Ok(present)) = (past, present) {
+                let first_working_time: f64 = (past.user()
+                    + past.nice()
+                    + past.system()
+                    + past.irq()
+                    + past.soft_irq()
+                    + past.steal())
+                .get::<heim::units::time::second>();
+                let first_total_time: f64 = first_working_time
+                    + (past.idle() + past.io_wait()).get::<heim::units::time::second>();
+
+                let second_working_time: f64 = (present.user()
+                    + present.nice()
+                    + present.system()
+                    + present.irq()
+                    + present.soft_irq()
+                    + present.steal())
+                .get::<heim::units::time::second>();
+                let second_total_time: f64 = second_working_time
+                    + (present.idle() + present.io_wait()).get::<heim::units::time::second>();
+
+                let working_time_delta: f64 = if second_working_time > first_working_time {
+                    second_working_time - first_working_time
+                } else {
+                    0.0
+                };
+                let total_time_delta: f64 = if second_total_time > first_total_time {
+                    second_total_time - first_total_time
+                } else {
+                    1.0
+                };
+
+                new_cpu_times.push((second_working_time, second_total_time));
+                cpu_deque.push_back(CpuData {
+                    cpu_prefix: "CPU".to_string(),
+                    cpu_count: Some(itx),
+                    cpu_usage: working_time_delta / total_time_delta * 100.0,
+                });
+            } else {
+                new_cpu_times.push((0.0, 0.0));
+                cpu_deque.push_back(CpuData {
+                    cpu_prefix: "CPU".to_string(),
+                    cpu_count: Some(itx),
+                    cpu_usage: 0.0,
+                });
+            }
+        }
+
+        *previous_cpu_times = new_cpu_times;
+        cpu_deque
+    } else {
+        let (new_cpu_times, cpu_deque): (Vec<(PastCpuWork, PastCpuTotal)>, VecDeque<CpuData>) =
+            cpu_times
+                .collect::<Vec<_>>()
+                .await
+                .iter()
+                .zip(&*previous_cpu_times)
+                .enumerate()
+                .map(|(itx, (current_cpu, (past_cpu_work, past_cpu_total)))| {
+                    if let Ok(current_cpu) = current_cpu {
+                        let working_time: f64 = (current_cpu.user()
+                            + current_cpu.nice()
+                            + current_cpu.system()
+                            + current_cpu.irq()
+                            + current_cpu.soft_irq()
+                            + current_cpu.steal())
+                        .get::<heim::units::time::second>();
+                        let total_time: f64 = working_time
+                            + (current_cpu.idle() + current_cpu.io_wait())
+                                .get::<heim::units::time::second>();
+
+                        let working_time_delta: f64 = if working_time > *past_cpu_work {
+                            working_time - *past_cpu_work
+                        } else {
+                            0.0
+                        };
+                        let total_time_delta: f64 = if total_time > *past_cpu_total {
+                            total_time - *past_cpu_total
+                        } else {
+                            1.0
+                        };
+
+                        (
+                            (working_time, total_time),
+                            CpuData {
+                                cpu_prefix: "CPU".to_string(),
+                                cpu_count: Some(itx),
+                                cpu_usage: working_time_delta / total_time_delta * 100.0,
+                            },
+                        )
+                    } else {
+                        (
+                            (*past_cpu_work, *past_cpu_total),
+                            CpuData {
+                                cpu_prefix: "CPU".to_string(),
+                                cpu_count: Some(itx),
+                                cpu_usage: 0.0,
+                            },
+                        )
+                    }
+                })
+                .unzip();
+
+        *previous_cpu_times = new_cpu_times;
+        cpu_deque
+    };
+
+    // Get average CPU if needed... and slap it at the top
+    if show_average_cpu {
+        let cpu_time = heim::cpu::time().await?;
+
+        let (cpu_usage, new_average_cpu_time) =
+            if let Some((past_cpu_work, past_cpu_total)) = previous_average_cpu_time {
+                let working_time: f64 = (cpu_time.user()
+                    + cpu_time.nice()
+                    + cpu_time.system()
+                    + cpu_time.irq()
+                    + cpu_time.soft_irq()
+                    + cpu_time.steal())
+                .get::<heim::units::time::second>();
+                let total_time: f64 = working_time
+                    + (cpu_time.idle() + cpu_time.io_wait()).get::<heim::units::time::second>();
+
+                let working_time_delta: f64 = if working_time > *past_cpu_work {
+                    working_time - *past_cpu_work
+                } else {
+                    0.0
+                };
+                let total_time_delta: f64 = if total_time > *past_cpu_total {
+                    total_time - *past_cpu_total
+                } else {
+                    1.0
+                };
+
+                (
+                    working_time_delta / total_time_delta * 100.0,
+                    (working_time, total_time),
+                )
+            } else {
+                // Again, we need to do a quick timeout...
+                futures_timer::Delay::new(std::time::Duration::from_millis(100)).await;
+                let second_cpu_time = heim::cpu::time().await?;
+
+                let first_working_time: f64 = (cpu_time.user()
+                    + cpu_time.nice()
+                    + cpu_time.system()
+                    + cpu_time.irq()
+                    + cpu_time.soft_irq()
+                    + cpu_time.steal())
+                .get::<heim::units::time::second>();
+                let first_total_time: f64 = first_working_time
+                    + (cpu_time.idle() + cpu_time.io_wait()).get::<heim::units::time::second>();
+
+                let second_working_time: f64 = (second_cpu_time.user()
+                    + second_cpu_time.nice()
+                    + second_cpu_time.system()
+                    + second_cpu_time.irq()
+                    + second_cpu_time.soft_irq()
+                    + second_cpu_time.steal())
+                .get::<heim::units::time::second>();
+                let second_total_time: f64 = second_working_time
+                    + (second_cpu_time.idle() + second_cpu_time.io_wait())
+                        .get::<heim::units::time::second>();
+
+                let working_time_delta: f64 = if second_working_time > first_working_time {
+                    second_working_time - first_working_time
+                } else {
+                    0.0
+                };
+                let total_time_delta: f64 = if second_total_time > first_total_time {
+                    second_total_time - first_total_time
+                } else {
+                    1.0
+                };
+
+                (
+                    working_time_delta / total_time_delta * 100.0,
+                    (second_working_time, second_total_time),
+                )
+            };
+
+        *previous_average_cpu_time = Some(new_average_cpu_time);
+        cpu_deque.push_front(CpuData {
+            cpu_prefix: "AVG".to_string(),
+            cpu_count: None,
+            cpu_usage,
+        })
+    }
+
+    Ok(Vec::from(cpu_deque))
 }


### PR DESCRIPTION
Refactors to use only heim for Linux builds.  This is now much easier to do since the 0.1 version of heim works fine for ARM.  This is ideal since having to rely on two separate sources of data isn't the greatest if we can avoid it.

Sysinfo is still required for macOS and Windows, though.  Temperature sensors do not work for those from heim, and for some reason, networks also don't work on Windows with heim...?

My personal CPU core calculation is also currently Linux-only, and as such, I'll still rely on sysinfo for Windows and macOS for now.

This isn't really a big optimization or anything btw.  Just something I wanted to try.

## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Refactoring (a change that doesn't change application functionality)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [x] _Windows_
- [x] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
