### PR TITLE
bug: Workaround for strange rendering when there are <4 CPU entries reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#372](https://github.com/ClementTsang/bottom/pull/372): Hides the SWAP graph and legend in normal mode if SWAP is 0.
 
 - [#390](https://github.com/ClementTsang/bottom/pull/390): macOS shouldn't need elevated privileges to see CPU usage on all processes now.
--
+
 - [#391](https://github.com/ClementTsang/bottom/pull/391): Show degree symbol on Celsius and Fahrenheit.
 
 ## [0.5.7] - Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#372](https://github.com/ClementTsang/bottom/pull/372): Hides the SWAP graph and legend in normal mode if SWAP is 0.
 
+- [#390](https://github.com/ClementTsang/bottom/pull/390): macOS shouldn't need elevated privileges to see CPU usage on all processes now.
+-
+- [#391](https://github.com/ClementTsang/bottom/pull/391): Show degree symbol on Celsius and Fahrenheit.
+
 ## Bug Fixes
 
 - [#373](https://github.com/ClementTsang/bottom/pull/373): Fixes incorrect colours being used the CPU widget in basic mode.
@@ -26,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#386](https://github.com/ClementTsang/bottom/pull/386): Fixes `hide_table_gap` not working in the battery widget.
 
 - [#389](https://github.com/ClementTsang/bottom/pull/389): Fixes the sorting arrow disappearing in proc widget under some cases.
+
+- [#398](https://github.com/ClementTsang/bottom/pull/398): Fixes basic mode failing to report CPUs if there are less than 4 entries to report.
 
 ## [0.5.6] - 2020-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 - [#391](https://github.com/ClementTsang/bottom/pull/391): Show degree symbol on Celsius and Fahrenheit.
 
+## [0.5.7] - Unreleased
+
 ## Bug Fixes
 
 - [#373](https://github.com/ClementTsang/bottom/pull/373): Fixes incorrect colours being used the CPU widget in basic mode.

--- a/src/app/data_harvester/cpu.rs
+++ b/src/app/data_harvester/cpu.rs
@@ -189,5 +189,6 @@ pub async fn get_cpu_data_list(
         })
     }
 
+    // Ok(Vec::from(cpu_deque.drain(0..5).collect::<Vec<_>>()))
     Ok(Vec::from(cpu_deque))
 }

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -520,18 +520,16 @@ impl Painter {
                     self.draw_frozen_indicator(&mut f, frozen_draw_loc);
                 }
 
+                let actual_cpu_data_len = app_state.canvas_data.cpu_data.len().saturating_sub(1);
+                let cpu_height = (actual_cpu_data_len / 4) as u16
+                    + (if actual_cpu_data_len % 4 == 0 { 0 } else { 1 });
+
                 let vertical_chunks = Layout::default()
                     .direction(Direction::Vertical)
+                    .margin(0)
                     .constraints([
-                        Constraint::Length(
-                            (app_state.canvas_data.cpu_data.len() / 4) as u16
-                                + (if app_state.canvas_data.cpu_data.len() % 4 == 0 {
-                                    0
-                                } else {
-                                    1
-                                }),
-                        ),
-                        Constraint::Length(1),
+                        Constraint::Length(cpu_height + if cpu_height <= 1 { 1 } else { 0 }), // This fixes #397, apparently if the height is 1, it can't render the CPU bars...
+                        Constraint::Length(if cpu_height <= 1 { 0 } else { 1 }),
                         Constraint::Length(2),
                         Constraint::Length(2),
                         Constraint::Min(5),

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -171,7 +171,7 @@ impl CpuBasicWidget for Painter {
                                         }
                                     } else {
                                         self.colours.cpu_colour_styles
-                                            [(itx - 1) % self.colours.cpu_colour_styles.len()]
+                                            [itx % self.colours.cpu_colour_styles.len()]
                                     },
                                 })
                             })


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_


So it seems that tui-rs doesn't like rendering my CPU bars if the height is exactly 1.  It needs at least 2.  I have no idea why, this is probably something weird with how I render.

This, of course, breaks when there is only one row to report (i.e. with a dual core setup in #397).

The workaround switches the gap between the CPU and mem/net parts to 0, and increases the CPU's draw height by 1, *only* when the height is otherwise 1 (so the draw height is now at least 2).  This does have the side effect of including an extra line to the side borders, but I think it's fine.

Before:
![image](https://user-images.githubusercontent.com/34804052/105668536-8349c300-5eab-11eb-983d-53153f8f60b6.png)

After:
![image](https://user-images.githubusercontent.com/34804052/105668511-77f69780-5eab-11eb-9614-9f7368138713.png)


## Issue

_If applicable, what issue does this address?_

Closes: #397

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
