### PR TITLE
bug: Fix sorting menu and sort shortcuts desync if menu is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#416](https://github.com/ClementTsang/bottom/pull/416): Fixes grouped vs ungrouped modes in the processes widget having inconsistent spacing.
 
+- [#417](https://github.com/ClementTsang/bottom/pull/417): Fixes the sort menu and sort shortcuts not syncing up.
+
 ## [0.5.7] - 2021-01-30
 
 ## Bug Fixes

--- a/src/app.rs
+++ b/src/app.rs
@@ -700,8 +700,8 @@ impl App {
                     .widget_states
                     .get_mut(&(self.current_widget.widget_id - 2))
                 {
-                    self.proc_state.force_update = Some(self.current_widget.widget_id - 2);
                     proc_widget_state.update_sorting_with_columns();
+                    self.proc_state.force_update = Some(self.current_widget.widget_id - 2);
                     self.toggle_sort();
                 }
             }
@@ -1473,25 +1473,15 @@ impl App {
             }
             'c' => {
                 if let BottomWidgetType::Proc = self.current_widget.widget_type {
-                    // FIXME: There's a mismatch bug with this and all sorting types when using the keybind vs the sorting menu.
-                    // If the sorting menu is open, it won't update when using this!
                     if let Some(proc_widget_state) = self
                         .proc_state
                         .get_mut_widget_state(self.current_widget.widget_id)
                     {
-                        match proc_widget_state.process_sorting_type {
-                            processes::ProcessSorting::CpuPercent => {
-                                proc_widget_state.is_process_sort_descending =
-                                    !proc_widget_state.is_process_sort_descending
-                            }
-                            _ => {
-                                proc_widget_state.process_sorting_type =
-                                    processes::ProcessSorting::CpuPercent;
-                                proc_widget_state.is_process_sort_descending = true;
-                            }
-                        }
+                        proc_widget_state
+                            .columns
+                            .set_to_sorted_index_from_type(&processes::ProcessSorting::CpuPercent);
+                        proc_widget_state.update_sorting_with_columns();
                         self.proc_state.force_update = Some(self.current_widget.widget_id);
-
                         self.skip_to_first();
                     }
                 }
@@ -1502,25 +1492,17 @@ impl App {
                         .proc_state
                         .get_mut_widget_state(self.current_widget.widget_id)
                     {
-                        match proc_widget_state.process_sorting_type {
-                            processes::ProcessSorting::MemPercent
-                            | processes::ProcessSorting::Mem => {
-                                proc_widget_state.is_process_sort_descending =
-                                    !proc_widget_state.is_process_sort_descending
-                            }
-
-                            _ => {
-                                proc_widget_state.process_sorting_type = if proc_widget_state
-                                    .columns
-                                    .is_enabled(&processes::ProcessSorting::MemPercent)
-                                {
-                                    processes::ProcessSorting::MemPercent
-                                } else {
-                                    processes::ProcessSorting::Mem
-                                };
-                                proc_widget_state.is_process_sort_descending = true;
-                            }
-                        }
+                        proc_widget_state.columns.set_to_sorted_index_from_type(
+                            &(if proc_widget_state
+                                .columns
+                                .is_enabled(&processes::ProcessSorting::MemPercent)
+                            {
+                                processes::ProcessSorting::MemPercent
+                            } else {
+                                processes::ProcessSorting::Mem
+                            }),
+                        );
+                        proc_widget_state.update_sorting_with_columns();
                         self.proc_state.force_update = Some(self.current_widget.widget_id);
                         self.skip_to_first();
                     }
@@ -1534,17 +1516,10 @@ impl App {
                     {
                         // Skip if grouped
                         if !proc_widget_state.is_grouped {
-                            match proc_widget_state.process_sorting_type {
-                                processes::ProcessSorting::Pid => {
-                                    proc_widget_state.is_process_sort_descending =
-                                        !proc_widget_state.is_process_sort_descending
-                                }
-                                _ => {
-                                    proc_widget_state.process_sorting_type =
-                                        processes::ProcessSorting::Pid;
-                                    proc_widget_state.is_process_sort_descending = false;
-                                }
-                            }
+                            proc_widget_state
+                                .columns
+                                .set_to_sorted_index_from_type(&processes::ProcessSorting::Pid);
+                            proc_widget_state.update_sorting_with_columns();
                             self.proc_state.force_update = Some(self.current_widget.widget_id);
                             self.skip_to_first();
                         }
@@ -1585,22 +1560,14 @@ impl App {
                         .proc_state
                         .get_mut_widget_state(self.current_widget.widget_id)
                     {
-                        match proc_widget_state.process_sorting_type {
-                            processes::ProcessSorting::ProcessName
-                            | processes::ProcessSorting::Command => {
-                                proc_widget_state.is_process_sort_descending =
-                                    !proc_widget_state.is_process_sort_descending
-                            }
-                            _ => {
-                                proc_widget_state.process_sorting_type =
-                                    if proc_widget_state.is_using_command {
-                                        processes::ProcessSorting::Command
-                                    } else {
-                                        processes::ProcessSorting::ProcessName
-                                    };
-                                proc_widget_state.is_process_sort_descending = false;
-                            }
-                        }
+                        proc_widget_state.columns.set_to_sorted_index_from_type(
+                            &(if proc_widget_state.is_using_command {
+                                processes::ProcessSorting::Command
+                            } else {
+                                processes::ProcessSorting::ProcessName
+                            }),
+                        );
+                        proc_widget_state.update_sorting_with_columns();
                         self.proc_state.force_update = Some(self.current_widget.widget_id);
                         self.skip_to_first();
                     }

--- a/src/app/states.rs
+++ b/src/app/states.rs
@@ -507,7 +507,9 @@ impl ProcWidgetState {
                         // Also invert anything that uses alphabetical sorting by default.
                         self.is_process_sort_descending = false;
                     }
-                    _ => {}
+                    _ => {
+                        self.is_process_sort_descending = true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Fixes sorting menus and shortcuts not syncing correctly if the sorting window is open.

## Issue

_If applicable, what issue does this address?_

Closes: #414 

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
