### PR TITLE
change: Don't jump to top when using sort shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#391](https://github.com/ClementTsang/bottom/pull/391): Show degree symbol on Celsius and Fahrenheit.
 
+- [#418](https://github.com/ClementTsang/bottom/pull/418): Removed automatically jumping to the top of the list for process sort shortcuts. The standard behaviour is to now stay in place.
+
 ## Bug Fixes
 
 - [#416](https://github.com/ClementTsang/bottom/pull/416): Fixes grouped vs ungrouped modes in the processes widget having inconsistent spacing.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1482,7 +1482,6 @@ impl App {
                             .set_to_sorted_index_from_type(&processes::ProcessSorting::CpuPercent);
                         proc_widget_state.update_sorting_with_columns();
                         self.proc_state.force_update = Some(self.current_widget.widget_id);
-                        self.skip_to_first();
                     }
                 }
             }
@@ -1504,7 +1503,6 @@ impl App {
                         );
                         proc_widget_state.update_sorting_with_columns();
                         self.proc_state.force_update = Some(self.current_widget.widget_id);
-                        self.skip_to_first();
                     }
                 }
             }
@@ -1521,7 +1519,6 @@ impl App {
                                 .set_to_sorted_index_from_type(&processes::ProcessSorting::Pid);
                             proc_widget_state.update_sorting_with_columns();
                             self.proc_state.force_update = Some(self.current_widget.widget_id);
-                            self.skip_to_first();
                         }
                     }
                 }
@@ -1569,7 +1566,6 @@ impl App {
                         );
                         proc_widget_state.update_sorting_with_columns();
                         self.proc_state.force_update = Some(self.current_widget.widget_id);
-                        self.skip_to_first();
                     }
                 }
             }


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

For consistency, we now don't automatically jump to the top of the list when using a sort shortcut.  This behaviour already occurred with the sort menu and sorting by mouse clicks, so this is just now more consistent (and IMO less annoying, you can also always jump to the top via `gg`).

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Other (something else - please specify)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
