### PR TITLE
other: adds advanced_kill to default config gen

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -430,7 +430,8 @@ pub const DEFAULT_BATTERY_LAYOUT: &str = r##"
 // Config and flags
 pub const DEFAULT_CONFIG_FILE_PATH: &str = "bottom/bottom.toml";
 
-pub const OLD_CONFIG_TEXT: &str = r##"# This is a default config file for bottom.  All of the settings are commented
+// TODO: Eventually deprecate this.
+pub const CONFIG_TEXT: &str = r##"# This is a default config file for bottom.  All of the settings are commented
 # out by default; if you wish to change them uncomment and modify as you see
 # fit.
 
@@ -495,6 +496,8 @@ pub const OLD_CONFIG_TEXT: &str = r##"# This is a default config file for bottom
 #network_use_bytes = false
 # Displays the network widget with a log scale.
 #network_use_log = false
+# Show a more advanced process kill screen
+#advanced_kill = false
 
 # These are all the components that support custom theming.  Note that colour support
 # will depend on terminal support.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ pub fn create_or_get_config(config_path: &Option<PathBuf>) -> error::Result<Conf
                 fs::create_dir_all(parent_path)?;
             }
             // fs::File::create(path)?.write_all(CONFIG_TOP_HEAD.as_bytes())?;
-            fs::File::create(path)?.write_all(OLD_CONFIG_TEXT.as_bytes())?;
+            fs::File::create(path)?.write_all(CONFIG_TEXT.as_bytes())?;
             Ok(Config::default())
         }
     } else {


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds `advanced_kill` to the default config gen.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Other (something else - please specify)_ really more of a documentation change

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Change has been tested to work, and does not cause new breakage unless intended_
- [ ] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
