### PR TITLE
change: Add decimal to disk values larger than 1GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#449](https://github.com/ClementTsang/bottom/pull/449): Add decimal place to actual memory usage in process widget for values greater or equal to 1GiB.
 
+- [#450](https://github.com/ClementTsang/bottom/pull/450): Tweak `default-light` colour scheme to look less terrible on white terminals.
+
 ## Bug Fixes
 
 - [#416](https://github.com/ClementTsang/bottom/pull/416): Fixes grouped vs ungrouped modes in the processes widget having inconsistent spacing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#450](https://github.com/ClementTsang/bottom/pull/450): Tweak `default-light` colour scheme to look less terrible on white terminals.
 
+- [#451](https://github.com/ClementTsang/bottom/pull/451): Add decimal place to disk values larger than 1GB for total read/write in process widgets, and read/write per second in process widgets and disk widgets.
+
 ## Bug Fixes
 
 - [#416](https://github.com/ClementTsang/bottom/pull/416): Fixes grouped vs ungrouped modes in the processes widget having inconsistent spacing.

--- a/src/app/data_farmer.rs
+++ b/src/app/data_farmer.rs
@@ -19,7 +19,7 @@ use std::{time::Instant, vec::Vec};
 use crate::app::data_harvester::load_avg::LoadAvgHarvest;
 use crate::{
     data_harvester::{batteries, cpu, disks, load_avg, mem, network, processes, temperature, Data},
-    utils::gen_util::get_decimal_bytes,
+    utils::gen_util::{get_decimal_bytes, GIGA_LIMIT},
 };
 use regex::Regex;
 
@@ -296,8 +296,16 @@ impl DataCollection {
                             let converted_read = get_decimal_bytes(r_rate);
                             let converted_write = get_decimal_bytes(w_rate);
                             *io_labels = (
-                                format!("{:.*}{}/s", 0, converted_read.0, converted_read.1),
-                                format!("{:.*}{}/s", 0, converted_write.0, converted_write.1),
+                                if r_rate >= GIGA_LIMIT {
+                                    format!("{:.*}{}/s", 1, converted_read.0, converted_read.1)
+                                } else {
+                                    format!("{:.*}{}/s", 0, converted_read.0, converted_read.1)
+                                },
+                                if w_rate >= GIGA_LIMIT {
+                                    format!("{:.*}{}/s", 1, converted_write.0, converted_write.1)
+                                } else {
+                                    format!("{:.*}{}/s", 0, converted_write.0, converted_write.1)
+                                },
                             );
                         }
                     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -43,6 +43,21 @@ pub static DEFAULT_LIGHT_MODE_COLOUR_PALETTE: Lazy<ConfigColours> = Lazy::new(||
     selected_text_color: Some("white".to_string()),
     graph_color: Some("black".to_string()),
     disabled_text_color: Some("gray".to_string()),
+    ram_color: Some("blue".to_string()),
+    swap_color: Some("red".to_string()),
+    rx_color: Some("blue".to_string()),
+    tx_color: Some("red".to_string()),
+    rx_total_color: Some("LightBlue".to_string()),
+    tx_total_color: Some("LightRed".to_string()),
+    cpu_core_colors: Some(vec![
+        "LightMagenta".to_string(),
+        "LightBlue".to_string(),
+        "LightRed".to_string(),
+        "Cyan".to_string(),
+        "Green".to_string(),
+        "Blue".to_string(),
+        "Red".to_string(),
+    ]),
     ..ConfigColours::default()
 });
 

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -586,13 +586,32 @@ fn get_disk_io_strings(
     let converted_total_write = get_decimal_bytes(total_write);
 
     (
-        format!("{:.*}{}/s", 0, converted_rps.0, converted_rps.1),
-        format!("{:.*}{}/s", 0, converted_wps.0, converted_wps.1),
-        format!("{:.*}{}", 0, converted_total_read.0, converted_total_read.1),
-        format!(
-            "{:.*}{}",
-            0, converted_total_write.0, converted_total_write.1
-        ),
+        if rps >= GIGA_LIMIT {
+            format!("{:.*}{}/s", 1, converted_rps.0, converted_rps.1)
+        } else {
+            format!("{:.*}{}/s", 0, converted_rps.0, converted_rps.1)
+        },
+        if wps >= GIGA_LIMIT {
+            format!("{:.*}{}/s", 1, converted_wps.0, converted_wps.1)
+        } else {
+            format!("{:.*}{}/s", 0, converted_wps.0, converted_wps.1)
+        },
+        if total_read >= GIGA_LIMIT {
+            format!("{:.*}{}", 1, converted_total_read.0, converted_total_read.1)
+        } else {
+            format!("{:.*}{}", 0, converted_total_read.0, converted_total_read.1)
+        },
+        if total_write >= GIGA_LIMIT {
+            format!(
+                "{:.*}{}",
+                1, converted_total_write.0, converted_total_write.1
+            )
+        } else {
+            format!(
+                "{:.*}{}",
+                0, converted_total_write.0, converted_total_write.1
+            )
+        },
     )
 }
 


### PR DESCRIPTION

## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

A bit of a followup to #449, this adds decimal places for values over 1GB in regards to disk usage.  This affects the disk widget (for the read/write per second) and process widgets (total read, total write, read/write per second).

![image](https://user-images.githubusercontent.com/34804052/114233961-17281880-994c-11eb-87df-3d975cc6795f.png)


## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Other (something else - please specify)_ Small change

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
