### PR TITLE
change: Make proc widget unit consistent with disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#437](https://github.com/ClementTsang/bottom/pull/437): Add linear interpolation step in drawing step to pr event missing entries on the right side of charts.
 
+- [#443](https://github.com/ClementTsang/bottom/pull/443): Make process widget consistent with disk widget in using decimal prefixes (kilo, mega, etc.) for memory usage and writes/reads.
+
 ## Bug Fixes
 
 - [#416](https://github.com/ClementTsang/bottom/pull/416): Fixes grouped vs ungrouped modes in the processes widget having inconsistent spacing.

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -588,10 +588,10 @@ pub fn convert_process_data(
         existing_converted_process_data.keys().copied().collect();
 
     for process in &current_data.process_harvest {
-        let converted_rps = get_binary_bytes(process.read_bytes_per_sec);
-        let converted_wps = get_binary_bytes(process.write_bytes_per_sec);
-        let converted_total_read = get_binary_bytes(process.total_read_bytes);
-        let converted_total_write = get_binary_bytes(process.total_write_bytes);
+        let converted_rps = get_decimal_bytes(process.read_bytes_per_sec);
+        let converted_wps = get_decimal_bytes(process.write_bytes_per_sec);
+        let converted_total_read = get_decimal_bytes(process.total_read_bytes);
+        let converted_total_write = get_decimal_bytes(process.total_write_bytes);
 
         let read_per_sec = format!("{:.*}{}/s", 0, converted_rps.0, converted_rps.1);
         let write_per_sec = format!("{:.*}{}/s", 0, converted_wps.0, converted_wps.1);
@@ -600,6 +600,8 @@ pub fn convert_process_data(
             "{:.*}{}",
             0, converted_total_write.0, converted_total_write.1
         );
+
+        let mem_usage_str = get_decimal_bytes(process.mem_usage_bytes);
 
         let user = {
             #[cfg(target_family = "unix")]
@@ -626,7 +628,7 @@ pub fn convert_process_data(
                 process_entry.cpu_percent_usage = process.cpu_usage_percent;
                 process_entry.mem_percent_usage = process.mem_usage_percent;
                 process_entry.mem_usage_bytes = process.mem_usage_bytes;
-                process_entry.mem_usage_str = get_binary_bytes(process.mem_usage_bytes);
+                process_entry.mem_usage_str = mem_usage_str;
                 process_entry.group_pids = vec![process.pid];
                 process_entry.read_per_sec = read_per_sec;
                 process_entry.write_per_sec = write_per_sec;
@@ -652,7 +654,7 @@ pub fn convert_process_data(
                     cpu_percent_usage: process.cpu_usage_percent,
                     mem_percent_usage: process.mem_usage_percent,
                     mem_usage_bytes: process.mem_usage_bytes,
-                    mem_usage_str: get_binary_bytes(process.mem_usage_bytes),
+                    mem_usage_str,
                     group_pids: vec![process.pid],
                     read_per_sec,
                     write_per_sec,
@@ -682,7 +684,7 @@ pub fn convert_process_data(
                     cpu_percent_usage: process.cpu_usage_percent,
                     mem_percent_usage: process.mem_usage_percent,
                     mem_usage_bytes: process.mem_usage_bytes,
-                    mem_usage_str: get_binary_bytes(process.mem_usage_bytes),
+                    mem_usage_str,
                     group_pids: vec![process.pid],
                     read_per_sec,
                     write_per_sec,


### PR DESCRIPTION
In particular, use non-binary prefixes for disk and memory usage in a process.  Ideally everything is configurable by the user, but this is fine for now IMO until I can get around to doing in-app config.

## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Other (something else - please specify)_ Just makes this consistent with disk widget.

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
