### PR TITLE
Show Celcius/Fahrenheit with degree symbol

### DIFF
--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -93,9 +93,9 @@ pub fn convert_temp_row(app: &App) -> Vec<Vec<String>> {
                 temp_harvest.name.clone(),
                 (temp_harvest.temperature.ceil() as u64).to_string()
                     + match temp_type {
-                        data_harvester::temperature::TemperatureType::Celsius => "C",
+                        data_harvester::temperature::TemperatureType::Celsius => "°C",
                         data_harvester::temperature::TemperatureType::Kelvin => "K",
-                        data_harvester::temperature::TemperatureType::Fahrenheit => "F",
+                        data_harvester::temperature::TemperatureType::Fahrenheit => "°F",
                     },
             ]
         })


### PR DESCRIPTION
## Description

Shows temperatures in Celsius/Fahrenheit with a degree symbol. (Kelvin is absolute, so it doesn't use a degree symbol.)

<img width="459" alt="Screenshot 2021-01-17 at 13 11 16" src="https://user-images.githubusercontent.com/16063/104840139-d6c57b00-58c5-11eb-98f4-99e151c94710.png">

## Issue

N/A
Closes: #

## Type of change

_Remove the irrelevant ones:_

- [ ] _Bug fix (non-breaking change which fixes an issue)_
- [ ] _New feature (non-breaking change which adds functionality)_
- [ ] _Breaking change (if this change causes breakage or new behaviour, please state what)_
- [ ] _Refactoring (a change that doesn't change application functionality)_
- [x] _Other_: Purely aesthetic

## Test methodology

_If relevant, please state how this was tested:_

Built and run.

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [X] _macOS_
- [ ] _Linux_

## Other information

N/A
