### PR TITLE
bug: Fix bugs with disk widget and disk encryption

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
     "GIGA",
     "Hamberg",
     "KIBI",
+    "LUKS",
     "Lukas",
     "MEBI",
     "MEBIBYTE",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#417](https://github.com/ClementTsang/bottom/pull/417): Fixes the sort menu and sort shortcuts not syncing up.
 
+- [#423](https://github.com/ClementTsang/bottom/pull/423): Fixes disk encryption causing the disk widget to fail or not properly map I/O statistics.
+
 ## [0.5.7] - 2021-01-30
 
 ## Bug Fixes

--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -361,13 +361,12 @@ impl DataCollector {
             self.data.swap = swap;
         }
 
+        debug!("Disks: {:?}", disk_res);
         if let Ok(disks) = disk_res {
-            debug!("Disks: {:?}", disks);
             self.data.disks = disks;
         }
 
         if let Ok(io) = io_res {
-            debug!("io: {:?}", io);
             self.data.io = io;
         }
 

--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -362,10 +362,12 @@ impl DataCollector {
         }
 
         if let Ok(disks) = disk_res {
+            debug!("Disks: {:?}", disks);
             self.data.disks = disks;
         }
 
         if let Ok(io) = io_res {
+            debug!("io: {:?}", io);
             self.data.io = io;
         }
 

--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -361,7 +361,6 @@ impl DataCollector {
             self.data.swap = swap;
         }
 
-        debug!("Disks: {:?}", disk_res);
         if let Ok(disks) = disk_res {
             self.data.disks = disks;
         }

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -69,6 +69,7 @@ pub async fn get_disk_usage(
                 // See if this disk is actually mounted elsewhere on Linux...
                 if cfg!(target_os = "linux") {
                     if let Ok(path) = std::fs::read_link(device) {
+                        debug!("CANON: {:?}", std::fs::canonicalize(path.clone()));
                         if let Ok(path) = std::fs::canonicalize(path) {
                             symlink = path.into_os_string();
                             symlink.as_os_str()

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -69,8 +69,12 @@ pub async fn get_disk_usage(
                 // See if this disk is actually mounted elsewhere on Linux...
                 if cfg!(target_os = "linux") {
                     if let Ok(path) = std::fs::read_link(device) {
-                        symlink = path.into_os_string();
-                        symlink.as_os_str()
+                        if let Ok(path) = std::fs::canonicalize(path) {
+                            symlink = path.into_os_string();
+                            symlink.as_os_str()
+                        } else {
+                            device
+                        }
                     } else {
                         device
                     }

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -63,7 +63,6 @@ pub async fn get_disk_usage(
     futures::pin_mut!(partitions_stream);
 
     while let Some(part) = partitions_stream.next().await {
-        debug!("part: {:?}", part);
         if let Ok(partition) = part {
             let name = (partition
                 .device()
@@ -71,14 +70,12 @@ pub async fn get_disk_usage(
                 .to_str()
                 .unwrap_or("Name Unavailable"))
             .to_string();
-            debug!("name: {}", name);
 
             let mount_point = (partition
                 .mount_point()
                 .to_str()
                 .unwrap_or("Name Unavailable"))
             .to_string();
-            debug!("mount_point: {}", mount_point);
 
             let to_keep = if let Some(filter) = name_filter {
                 let mut ret = filter.is_list_ignored;
@@ -94,17 +91,16 @@ pub async fn get_disk_usage(
             };
 
             if to_keep {
-                let usage = heim::disk::usage(partition.mount_point().to_path_buf()).await?;
-                debug!("usage: {:?}", usage);
-
-                vec_disks.push(DiskHarvest {
-                    free_space: usage.free().get::<heim::units::information::byte>(),
-                    used_space: usage.used().get::<heim::units::information::byte>(),
-                    total_space: usage.total().get::<heim::units::information::byte>(),
-                    mount_point,
-                    name,
-                });
-                debug!("vec_disks: {:?}", vec_disks);
+                // The usage line fails in some cases (Void linux + LUKS)
+                if let Ok(usage) = heim::disk::usage(partition.mount_point().to_path_buf()).await {
+                    vec_disks.push(DiskHarvest {
+                        free_space: usage.free().get::<heim::units::information::byte>(),
+                        used_space: usage.used().get::<heim::units::information::byte>(),
+                        total_space: usage.total().get::<heim::units::information::byte>(),
+                        mount_point,
+                        name,
+                    });
+                }
             }
         }
     }

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -31,11 +31,11 @@ pub async fn get_io_usage(actually_get: bool) -> crate::utils::error::Result<Opt
     futures::pin_mut!(counter_stream);
 
     while let Some(io) = counter_stream.next().await {
+        debug!("io: {:?}", io);
         if let Ok(io) = io {
             let mount_point = io.device_name().to_str().unwrap_or("Name Unavailable");
 
             // FIXME: [MOUNT POINT] Add the filter here I guess?
-
             io_hash.insert(
                 mount_point.to_string(),
                 Some(IOData {

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -90,11 +90,8 @@ pub async fn get_disk_usage(
                 true
             };
 
-            debug!("to_keep: {}", to_keep);
-
             if to_keep {
                 let usage = heim::disk::usage(partition.mount_point().to_path_buf()).await?;
-                debug!("usage: {:?}", usage);
 
                 vec_disks.push(DiskHarvest {
                     free_space: usage.free().get::<heim::units::information::byte>(),

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -63,6 +63,7 @@ pub async fn get_disk_usage(
     futures::pin_mut!(partitions_stream);
 
     while let Some(part) = partitions_stream.next().await {
+        debug!("part: {:?}", part);
         if let Ok(partition) = part {
             let name = (partition
                 .device()
@@ -70,12 +71,14 @@ pub async fn get_disk_usage(
                 .to_str()
                 .unwrap_or("Name Unavailable"))
             .to_string();
+            debug!("name: {}", name);
 
             let mount_point = (partition
                 .mount_point()
                 .to_str()
                 .unwrap_or("Name Unavailable"))
             .to_string();
+            debug!("mount_point: {}", mount_point);
 
             let to_keep = if let Some(filter) = name_filter {
                 let mut ret = filter.is_list_ignored;
@@ -92,6 +95,7 @@ pub async fn get_disk_usage(
 
             if to_keep {
                 let usage = heim::disk::usage(partition.mount_point().to_path_buf()).await?;
+                debug!("usage: {:?}", usage);
 
                 vec_disks.push(DiskHarvest {
                     free_space: usage.free().get::<heim::units::information::byte>(),
@@ -100,6 +104,7 @@ pub async fn get_disk_usage(
                     mount_point,
                     name,
                 });
+                debug!("vec_disks: {:?}", vec_disks);
             }
         }
     }

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -31,7 +31,6 @@ pub async fn get_io_usage(actually_get: bool) -> crate::utils::error::Result<Opt
     futures::pin_mut!(counter_stream);
 
     while let Some(io) = counter_stream.next().await {
-        debug!("io: {:?}", io);
         if let Ok(io) = io {
             let mount_point = io.device_name().to_str().unwrap_or("Name Unavailable");
 
@@ -64,8 +63,6 @@ pub async fn get_disk_usage(
     futures::pin_mut!(partitions_stream);
 
     while let Some(part) = partitions_stream.next().await {
-        debug!("partition: {:?}", part);
-
         if let Ok(partition) = part {
             let name = (partition
                 .device()
@@ -73,12 +70,14 @@ pub async fn get_disk_usage(
                 .to_str()
                 .unwrap_or("Name Unavailable"))
             .to_string();
+            debug!("Partition name: {}", name);
 
             let mount_point = (partition
                 .mount_point()
                 .to_str()
                 .unwrap_or("Name Unavailable"))
             .to_string();
+            debug!("Mount point: {}", name);
 
             let to_keep = if let Some(filter) = name_filter {
                 let mut ret = filter.is_list_ignored;

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -70,14 +70,12 @@ pub async fn get_disk_usage(
                 .to_str()
                 .unwrap_or("Name Unavailable"))
             .to_string();
-            debug!("Partition name: {}", name);
 
             let mount_point = (partition
                 .mount_point()
                 .to_str()
                 .unwrap_or("Name Unavailable"))
             .to_string();
-            debug!("Mount point: {}", name);
 
             let to_keep = if let Some(filter) = name_filter {
                 let mut ret = filter.is_list_ignored;
@@ -92,8 +90,12 @@ pub async fn get_disk_usage(
                 true
             };
 
+            debug!("to_keep: {}", to_keep);
+
             if to_keep {
                 let usage = heim::disk::usage(partition.mount_point().to_path_buf()).await?;
+                debug!("usage: {:?}", usage);
+
                 vec_disks.push(DiskHarvest {
                     free_space: usage.free().get::<heim::units::information::byte>(),
                     used_space: usage.used().get::<heim::units::information::byte>(),

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -73,6 +73,7 @@ pub async fn get_disk_usage(
                     if let Ok(path) = std::fs::read_link(device) {
                         let mut combined_path = std::path::PathBuf::new();
                         combined_path.push(device);
+                        combined_path.pop();
                         combined_path.push(path.clone());
 
                         if let Ok(path) = std::fs::canonicalize(combined_path) {

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -31,6 +31,7 @@ pub async fn get_io_usage(actually_get: bool) -> crate::utils::error::Result<Opt
     futures::pin_mut!(counter_stream);
 
     while let Some(io) = counter_stream.next().await {
+        debug!("io: {:?}", io);
         if let Ok(io) = io {
             let mount_point = io.device_name().to_str().unwrap_or("Name Unavailable");
 
@@ -63,6 +64,8 @@ pub async fn get_disk_usage(
     futures::pin_mut!(partitions_stream);
 
     while let Some(part) = partitions_stream.next().await {
+        debug!("partition: {:?}", part);
+
         if let Ok(partition) = part {
             let name = (partition
                 .device()

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -67,7 +67,7 @@ pub async fn get_disk_usage(
 
             let name = (if let Some(device) = partition.device() {
                 // See if this disk is actually mounted elsewhere on Linux...
-                // This is part of a workaround to properly map I/O, see
+                // This is a workaround to properly map I/O in some cases (i.e. disk encryption), see
                 // https://github.com/ClementTsang/bottom/issues/419
                 if cfg!(target_os = "linux") {
                     if let Ok(path) = std::fs::read_link(device) {

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -116,20 +116,36 @@ pub fn convert_disk_row(current_data: &data_farmer::DataCollection) -> Vec<Vec<S
         .iter()
         .zip(&current_data.io_labels)
         .for_each(|(disk, (io_read, io_write))| {
-            let converted_free_space = get_simple_byte_values(disk.free_space, false);
-            let converted_total_space = get_simple_byte_values(disk.total_space, false);
-            disk_vector.push(vec![
-                disk.name.to_string(),
-                disk.mount_point.to_string(),
-                format!(
-                    "{:.0}%",
-                    disk.used_space as f64 / disk.total_space as f64 * 100_f64
-                ),
-                format!("{:.*}{}", 0, converted_free_space.0, converted_free_space.1),
+            let free_space_fmt = if let Some(free_space) = disk.free_space {
+                let converted_free_space = get_simple_byte_values(free_space, false);
+                format!("{:.*}{}", 0, converted_free_space.0, converted_free_space.1)
+            } else {
+                "N/A".to_string()
+            };
+            let total_space_fmt = if let Some(total_space) = disk.total_space {
+                let converted_total_space = get_simple_byte_values(total_space, false);
                 format!(
                     "{:.*}{}",
                     0, converted_total_space.0, converted_total_space.1
-                ),
+                )
+            } else {
+                "N/A".to_string()
+            };
+
+            let usage_fmt = if let (Some(used_space), Some(total_space)) =
+                (disk.used_space, disk.total_space)
+            {
+                format!("{:.0}%", used_space as f64 / total_space as f64 * 100_f64)
+            } else {
+                "N/A".to_string()
+            };
+
+            disk_vector.push(vec![
+                disk.name.to_string(),
+                disk.mount_point.to_string(),
+                usage_fmt,
+                free_space_fmt,
+                total_space_fmt,
                 io_read.to_string(),
                 io_write.to_string(),
             ]);


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant, please provide screenshots of what results from the change:_

Two issues were highlighted as a result of using either Void Linux with disk encryption, or just disk encryption on Linux in general:

Two fixes:
1. Fixes a failed `usage()` call in the `get_disk_usage` function from failing the entire result.  Now it only returns an entry with N/A results.  This occurred in some distros and disk encryption setups, for example, [the one for Void Linux](https://docs.voidlinux.org/installation/guides/fde.html).
2. Fixes a potential mapping issue with disk encryption on Linux in general.  Since the disk might map to `/dev/mapper/whatever`, but the I/O harvester was using another name, the mappings would not match.  As such, we now also check if a symlink exists; if it does, then we take it and work out the correct path.  This also fixes the disk name being wrong.

Void Linux + LUKS:
![image](https://user-images.githubusercontent.com/34804052/109086416-8a960380-76d9-11eb-8e1b-f4138a19e976.png)

PopOS with disk encryption:
![image](https://user-images.githubusercontent.com/34804052/109087027-ae0d7e00-76da-11eb-9cde-ad9c426d299b.png)

## Issue

_If applicable, what issue does this address?_

#419 

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
