### PR TITLE
Fix getpwuid segfault

### DIFF
--- a/src/app/data_harvester/processes.rs
+++ b/src/app/data_harvester/processes.rs
@@ -138,7 +138,7 @@ impl UserTable {
             let passwd = unsafe { libc::getpwuid(uid) };
 
             if passwd.is_null() {
-                return Err(BottomError::QueryError("Missing passwd".into()))
+                return Err(BottomError::QueryError("Missing passwd".into()));
             }
 
             let username = unsafe { std::ffi::CStr::from_ptr((*passwd).pw_name) }

--- a/src/app/data_harvester/processes.rs
+++ b/src/app/data_harvester/processes.rs
@@ -138,7 +138,7 @@ impl UserTable {
             let passwd = unsafe { libc::getpwuid(uid) };
 
             if passwd.is_null() {
-                return Err(BottomError::QueryError("Missing passwd".into()));
+                return Err(error::BottomError::QueryError("Missing passwd".into()));
             }
 
             let username = unsafe { std::ffi::CStr::from_ptr((*passwd).pw_name) }


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Fixes a rare segfault if a uid does not have a passwd entry. The unsafe block [here](https://github.com/ClementTsang/bottom/blob/master/src/app/data_harvester/processes.rs#L137) can return a null pointer as specified [here](https://www.gnu.org/software/libc/manual/html_node/Lookup-User.html). 

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [X] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [X] _Change has been tested to work, and does not cause new breakage unless intended_
- [X] _Code has been self-reviewed_
- [X] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [X] _Passes CI pipeline (clippy check and `cargo test` check)_
- [X] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [X] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
