### PR TITLE
bug: Fix hide table gap option not working in battery widget

### DIFF
--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -35,6 +35,11 @@ impl BatteryDisplayWidget for Painter {
             } else {
                 self.colours.border_style
             };
+            let table_gap = if draw_loc.height < TABLE_GAP_HEIGHT_LIMIT {
+                0
+            } else {
+                app_state.app_config_fields.table_gap
+            };
 
             let title = if app_state.is_expanded {
                 const TITLE_BASE: &str = " Battery ── Esc to go back ";
@@ -156,16 +161,20 @@ impl BatteryDisplayWidget for Painter {
                     Table::new([""].iter(), battery_rows)
                         .block(battery_block)
                         .header_style(self.colours.table_header_style)
-                        .widths(&[Constraint::Percentage(50), Constraint::Percentage(50)]),
+                        .widths(&[Constraint::Percentage(50), Constraint::Percentage(50)])
+                        .header_gap(table_gap),
                     margined_draw_loc,
                 );
             } else {
+                let mut contents = vec![Spans::default(); table_gap as usize];
+
+                contents.push(Spans::from(Span::styled(
+                    "No data found for this battery",
+                    self.colours.text_style,
+                )));
+
                 f.render_widget(
-                    Paragraph::new(Span::styled(
-                        "No data found for this battery",
-                        self.colours.text_style,
-                    ))
-                    .block(battery_block),
+                    Paragraph::new(contents).block(battery_block),
                     margined_draw_loc,
                 );
             }


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes the `hide_table_gap` option not working with the battery widget.

Example now:

`cargo r -- --battery`:
![image](https://user-images.githubusercontent.com/34804052/103723667-87677c80-4fa0-11eb-9602-6295fb310b29.png)

`cargo r -- --battery --hide_table_gap`
![image](https://user-images.githubusercontent.com/34804052/103723684-977f5c00-4fa0-11eb-94d0-3af3331c01ab.png)

## Issue

_If applicable, what issue does this address?_

Closes: #385

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Change has been tested to work, and does not cause new breakage unless intended_
- [ ] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
