### PR TITLE
bug: Fixes incorrect colours being used the CPU widget in basic mode

### DIFF
--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -49,6 +49,7 @@ impl CpuBasicWidget for Painter {
             }
 
             let num_cpus = cpu_data.len();
+            let show_avg_cpu = app_state.app_config_fields.show_average_cpu;
 
             if draw_loc.height > 0 {
                 let remaining_height = usize::from(draw_loc.height);
@@ -158,11 +159,20 @@ impl CpuBasicWidget for Painter {
                         let end_index = min(start_index + how_many_cpus, num_cpus);
 
                         let cpu_column = (start_index..end_index)
-                            .map(|cpu_index| {
+                            .map(|itx| {
                                 Spans::from(Span {
-                                    content: (&cpu_bars[cpu_index]).into(),
-                                    style: self.colours.cpu_colour_styles
-                                        [cpu_index % self.colours.cpu_colour_styles.len()],
+                                    content: (&cpu_bars[itx]).into(),
+                                    style: if show_avg_cpu {
+                                        if itx == 0 {
+                                            self.colours.avg_colour_style
+                                        } else {
+                                            self.colours.cpu_colour_styles
+                                                [(itx - 1) % self.colours.cpu_colour_styles.len()]
+                                        }
+                                    } else {
+                                        self.colours.cpu_colour_styles
+                                            [(itx - 1) % self.colours.cpu_colour_styles.len()]
+                                    },
                                 })
                             })
                             .collect::<Vec<_>>();


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes the colour order being off in basic mode, and not using the average CPU colour.

Side by side comparison (first is new, second is old):
![image](https://user-images.githubusercontent.com/34804052/102859375-ca9aea80-43f9-11eb-889c-91d98ab72353.png)

![image](https://user-images.githubusercontent.com/34804052/102859385-cd95db00-43f9-11eb-91ec-d92771543cda.png)


## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
