### PR TITLE
bug: Fix missing sorting arrow when for non-% mem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#386](https://github.com/ClementTsang/bottom/pull/386): Fixes `hide_table_gap` not working in the battery widget.
 
+- [#389](https://github.com/ClementTsang/bottom/pull/389): Fixes the sorting arrow disappearing in proc widget under some cases.
+
 ## [0.5.6] - 2020-12-17
 
 ## Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
+checksum = "73dd9b7b200044694dfede9edf907c1ca19630908443e9447e624993700c6932"
 dependencies = [
  "difference",
  "float-cmp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,8 +72,8 @@ heim = { version = "0.1.0-rc.1", features = ["disk", "memory"] }
 winapi = "0.3.9"
 
 [dev-dependencies]
-assert_cmd = "~1.0"
-predicates = "1"
+assert_cmd = "1.0.2"
+predicates = "1.0.6"
 
 [build-dependencies]
 clap = "2.33"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1423,13 +1423,21 @@ impl App {
                         .get_mut_widget_state(self.current_widget.widget_id)
                     {
                         match proc_widget_state.process_sorting_type {
-                            processes::ProcessSorting::MemPercent => {
+                            processes::ProcessSorting::MemPercent
+                            | processes::ProcessSorting::Mem => {
                                 proc_widget_state.is_process_sort_descending =
                                     !proc_widget_state.is_process_sort_descending
                             }
+
                             _ => {
-                                proc_widget_state.process_sorting_type =
-                                    processes::ProcessSorting::MemPercent;
+                                proc_widget_state.process_sorting_type = if proc_widget_state
+                                    .columns
+                                    .is_enabled(&processes::ProcessSorting::MemPercent)
+                                {
+                                    processes::ProcessSorting::MemPercent
+                                } else {
+                                    processes::ProcessSorting::Mem
+                                };
                                 proc_widget_state.is_process_sort_descending = true;
                             }
                         }


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes a bug where you could make the sorting arrow disappear in the mem column if you did:

1. Go to proc widget
2. Switch to memory values from %
3. Press `m`

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Change has been tested to work, and does not cause new breakage unless intended_
- [ ] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
