### PR TITLE
feature: Add process_command to default to the process command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Features
 
-- [#333](https://github.com/ClementTsang/bottom/pull/333): Adds an "out of" indicator that can be enabled using `--show_table_scroll_position` to help keep track of scrolled position.
+- [#333](https://github.com/ClementTsang/bottom/pull/333): Adds an "out of" indicator that can be enabled using `--show_table_scroll_position` (and its corresponding config option) to help keep track of scrolled position.
+
+- [#379](https://github.com/ClementTsang/bottom/pull/379): Adds `--process_command` flag and corresponding config option to default to showing a process' command.
 
 ## Changes
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Use `btm --help` for more information.
     -S, --case_sensitive                       Enables case sensitivity by default.
     -c, --celsius                              Sets the temperature type to Celsius.
         --color <COLOR SCHEME>                 Use a color scheme, use --help for supported values.
+        --process_command                         Show processes as their commands by default.
     -C, --config <CONFIG PATH>                 Sets the location of the config file.
     -u, --current_usage                        Sets process CPU% to be based on current CPU%.
     -t, --default_time_value <MS>              Default time value for graphs in ms.
@@ -531,32 +532,31 @@ The following options can be set under `[flags]` to achieve the same effect as p
 
 These are the following supported flag config values, which correspond to the flag of the same name described in [Flags](#flags):
 
-| Field                        | Type                                                                                  |
-| ---------------------------- | ------------------------------------------------------------------------------------- |
-| `hide_avg_cpu`               | Boolean                                                                               |
-| `dot_marker`                 | Boolean                                                                               |
-| `left_legend`                | Boolean                                                                               |
-| `current_usage`              | Boolean                                                                               |
-| `group_processes`            | Boolean                                                                               |
-| `case_sensitive`             | Boolean                                                                               |
-| `whole_word`                 | Boolean                                                                               |
-| `regex`                      | Boolean                                                                               |
-| `show_disabled_data`         | Boolean                                                                               |
-| `basic`                      | Boolean                                                                               |
-| `hide_table_count`           | Boolean                                                                               |
-| `use_old_network_legend`     | Boolean                                                                               |
-| `battery`                    | Boolean                                                                               |
-| `rate`                       | Unsigned Int (represents milliseconds)                                                |
-| `default_time_value`         | Unsigned Int (represents milliseconds)                                                |
-| `time_delta`                 | Unsigned Int (represents milliseconds)                                                |
-| `temperature_type`           | String (one of ["k", "f", "c", "kelvin", "fahrenheit", "celsius"])                    |
-| `default_widget_type`        | String (one of ["cpu", "proc", "net", "temp", "mem", "disk"], same as layout options) |
-| `default_widget_count`       | Unsigned Int (represents which `default_widget_type`)                                 |
-| `disable_click`              | Boolean                                                                               |
-| `color`                      | String (one of ["default", "default-light", "gruvbox", "gruvbox-light"])              |
-| `mem_as_value`               | Boolean                                                                               |
-| `tree`                       | Boolean                                                                               |
-| `show_table_scroll_position` | Boolean                                                                               |
+| Field                        | Type                                                                                  | Functionality                                           |
+| ---------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `hide_avg_cpu`               | Boolean                                                                               | Hides the average CPU usage.                            |
+| `dot_marker`                 | Boolean                                                                               | Uses a dot marker for graphs.                           |
+| `left_legend`                | Boolean                                                                               | Puts the CPU chart legend to the left side.             |
+| `current_usage`              | Boolean                                                                               | Sets process CPU% to be based on current CPU%.          |
+| `group_processes`            | Boolean                                                                               | Groups processes with the same name by default.         |
+| `case_sensitive`             | Boolean                                                                               | Enables case sensitivity by default.                    |
+| `whole_word`                 | Boolean                                                                               | Enables whole-word matching by default.                 |
+| `regex`                      | Boolean                                                                               | Enables regex by default.                               |
+| `basic`                      | Boolean                                                                               | Hides graphs and uses a more basic look.                |
+| `use_old_network_legend`     | Boolean                                                                               | DEPRECATED - uses the older network legend.             |
+| `battery`                    | Boolean                                                                               | Shows the battery widget.                               |
+| `rate`                       | Unsigned Int (represents milliseconds)                                                | Sets a refresh rate in ms.                              |
+| `default_time_value`         | Unsigned Int (represents milliseconds)                                                | Default time value for graphs in ms.                    |
+| `time_delta`                 | Unsigned Int (represents milliseconds)                                                | The amount in ms changed upon zooming.                  |
+| `temperature_type`           | String (one of ["k", "f", "c", "kelvin", "fahrenheit", "celsius"])                    | Sets the temperature unit type.                         |
+| `default_widget_type`        | String (one of ["cpu", "proc", "net", "temp", "mem", "disk"], same as layout options) | Sets the default widget type, use --help for more info. |
+| `default_widget_count`       | Unsigned Int (represents which `default_widget_type`)                                 | Sets the n'th selected widget type as the default.      |
+| `disable_click`              | Boolean                                                                               | Disables mouse clicks.                                  |
+| `color`                      | String (one of ["default", "default-light", "gruvbox", "gruvbox-light"])              | Use a color scheme, use --help for supported values.    |
+| `mem_as_value`               | Boolean                                                                               | Defaults to showing process memory usage by value.      |
+| `tree`                       | Boolean                                                                               | Defaults to showing the process widget in tree mode.    |
+| `show_table_scroll_position` | Boolean                                                                               | Shows the scroll position tracker in table widgets.     |
+| `process_command`            | Boolean                                                                               | Show processes as their commands by default.            |
 
 #### Theming
 

--- a/sample_configs/demo_config.toml
+++ b/sample_configs/demo_config.toml
@@ -11,7 +11,6 @@ group_processes = false
 case_sensitive = false
 whole_word = false
 regex = true
-show_disabled_data = true
 default_widget_type = "cpu"
 default_widget_count = 1
 

--- a/src/app/states.rs
+++ b/src/app/states.rs
@@ -409,7 +409,7 @@ pub struct ProcWidgetState {
 impl ProcWidgetState {
     pub fn init(
         is_case_sensitive: bool, is_match_whole_word: bool, is_use_regex: bool, is_grouped: bool,
-        show_memory_as_values: bool, is_tree_mode: bool,
+        show_memory_as_values: bool, is_tree_mode: bool, is_using_command: bool,
     ) -> Self {
         let mut process_search_state = ProcessSearchState::default();
 
@@ -450,7 +450,7 @@ impl ProcWidgetState {
             scroll_state: AppScrollWidgetState::default(),
             process_sorting_type,
             is_process_sort_descending,
-            is_using_command: false,
+            is_using_command,
             current_column_index: 0,
             is_sort_open: false,
             columns,

--- a/src/clap.rs
+++ b/src/clap.rs
@@ -115,7 +115,7 @@ Disables mouse clicks from interacting with the program.\n\n",
 Uses a dot marker for graphs as opposed to the default braille
 marker.\n\n",
         );
-    let group = Arg::with_name("group")
+    let group = Arg::with_name("group") // FIXME: Rename this to something like "group_process", would be "breaking" though.
         .short("g")
         .long("group")
         .help("Groups processes with the same name by default.")
@@ -145,12 +145,12 @@ Hides the spacing between table headers and entries.\n\n",
             "\
 Completely hides the time scaling from being shown.\n\n",
         );
-    let proc_command = Arg::with_name("command")
-        .long("proc_command")
-        .help("Defaults to showing the full command in a process..")
+    let process_command = Arg::with_name("process_command")
+        .long("process_command")
+        .help("Show processes as their commands by default.")
         .long_help(
             "\
-Defaults to showing the full command in a process.
+            Show processes as their commands by default in the process widget.
             ",
         );
     let left_legend = Arg::with_name("left_legend")
@@ -178,7 +178,7 @@ When searching for a process, enables regex by default.\n\n",
         );
     let show_table_scroll_position = Arg::with_name("show_table_scroll_position")
         .long("show_table_scroll_position")
-        .help("Shows the scroll position tracker in table widgets")
+        .help("Shows the scroll position tracker in table widgets.")
         .long_help(
             "\
     Shows the list scroll position tracker in the widget title for table widgets.\n\n",
@@ -285,7 +285,7 @@ use CPU (3) as the default instead.
         .long("default_widget_type")
         .takes_value(true)
         .value_name("WIDGET TYPE")
-        .help("Sets which widget type to use as the default widget.")
+        .help("Sets the default widget type, use --help for more info.")
         .long_help(
             "\
 Sets which widget type to use as the default widget.
@@ -369,7 +369,7 @@ Defaults to showing the process widget in tree mode.\n\n",
         .arg(basic)
         .arg(battery)
         .arg(case_sensitive)
-        .arg(proc_command)
+        .arg(process_command)
         .arg(config_location)
         .arg(color)
         // .arg(debug)

--- a/src/clap.rs
+++ b/src/clap.rs
@@ -81,6 +81,15 @@ custom layouts.\n\n",
             "\
 When searching for a process, enables case sensitivity by default.\n\n",
         );
+    let current_usage = Arg::with_name("current_usage")
+        .short("u")
+        .long("current_usage")
+        .help("Sets process CPU% to be based on current CPU%.")
+        .long_help(
+            "\
+Sets process CPU% usage to be based on the current system CPU% usage
+rather than total CPU usage.\n\n",
+        );
     // TODO: [DEBUG] Add a proper debugging solution.
     //     let debug = Arg::with_name("debug")
     //         .long("debug")
@@ -136,12 +145,13 @@ Hides the spacing between table headers and entries.\n\n",
             "\
 Completely hides the time scaling from being shown.\n\n",
         );
-    let show_table_scroll_position = Arg::with_name("show_table_scroll_position")
-        .long("show_table_scroll_position")
-        .help("Shows the scroll position tracker in table widgets")
+    let proc_command = Arg::with_name("command")
+        .long("proc_command")
+        .help("Defaults to showing the full command in a process..")
         .long_help(
             "\
-    Shows the list scroll position tracker in the widget title for table widgets.\n\n",
+Defaults to showing the full command in a process.
+            ",
         );
     let left_legend = Arg::with_name("left_legend")
         .short("l")
@@ -166,14 +176,12 @@ Puts the CPU chart legend to the left side rather than the right side.\n\n",
             "\
 When searching for a process, enables regex by default.\n\n",
         );
-    let current_usage = Arg::with_name("current_usage")
-        .short("u")
-        .long("current_usage")
-        .help("Sets process CPU% to be based on current CPU%.")
+    let show_table_scroll_position = Arg::with_name("show_table_scroll_position")
+        .long("show_table_scroll_position")
+        .help("Shows the scroll position tracker in table widgets")
         .long_help(
             "\
-Sets process CPU% usage to be based on the current system CPU% usage
-rather than total CPU usage.\n\n",
+    Shows the list scroll position tracker in the widget title for table widgets.\n\n",
         );
     let use_old_network_legend = Arg::with_name("use_old_network_legend")
         .long("use_old_network_legend")
@@ -361,6 +369,7 @@ Defaults to showing the process widget in tree mode.\n\n",
         .arg(basic)
         .arg(battery)
         .arg(case_sensitive)
+        .arg(proc_command)
         .arg(config_location)
         .arg(color)
         // .arg(debug)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -401,7 +401,7 @@ pub const OLD_CONFIG_TEXT: &str = r##"# This is a default config file for bottom
 # Shows an indicator in table widgets tracking where in the list you are.
 #show_table_scroll_position = false
 # Show processes as their commands by default in the process widget.
-#proc_command = false
+#process_command = false
 
 # These are all the components that support custom theming.  Note that colour support
 # will depend on terminal support.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -398,6 +398,10 @@ pub const OLD_CONFIG_TEXT: &str = r##"# This is a default config file for bottom
 #mem_as_value = false
 # Show tree mode by default in the processes widget.
 #tree = false
+# Shows an indicator in table widgets tracking where in the list you are.
+#show_table_scroll_position = false
+# Show processes as their commands by default in the process widget.
+#proc_command = false
 
 # These are all the components that support custom theming.  Note that colour support
 # will depend on terminal support.

--- a/src/options.rs
+++ b/src/options.rs
@@ -152,7 +152,7 @@ pub struct ConfigFlags {
     show_table_scroll_position: Option<bool>,
 
     #[builder(default, setter(strip_option))]
-    pub proc_command: Option<bool>,
+    pub process_command: Option<bool>,
 }
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
@@ -257,7 +257,7 @@ pub fn build_app(
 
     let show_memory_as_values = get_mem_as_value(matches, config);
     let is_default_tree = get_is_default_tree(matches, config);
-    let is_default_command = get_is_default_proc_command(matches, config);
+    let is_default_command = get_is_default_process_command(matches, config);
 
     for row in &widget_layout.rows {
         for col in &row.children {
@@ -993,12 +993,12 @@ fn get_show_table_scroll_position(matches: &clap::ArgMatches<'static>, config: &
     false
 }
 
-fn get_is_default_proc_command(matches: &clap::ArgMatches<'static>, config: &Config) -> bool {
-    if matches.is_present("proc_command") {
+fn get_is_default_process_command(matches: &clap::ArgMatches<'static>, config: &Config) -> bool {
+    if matches.is_present("process_command") {
         return true;
     } else if let Some(flags) = &config.flags {
-        if let Some(command) = flags.proc_command {
-            return command;
+        if let Some(process_command) = flags.process_command {
+            return process_command;
         }
     }
     false

--- a/src/options.rs
+++ b/src/options.rs
@@ -150,6 +150,9 @@ pub struct ConfigFlags {
 
     #[builder(default, setter(strip_option))]
     show_table_scroll_position: Option<bool>,
+
+    #[builder(default, setter(strip_option))]
+    pub proc_command: Option<bool>,
 }
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
@@ -254,6 +257,7 @@ pub fn build_app(
 
     let show_memory_as_values = get_mem_as_value(matches, config);
     let is_default_tree = get_is_default_tree(matches, config);
+    let is_default_command = get_is_default_proc_command(matches, config);
 
     for row in &widget_layout.rows {
         for col in &row.children {
@@ -322,6 +326,7 @@ pub fn build_app(
                                     is_grouped,
                                     show_memory_as_values,
                                     is_default_tree,
+                                    is_default_command,
                                 ),
                             );
                         }
@@ -983,6 +988,17 @@ fn get_show_table_scroll_position(matches: &clap::ArgMatches<'static>, config: &
     } else if let Some(flags) = &config.flags {
         if let Some(show_table_scroll_position) = flags.show_table_scroll_position {
             return show_table_scroll_position;
+        }
+    }
+    false
+}
+
+fn get_is_default_proc_command(matches: &clap::ArgMatches<'static>, config: &Config) -> bool {
+    if matches.is_present("proc_command") {
+        return true;
+    } else if let Some(flags) = &config.flags {
+        if let Some(command) = flags.proc_command {
+            return command;
         }
     }
     false


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Adds a `process_command` flag and config option to default to showing the full command in the process widget on startup.

## Issue

_If applicable, what issue does this address?_

Closes: #305

## Type of change

_Remove the irrelevant ones:_

- [x] _New feature (non-breaking change which adds functionality)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Change has been tested to work, and does not cause new breakage unless intended_
- [ ] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
