### PR TITLE
bug: Fixes basic mode hitboxes being broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#425](https://github.com/ClementTsang/bottom/pull/425): Fixed a bug allowing grouped mode in tree mode if already in grouped mode.
 
+- [#458](https://github.com/ClementTsang/bottom/pull/458): Fix basic mode having really broken click bounding boxes.
+
 ## [0.5.7] - 2021-01-30
 
 ## Bug Fixes

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -536,24 +536,15 @@ impl Painter {
                 }
 
                 let actual_cpu_data_len = app_state.canvas_data.cpu_data.len().saturating_sub(1);
-
-                // This fixes #397, apparently if the height is 1, it can't render the CPU bars...
-                let cpu_height = {
-                    let c = (actual_cpu_data_len / 4) as u16
-                        + (if actual_cpu_data_len % 4 == 0 { 0 } else { 1 });
-
-                    if c <= 1 {
-                        1
-                    } else {
-                        c
-                    }
-                };
+                let cpu_height = (actual_cpu_data_len / 4) as u16
+                    + (if actual_cpu_data_len % 4 == 0 { 0 } else { 1 });
 
                 let vertical_chunks = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
                     .constraints([
-                        Constraint::Length(cpu_height),
+                        Constraint::Length(cpu_height + if cpu_height <= 1 { 1 } else { 0 }), // This fixes #397, apparently if the height is 1, it can't render the CPU bars...
+                        Constraint::Length(if cpu_height <= 1 { 0 } else { 1 }),
                         Constraint::Length(2),
                         Constraint::Length(2),
                         Constraint::Min(5),
@@ -563,7 +554,7 @@ impl Painter {
                 let middle_chunks = Layout::default()
                     .direction(Direction::Horizontal)
                     .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                    .split(vertical_chunks[1]);
+                    .split(vertical_chunks[2]);
                 self.draw_basic_cpu(&mut f, app_state, vertical_chunks[0], 1);
                 self.draw_basic_memory(&mut f, app_state, middle_chunks[0], 2);
                 self.draw_basic_network(&mut f, app_state, middle_chunks[1], 3);
@@ -576,7 +567,7 @@ impl Painter {
                         Disk => self.draw_disk_table(
                             &mut f,
                             app_state,
-                            vertical_chunks[3],
+                            vertical_chunks[4],
                             false,
                             widget_id,
                         ),
@@ -590,7 +581,7 @@ impl Painter {
                             self.draw_process_features(
                                 &mut f,
                                 app_state,
-                                vertical_chunks[3],
+                                vertical_chunks[4],
                                 false,
                                 wid,
                             );
@@ -598,14 +589,14 @@ impl Painter {
                         Temp => self.draw_temp_table(
                             &mut f,
                             app_state,
-                            vertical_chunks[3],
+                            vertical_chunks[4],
                             false,
                             widget_id,
                         ),
                         Battery => self.draw_battery_display(
                             &mut f,
                             app_state,
-                            vertical_chunks[3],
+                            vertical_chunks[4],
                             false,
                             widget_id,
                         ),
@@ -614,7 +605,7 @@ impl Painter {
                 }
 
                 if let Some(widget_id) = later_widget_id {
-                    self.draw_basic_table_arrows(&mut f, app_state, vertical_chunks[2], widget_id);
+                    self.draw_basic_table_arrows(&mut f, app_state, vertical_chunks[3], widget_id);
                 }
             } else {
                 // Draws using the passed in (or default) layout.

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -536,15 +536,24 @@ impl Painter {
                 }
 
                 let actual_cpu_data_len = app_state.canvas_data.cpu_data.len().saturating_sub(1);
-                let cpu_height = (actual_cpu_data_len / 4) as u16
-                    + (if actual_cpu_data_len % 4 == 0 { 0 } else { 1 });
+
+                // This fixes #397, apparently if the height is 1, it can't render the CPU bars...
+                let cpu_height = {
+                    let c = (actual_cpu_data_len / 4) as u16
+                        + (if actual_cpu_data_len % 4 == 0 { 0 } else { 1 });
+
+                    if c <= 1 {
+                        1
+                    } else {
+                        c
+                    }
+                };
 
                 let vertical_chunks = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
                     .constraints([
-                        Constraint::Length(cpu_height + if cpu_height <= 1 { 1 } else { 0 }), // This fixes #397, apparently if the height is 1, it can't render the CPU bars...
-                        Constraint::Length(if cpu_height <= 1 { 0 } else { 1 }),
+                        Constraint::Length(cpu_height),
                         Constraint::Length(2),
                         Constraint::Length(2),
                         Constraint::Min(5),
@@ -554,7 +563,7 @@ impl Painter {
                 let middle_chunks = Layout::default()
                     .direction(Direction::Horizontal)
                     .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                    .split(vertical_chunks[2]);
+                    .split(vertical_chunks[1]);
                 self.draw_basic_cpu(&mut f, app_state, vertical_chunks[0], 1);
                 self.draw_basic_memory(&mut f, app_state, middle_chunks[0], 2);
                 self.draw_basic_network(&mut f, app_state, middle_chunks[1], 3);
@@ -567,7 +576,7 @@ impl Painter {
                         Disk => self.draw_disk_table(
                             &mut f,
                             app_state,
-                            vertical_chunks[4],
+                            vertical_chunks[3],
                             false,
                             widget_id,
                         ),
@@ -581,7 +590,7 @@ impl Painter {
                             self.draw_process_features(
                                 &mut f,
                                 app_state,
-                                vertical_chunks[4],
+                                vertical_chunks[3],
                                 false,
                                 wid,
                             );
@@ -589,14 +598,14 @@ impl Painter {
                         Temp => self.draw_temp_table(
                             &mut f,
                             app_state,
-                            vertical_chunks[4],
+                            vertical_chunks[3],
                             false,
                             widget_id,
                         ),
                         Battery => self.draw_battery_display(
                             &mut f,
                             app_state,
-                            vertical_chunks[4],
+                            vertical_chunks[3],
                             false,
                             widget_id,
                         ),
@@ -605,7 +614,7 @@ impl Painter {
                 }
 
                 if let Some(widget_id) = later_widget_id {
-                    self.draw_basic_table_arrows(&mut f, app_state, vertical_chunks[3], widget_id);
+                    self.draw_basic_table_arrows(&mut f, app_state, vertical_chunks[2], widget_id);
                 }
             } else {
                 // Draws using the passed in (or default) layout.

--- a/src/canvas/widgets/basic_table_arrows.rs
+++ b/src/canvas/widgets/basic_table_arrows.rs
@@ -136,19 +136,18 @@ impl BasicTableArrows for Painter {
             );
 
             if app_state.should_get_widget_bounds() {
-                // The y is +1 as for some reason the height is 2... but we only want a height of 1.
                 if let Some(basic_table) = &mut app_state.basic_table_widget_state {
                     basic_table.left_tlc =
-                        Some((margined_draw_loc[0].x, margined_draw_loc[0].y + 1));
+                        Some((margined_draw_loc[0].x - 1, margined_draw_loc[0].y + 1));
                     basic_table.left_brc = Some((
-                        margined_draw_loc[0].x + margined_draw_loc[0].width,
-                        margined_draw_loc[0].y + 1 + margined_draw_loc[0].height,
+                        margined_draw_loc[0].x + margined_draw_loc[0].width - 1,
+                        margined_draw_loc[0].y + 1,
                     ));
                     basic_table.right_tlc =
-                        Some((margined_draw_loc[2].x, margined_draw_loc[2].y + 1));
+                        Some((margined_draw_loc[2].x - 1, margined_draw_loc[2].y + 1));
                     basic_table.right_brc = Some((
-                        margined_draw_loc[2].x + margined_draw_loc[2].width,
-                        margined_draw_loc[2].y + 1 + margined_draw_loc[2].height,
+                        margined_draw_loc[2].x + margined_draw_loc[2].width - 1,
+                        margined_draw_loc[2].y + 1,
                     ));
                 }
             }

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -199,7 +199,7 @@ impl CpuBasicWidget for Painter {
             if let Some(widget) = app_state.widget_map.get_mut(&widget_id) {
                 widget.top_left_corner = Some((draw_loc.x, draw_loc.y));
                 widget.bottom_right_corner =
-                    Some((draw_loc.x + draw_loc.width, draw_loc.y + draw_loc.height));
+                    Some((draw_loc.x + draw_loc.width - 1, draw_loc.y + draw_loc.height - 1));
             }
         }
     }

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -198,8 +198,10 @@ impl CpuBasicWidget for Painter {
             // Update draw loc in widget map
             if let Some(widget) = app_state.widget_map.get_mut(&widget_id) {
                 widget.top_left_corner = Some((draw_loc.x, draw_loc.y));
-                widget.bottom_right_corner =
-                    Some((draw_loc.x + draw_loc.width - 1, draw_loc.y + draw_loc.height - 1));
+                widget.bottom_right_corner = Some((
+                    draw_loc.x + draw_loc.width - 1,
+                    draw_loc.y + draw_loc.height - 1,
+                ));
             }
         }
     }

--- a/src/canvas/widgets/mem_basic.rs
+++ b/src/canvas/widgets/mem_basic.rs
@@ -122,8 +122,10 @@ impl MemBasicWidget for Painter {
         if app_state.should_get_widget_bounds() {
             if let Some(widget) = app_state.widget_map.get_mut(&widget_id) {
                 widget.top_left_corner = Some((draw_loc.x, draw_loc.y));
-                widget.bottom_right_corner =
-                    Some((draw_loc.x + draw_loc.width, draw_loc.y + draw_loc.height));
+                widget.bottom_right_corner = Some((
+                    draw_loc.x + draw_loc.width - 1,
+                    draw_loc.y + draw_loc.height - 1,
+                ));
             }
         }
     }

--- a/src/canvas/widgets/network_basic.rs
+++ b/src/canvas/widgets/network_basic.rs
@@ -70,8 +70,10 @@ impl NetworkBasicWidget for Painter {
         if app_state.should_get_widget_bounds() {
             if let Some(widget) = app_state.widget_map.get_mut(&widget_id) {
                 widget.top_left_corner = Some((draw_loc.x, draw_loc.y));
-                widget.bottom_right_corner =
-                    Some((draw_loc.x + draw_loc.width, draw_loc.y + draw_loc.height));
+                widget.bottom_right_corner = Some((
+                    draw_loc.x + draw_loc.width - 1,
+                    draw_loc.y + draw_loc.height - 1,
+                ));
             }
         }
     }


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Fixes basic mode having broken click hitboxes (they were 1 unit too long in both directions).  I'm pretty sure normal mode does too, but it's less noticeable due to bounding boxes.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
