### PR TITLE
other: make advanced kill default

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ Run using `btm`.
 Use `btm --help` for more information.
 
 ```
-        --advanced_kill                        Shows more options when killing a process on Unix-like systems.
         --autohide_time                        Temporarily shows the time scale in graphs.
     -b, --basic                                Hides graphs and uses a more basic look.
         --battery                              Shows the battery widget.
@@ -264,6 +263,7 @@ Use `btm --help` for more information.
     -t, --default_time_value <MS>              Default time value for graphs in ms.
         --default_widget_count <INT>           Sets the n'th selected widget type as the default.
         --default_widget_type <WIDGET TYPE>    Sets the default widget type, use --help for more info.
+        --disable_advanced_kill                Hides advanced options to stop a process on Unix-like systems.
         --disable_click                        Disables mouse clicks.
     -m, --dot_marker                           Uses a dot marker for graphs.
     -f, --fahrenheit                           Sets the temperature type to Fahrenheit.
@@ -576,35 +576,35 @@ The following options can be set under `[flags]` to achieve the same effect as p
 
 These are the following supported flag config values, which correspond to the flag of the same name described in [Flags](#flags):
 
-| Field                        | Type                                                                                           | Functionality                                                   |
-| ---------------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `hide_avg_cpu`               | Boolean                                                                                        | Hides the average CPU usage.                                    |
-| `dot_marker`                 | Boolean                                                                                        | Uses a dot marker for graphs.                                   |
-| `left_legend`                | Boolean                                                                                        | Puts the CPU chart legend to the left side.                     |
-| `current_usage`              | Boolean                                                                                        | Sets process CPU% to be based on current CPU%.                  |
-| `group_processes`            | Boolean                                                                                        | Groups processes with the same name by default.                 |
-| `case_sensitive`             | Boolean                                                                                        | Enables case sensitivity by default.                            |
-| `whole_word`                 | Boolean                                                                                        | Enables whole-word matching by default.                         |
-| `regex`                      | Boolean                                                                                        | Enables regex by default.                                       |
-| `basic`                      | Boolean                                                                                        | Hides graphs and uses a more basic look.                        |
-| `use_old_network_legend`     | Boolean                                                                                        | DEPRECATED - uses the older network legend.                     |
-| `battery`                    | Boolean                                                                                        | Shows the battery widget.                                       |
-| `rate`                       | Unsigned Int (represents milliseconds)                                                         | Sets a refresh rate in ms.                                      |
-| `default_time_value`         | Unsigned Int (represents milliseconds)                                                         | Default time value for graphs in ms.                            |
-| `time_delta`                 | Unsigned Int (represents milliseconds)                                                         | The amount in ms changed upon zooming.                          |
-| `temperature_type`           | String (one of ["k", "f", "c", "kelvin", "fahrenheit", "celsius"])                             | Sets the temperature unit type.                                 |
-| `default_widget_type`        | String (one of ["cpu", "proc", "net", "temp", "mem", "disk"], same as layout options)          | Sets the default widget type, use --help for more info.         |
-| `default_widget_count`       | Unsigned Int (represents which `default_widget_type`)                                          | Sets the n'th selected widget type as the default.              |
-| `disable_click`              | Boolean                                                                                        | Disables mouse clicks.                                          |
-| `color`                      | String (one of ["default", "default-light", "gruvbox", "gruvbox-light", "nord", "nord-light"]) | Use a color scheme, use --help for supported values.            |
-| `mem_as_value`               | Boolean                                                                                        | Defaults to showing process memory usage by value.              |
-| `tree`                       | Boolean                                                                                        | Defaults to showing the process widget in tree mode.            |
-| `show_table_scroll_position` | Boolean                                                                                        | Shows the scroll position tracker in table widgets.             |
-| `process_command`            | Boolean                                                                                        | Show processes as their commands by default.                    |
-| `advanced_kill`              | Boolean                                                                                        | Shows more options when killing a process on Unix-like systems. |
-| `network_use_binary_prefix`  | Boolean                                                                                        | Displays the network widget with binary prefixes.               |
-| `network_use_bytes`          | Boolean                                                                                        | Displays the network widget using bytes.                        |
-| `network_use_log`            | Boolean                                                                                        | Displays the network widget with a log scale.                   |
+| Field                        | Type                                                                                           | Functionality                                                  |
+| ---------------------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `hide_avg_cpu`               | Boolean                                                                                        | Hides the average CPU usage.                                   |
+| `dot_marker`                 | Boolean                                                                                        | Uses a dot marker for graphs.                                  |
+| `left_legend`                | Boolean                                                                                        | Puts the CPU chart legend to the left side.                    |
+| `current_usage`              | Boolean                                                                                        | Sets process CPU% to be based on current CPU%.                 |
+| `group_processes`            | Boolean                                                                                        | Groups processes with the same name by default.                |
+| `case_sensitive`             | Boolean                                                                                        | Enables case sensitivity by default.                           |
+| `whole_word`                 | Boolean                                                                                        | Enables whole-word matching by default.                        |
+| `regex`                      | Boolean                                                                                        | Enables regex by default.                                      |
+| `basic`                      | Boolean                                                                                        | Hides graphs and uses a more basic look.                       |
+| `use_old_network_legend`     | Boolean                                                                                        | DEPRECATED - uses the older network legend.                    |
+| `battery`                    | Boolean                                                                                        | Shows the battery widget.                                      |
+| `rate`                       | Unsigned Int (represents milliseconds)                                                         | Sets a refresh rate in ms.                                     |
+| `default_time_value`         | Unsigned Int (represents milliseconds)                                                         | Default time value for graphs in ms.                           |
+| `time_delta`                 | Unsigned Int (represents milliseconds)                                                         | The amount in ms changed upon zooming.                         |
+| `temperature_type`           | String (one of ["k", "f", "c", "kelvin", "fahrenheit", "celsius"])                             | Sets the temperature unit type.                                |
+| `default_widget_type`        | String (one of ["cpu", "proc", "net", "temp", "mem", "disk"], same as layout options)          | Sets the default widget type, use --help for more info.        |
+| `default_widget_count`       | Unsigned Int (represents which `default_widget_type`)                                          | Sets the n'th selected widget type as the default.             |
+| `disable_click`              | Boolean                                                                                        | Disables mouse clicks.                                         |
+| `color`                      | String (one of ["default", "default-light", "gruvbox", "gruvbox-light", "nord", "nord-light"]) | Use a color scheme, use --help for supported values.           |
+| `mem_as_value`               | Boolean                                                                                        | Defaults to showing process memory usage by value.             |
+| `tree`                       | Boolean                                                                                        | Defaults to showing the process widget in tree mode.           |
+| `show_table_scroll_position` | Boolean                                                                                        | Shows the scroll position tracker in table widgets.            |
+| `process_command`            | Boolean                                                                                        | Show processes as their commands by default.                   |
+| `disable_advanced_kill`      | Boolean                                                                                        | Hides advanced options to stop a process on Unix-like systems. |
+| `network_use_binary_prefix`  | Boolean                                                                                        | Displays the network widget with binary prefixes.              |
+| `network_use_bytes`          | Boolean                                                                                        | Displays the network widget using bytes.                       |
+| `network_use_log`            | Boolean                                                                                        | Displays the network widget with a log scale.                  |
 
 #### Theming
 

--- a/src/clap.rs
+++ b/src/clap.rs
@@ -187,12 +187,12 @@ Puts the CPU chart legend to the left side rather than the right side.\n\n",
 When searching for a process, enables regex by default.\n\n",
         );
 
-    let advanced_kill = Arg::with_name("advanced_kill")
-        .long("advanced_kill")
-        .help("Shows more options when killing a process on Unix-like systems.")
+    let disable_advanced_kill = Arg::with_name("disable_advanced_kill")
+        .long("disable_advanced_kill")
+        .help("Hides advanced options to stop a process on Unix-like systems.")
         .long_help(
             "\
-Shows more options when killing a process on Unix-like systems.\n\n",
+Hides advanced options to stop a process on Unix-like systems.  The only option shown is -15.\n\n",
         );
 
     let show_table_scroll_position = Arg::with_name("show_table_scroll_position")
@@ -441,7 +441,7 @@ Displays the network widget with binary prefixes (i.e. kibibits, mebibits) rathe
         .arg(hide_time)
         .arg(show_table_scroll_position)
         .arg(left_legend)
-        .arg(advanced_kill)
+        .arg(disable_advanced_kill)
         // .arg(no_write)
         .arg(rate)
         .arg(regex)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -496,8 +496,8 @@ pub const CONFIG_TEXT: &str = r##"# This is a default config file for bottom.  A
 #network_use_bytes = false
 # Displays the network widget with a log scale.
 #network_use_log = false
-# Show a more advanced process kill screen
-#advanced_kill = false
+# Hides advanced options to stop a process on Unix-like systems.
+#disable_advanced_kill = false
 
 # These are all the components that support custom theming.  Note that colour support
 # will depend on terminal support.

--- a/src/options.rs
+++ b/src/options.rs
@@ -158,7 +158,7 @@ pub struct ConfigFlags {
     pub process_command: Option<bool>,
 
     #[builder(default, setter(strip_option))]
-    pub advanced_kill: Option<bool>,
+    pub disable_advanced_kill: Option<bool>,
 
     #[builder(default, setter(strip_option))]
     pub network_use_bytes: Option<bool>,
@@ -285,7 +285,7 @@ pub fn build_app(
     let show_memory_as_values = get_mem_as_value(matches, config);
     let is_default_tree = get_is_default_tree(matches, config);
     let is_default_command = get_is_default_process_command(matches, config);
-    let is_advanced_kill = get_is_using_advanced_kill(matches, config);
+    let is_advanced_kill = !get_is_advanced_kill_disabled(matches, config);
 
     let network_unit_type = get_network_unit_type(matches, config);
     let network_scale_type = get_network_scale_type(matches, config);
@@ -1044,12 +1044,12 @@ fn get_is_default_process_command(matches: &clap::ArgMatches<'static>, config: &
     false
 }
 
-fn get_is_using_advanced_kill(matches: &clap::ArgMatches<'static>, config: &Config) -> bool {
-    if matches.is_present("advanced_kill") {
+fn get_is_advanced_kill_disabled(matches: &clap::ArgMatches<'static>, config: &Config) -> bool {
+    if matches.is_present("disable_advanced_kill") {
         return true;
     } else if let Some(flags) = &config.flags {
-        if let Some(advanced_kill) = flags.advanced_kill {
-            return advanced_kill;
+        if let Some(disable_advanced_kill) = flags.disable_advanced_kill {
+            return disable_advanced_kill;
         }
     }
     false


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

We make the advanced kill menu the default instead.  You can opt out with `disable_advanced_kill`.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Other (something else - please specify)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
