### PR TITLE
bug: fix inconsistent spacing with grouped vs non-grouped in the process widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#391](https://github.com/ClementTsang/bottom/pull/391): Show degree symbol on Celsius and Fahrenheit.
 
+## Bug Fixes
+
+- [#416](https://github.com/ClementTsang/bottom/pull/416): Fixes grouped vs ungrouped modes in the processes widget having inconsistent spacing.
+
 ## [0.5.7] - 2021-01-30
 
 ## Bug Fixes

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -52,7 +52,7 @@ static PROCESS_HEADERS_SOFT_WIDTH_MAX_GROUPED_COMMAND: Lazy<Vec<Option<f64>>> =
 static PROCESS_HEADERS_SOFT_WIDTH_MAX_GROUPED_TREE: Lazy<Vec<Option<f64>>> =
     Lazy::new(|| vec![None, Some(0.5), None, None, None, None, None, None]);
 static PROCESS_HEADERS_SOFT_WIDTH_MAX_GROUPED_ELSE: Lazy<Vec<Option<f64>>> =
-    Lazy::new(|| vec![None, Some(0.4), None, None, None, None, None, None]);
+    Lazy::new(|| vec![None, Some(0.3), None, None, None, None, None, None]);
 
 static PROCESS_HEADERS_SOFT_WIDTH_MAX_NO_GROUP_COMMAND: Lazy<Vec<Option<f64>>> = Lazy::new(|| {
     vec![
@@ -356,6 +356,7 @@ impl ProcessTableWidget for Painter {
                         .iter()
                         .map(|entry| UnicodeWidthStr::width(entry.as_str()) as u16)
                         .collect::<Vec<_>>();
+
                     let soft_widths_min = column_widths
                         .iter()
                         .map(|width| Some(*width))


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes grouped mode having different spacing than non-grouped mode.

Video below compares the fixed version (first one) to the release version (0.5.7):

https://user-images.githubusercontent.com/34804052/108430548-88323600-720f-11eb-8367-a194a220d7ad.mp4

## Issue

_If applicable, what issue does this address?_

Closes: #415 

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
