### PR TITLE
change: Add decimal to actual memory usage in proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#443](https://github.com/ClementTsang/bottom/pull/443): Make process widget consistent with disk widget in using decimal prefixes (kilo, mega, etc.) for memory usage and writes/reads.
 
-- [#449](https://github.com/ClementTsang/bottom/pull/449): Add decimal place to actual memory usage in process widget.
+- [#449](https://github.com/ClementTsang/bottom/pull/449): Add decimal place to actual memory usage in process widget for values greater or equal to 1GiB.
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#443](https://github.com/ClementTsang/bottom/pull/443): Make process widget consistent with disk widget in using decimal prefixes (kilo, mega, etc.) for memory usage and writes/reads.
 
+- [#449](https://github.com/ClementTsang/bottom/pull/449): Add decimal place to actual memory usage in process widget.
+
 ## Bug Fixes
 
 - [#416](https://github.com/ClementTsang/bottom/pull/416): Fixes grouped vs ungrouped modes in the processes widget having inconsistent spacing.

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -1236,7 +1236,7 @@ pub fn stringify_process_data(
                     (format!("{:.1}%", process.cpu_percent_usage), None),
                     (
                         if mem_enabled {
-                            if process.mem_usage_str.0 < 0.05 {
+                            if process.mem_usage_bytes <= GIBI_LIMIT {
                                 format!("{:.0}{}", process.mem_usage_str.0, process.mem_usage_str.1)
                             } else {
                                 format!("{:.1}{}", process.mem_usage_str.0, process.mem_usage_str.1)

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -617,7 +617,7 @@ pub fn convert_process_data(
             process.total_write_bytes,
         );
 
-        let mem_usage_str = get_decimal_bytes(process.mem_usage_bytes);
+        let mem_usage_str = get_binary_bytes(process.mem_usage_bytes);
 
         let user = {
             #[cfg(target_family = "unix")]
@@ -1236,7 +1236,11 @@ pub fn stringify_process_data(
                     (format!("{:.1}%", process.cpu_percent_usage), None),
                     (
                         if mem_enabled {
-                            format!("{:.0}{}", process.mem_usage_str.0, process.mem_usage_str.1)
+                            if process.mem_usage_str.0 < 0.05 {
+                                format!("{:.0}{}", process.mem_usage_str.0, process.mem_usage_str.1)
+                            } else {
+                                format!("{:.1}{}", process.mem_usage_str.0, process.mem_usage_str.1)
+                            }
                         } else {
                             format!("{:.1}%", process.mem_percent_usage)
                         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,7 @@ pub fn handle_force_redraws(app: &mut App) {
         app.cpu_state.force_update = None;
     }
 
-    // FIXME: [OPT] Prefer reassignment over new vecs?
+    // FIXME: [OPT] Prefer reassignment over new vectors?
     if app.mem_state.force_update.is_some() {
         app.canvas_data.mem_data = convert_mem_data_points(&app.data_collection, app.is_frozen);
         app.canvas_data.swap_data = convert_swap_data_points(&app.data_collection, app.is_frozen);


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

~~This change adds a decimal + single digit to memory usage in the process widget.  Note that this only affects all cases where the value is less than 0.05, so we don't have `0.0B` displayed.  Otherwise, it's a fairly straightforward change.~~

This change adds a decimal + single digit to memory usage values over the 1 GiB threshold.  Otherwise, there is no visible change.

(Note to self: implement the per-column width system soon, this change causes some values to potentially look a bit weird in mem-non-percent mode as it is if the value is really large, like 530.2GiB pushing right up against the column width, but it's currently tied to mem-percent mode.  Ugh.)

Also revert a change made by accident where I switched to a decimal prefix system (GB) for memory values.  This has been reverted back to a binary prefix (GiB).

![image](https://user-images.githubusercontent.com/34804052/114230456-28225b00-9947-11eb-82f8-e98aa847739c.png)

## Issue

_If applicable, what issue does this address?_

Closes: #448 

## Type of change

_Remove the irrelevant ones:_

- [x] _Other (something else - please specify)_ Small change to add a decimal place to memory usage values

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [x] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
