### PR TITLE
feature: Add ctrl-w and ctrl-h support in the search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#406](https://github.com/ClementTsang/bottom/pull/406): Adds the Nord colour scheme, as well as a light variant.
 
+- [#409](https://github.com/ClementTsang/bottom/pull/409): Adds `Ctrl-w` and `Ctrl-h` shortcuts in search, to delete a word and delete a character respectively.
+
 ## Changes
 
 - [#372](https://github.com/ClementTsang/bottom/pull/372): Hides the SWAP graph and legend in normal mode if SWAP is 0.

--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ Use `btm --help` for more information.
 | `Ctrl-a`      | Skip to the start of the search query        |
 | `Ctrl-e`      | Skip to the end of the search query          |
 | `Ctrl-u`      | Clear the current search query               |
+| `Ctrl-w`      | Delete a word behind the cursor              |
+| `Ctrl-h`      | Delete the character behind the cursor       |
 | `Backspace`   | Delete the character behind the cursor       |
 | `Delete`      | Delete the character at the cursor           |
 | `Alt-c`, `F1` | Toggle matching case                         |

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -549,7 +549,7 @@ impl ProcessTableWidget for Painter {
                     })
                     .collect::<Vec<_>>();
 
-                if cursor_position >= query.len() {
+                if cursor_position == query.len() {
                     res.push(Span::styled(" ", currently_selected_text_style))
                 }
 
@@ -558,17 +558,7 @@ impl ProcessTableWidget for Painter {
                 // This is easier - we just need to get a range of graphemes, rather than
                 // dealing with possibly inserting a cursor (as none is shown!)
 
-                grapheme_indices
-                    .filter_map(|grapheme| {
-                        current_grapheme_posn += UnicodeWidthStr::width(grapheme.1);
-                        if current_grapheme_posn <= start_position {
-                            None
-                        } else {
-                            let styled = Span::styled(grapheme.1, text_style);
-                            Some(styled)
-                        }
-                    })
-                    .collect::<Vec<_>>()
+                vec![Span::styled(query.to_string(), text_style)]
             }
         }
 
@@ -622,6 +612,7 @@ impl ProcessTableWidget for Painter {
                     },
                 )];
                 search_vec.extend(query_with_cursor);
+
                 search_vec
             })];
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -271,13 +271,15 @@ pub const PROCESS_HELP_TEXT: [&str; 14] = [
     "+, -, click      Collapse/expand a branch while in tree mode",
 ];
 
-pub const SEARCH_HELP_TEXT: [&str; 46] = [
+pub const SEARCH_HELP_TEXT: [&str; 48] = [
     "4 - Process search widget",
     "Tab              Toggle between searching for PID and name",
     "Esc              Close the search widget (retains the filter)",
     "Ctrl-a           Skip to the start of the search query",
     "Ctrl-e           Skip to the end of the search query",
     "Ctrl-u           Clear the current search query",
+    "Ctrl-w           Delete a word behind the cursor",
+    "Ctrl-h           Delete the character behind the cursor",
     "Backspace        Delete the character behind the cursor",
     "Delete           Delete the character at the cursor",
     "Alt-c, F1        Toggle matching case",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,8 @@ pub fn handle_key_event_or_break(
                 KeyCode::Char('a') => app.skip_cursor_beginning(),
                 KeyCode::Char('e') => app.skip_cursor_end(),
                 KeyCode::Char('u') => app.clear_search(),
+                KeyCode::Char('w') => app.clear_previous_word(),
+                KeyCode::Char('h') => app.on_backspace(),
                 // KeyCode::Char('j') => {}, // Move down
                 // KeyCode::Char('k') => {}, // Move up
                 // KeyCode::Char('h') => {}, // Move right


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

`Ctrl-w` deletes one word backwards from the current cursor location.  `Ctrl-h` is just an alias for backspace.

## Issue

_If applicable, what issue does this address?_

Closes: #270, also affects #407 

## Type of change

_Remove the irrelevant ones:_

- [x] _New feature (non-breaking change which adds functionality)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
