### PR TITLE
github: Remove strip from Windows deploy/nightly

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -96,7 +96,7 @@ jobs:
               target: "x86_64-pc-windows-msvc",
               cross: false,
             }
-          - { os: "windows-2019", target: "i686-pc-windows-msvc", cross: true }
+          - { os: "windows-2019", target: "i686-pc-windows-msvc", cross: false }
           - {
               os: "windows-2019",
               target: "x86_64-pc-windows-gnu",

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -193,11 +193,6 @@ jobs:
         run: |
           cp -r ./target/${{ matrix.triple.target }}/release/build/bottom-*/out completion
 
-      - name: Strip release binary (Windows x86-64/i686)
-        if: matrix.triple.os == 'windows-2019' && matrix.triple.target != 'aarch64-unknown-linux-gnu' && matrix.triple.target != 'armv7-unknown-linux-gnueabihf' && matrix.triple.target != 'powerpc64le-unknown-linux-gnu'
-        run: |
-          strip target/${{ matrix.triple.target }}/release/btm.exe
-
       - name: Strip release binary (macOS or Linux x86-64/i686)
         if: matrix.triple.os != 'windows-2019' && matrix.triple.target != 'aarch64-unknown-linux-gnu' && matrix.triple.target != 'armv7-unknown-linux-gnueabihf' && matrix.triple.target != 'powerpc64le-unknown-linux-gnu'
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,19 +82,19 @@ jobs:
           #     cross: true,
           #   }
           # - { os: "macOS-latest", target: "x86_64-apple-darwin", cross: false }
-          # - {
-          #     os: "windows-2019",
-          #     target: "x86_64-pc-windows-msvc",
-          #     cross: false,
-          #   }
-          - { os: "windows-2019", target: "i686-pc-windows-msvc", cross: true }
+          - {
+              os: "windows-2019",
+              target: "x86_64-pc-windows-msvc",
+              cross: false,
+            }
+          - { os: "windows-2019", target: "i686-pc-windows-msvc", cross: false }
           - {
               os: "windows-2019",
               target: "x86_64-pc-windows-gnu",
               cross: false,
             }
 
-          # aarch64
+          # # aarch64
           # - {
           #     os: "ubuntu-18.04",
           #     target: "aarch64-unknown-linux-gnu",

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,27 +61,27 @@ jobs:
       matrix:
         triple:
           # Standard x86-64 stuff, stable
-          # - {
-          #     os: "ubuntu-16.04",
-          #     target: "x86_64-unknown-linux-gnu",
-          #     cross: false,
-          #   }
-          # - {
-          #     os: "ubuntu-16.04",
-          #     target: "i686-unknown-linux-gnu",
-          #     cross: true,
-          #   }
-          # - {
-          #     os: "ubuntu-18.04",
-          #     target: "x86_64-unknown-linux-musl",
-          #     cross: false,
-          #   }
-          # - {
-          #     os: "ubuntu-18.04",
-          #     target: "i686-unknown-linux-musl",
-          #     cross: true,
-          #   }
-          # - { os: "macOS-latest", target: "x86_64-apple-darwin", cross: false }
+          - {
+              os: "ubuntu-16.04",
+              target: "x86_64-unknown-linux-gnu",
+              cross: false,
+            }
+          - {
+              os: "ubuntu-16.04",
+              target: "i686-unknown-linux-gnu",
+              cross: true,
+            }
+          - {
+              os: "ubuntu-18.04",
+              target: "x86_64-unknown-linux-musl",
+              cross: false,
+            }
+          - {
+              os: "ubuntu-18.04",
+              target: "i686-unknown-linux-musl",
+              cross: true,
+            }
+          - { os: "macOS-latest", target: "x86_64-apple-darwin", cross: false }
           - {
               os: "windows-2019",
               target: "x86_64-pc-windows-msvc",
@@ -94,26 +94,26 @@ jobs:
               cross: false,
             }
 
-          # # aarch64
-          # - {
-          #     os: "ubuntu-18.04",
-          #     target: "aarch64-unknown-linux-gnu",
-          #     cross: true,
-          #   }
+          # aarch64
+          - {
+              os: "ubuntu-18.04",
+              target: "aarch64-unknown-linux-gnu",
+              cross: true,
+            }
 
-          # # armv7
-          # - {
-          #     os: "ubuntu-18.04",
-          #     target: "armv7-unknown-linux-gnueabihf",
-          #     cross: true,
-          #   }
+          # armv7
+          - {
+              os: "ubuntu-18.04",
+              target: "armv7-unknown-linux-gnueabihf",
+              cross: true,
+            }
 
-          # # PowerPC 64 LE
-          # - {
-          #     os: "ubuntu-18.04",
-          #     target: "powerpc64le-unknown-linux-gnu",
-          #     cross: true,
-          #   }
+          # PowerPC 64 LE
+          - {
+              os: "ubuntu-18.04",
+              target: "powerpc64le-unknown-linux-gnu",
+              cross: true,
+            }
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,32 +61,32 @@ jobs:
       matrix:
         triple:
           # Standard x86-64 stuff, stable
-          - {
-              os: "ubuntu-16.04",
-              target: "x86_64-unknown-linux-gnu",
-              cross: false,
-            }
-          - {
-              os: "ubuntu-16.04",
-              target: "i686-unknown-linux-gnu",
-              cross: true,
-            }
-          - {
-              os: "ubuntu-18.04",
-              target: "x86_64-unknown-linux-musl",
-              cross: false,
-            }
-          - {
-              os: "ubuntu-18.04",
-              target: "i686-unknown-linux-musl",
-              cross: true,
-            }
-          - { os: "macOS-latest", target: "x86_64-apple-darwin", cross: false }
-          - {
-              os: "windows-2019",
-              target: "x86_64-pc-windows-msvc",
-              cross: false,
-            }
+          # - {
+          #     os: "ubuntu-16.04",
+          #     target: "x86_64-unknown-linux-gnu",
+          #     cross: false,
+          #   }
+          # - {
+          #     os: "ubuntu-16.04",
+          #     target: "i686-unknown-linux-gnu",
+          #     cross: true,
+          #   }
+          # - {
+          #     os: "ubuntu-18.04",
+          #     target: "x86_64-unknown-linux-musl",
+          #     cross: false,
+          #   }
+          # - {
+          #     os: "ubuntu-18.04",
+          #     target: "i686-unknown-linux-musl",
+          #     cross: true,
+          #   }
+          # - { os: "macOS-latest", target: "x86_64-apple-darwin", cross: false }
+          # - {
+          #     os: "windows-2019",
+          #     target: "x86_64-pc-windows-msvc",
+          #     cross: false,
+          #   }
           - { os: "windows-2019", target: "i686-pc-windows-msvc", cross: true }
           - {
               os: "windows-2019",
@@ -95,25 +95,25 @@ jobs:
             }
 
           # aarch64
-          - {
-              os: "ubuntu-18.04",
-              target: "aarch64-unknown-linux-gnu",
-              cross: true,
-            }
+          # - {
+          #     os: "ubuntu-18.04",
+          #     target: "aarch64-unknown-linux-gnu",
+          #     cross: true,
+          #   }
 
-          # armv7
-          - {
-              os: "ubuntu-18.04",
-              target: "armv7-unknown-linux-gnueabihf",
-              cross: true,
-            }
+          # # armv7
+          # - {
+          #     os: "ubuntu-18.04",
+          #     target: "armv7-unknown-linux-gnueabihf",
+          #     cross: true,
+          #   }
 
-          # PowerPC 64 LE
-          - {
-              os: "ubuntu-18.04",
-              target: "powerpc64le-unknown-linux-gnu",
-              cross: true,
-            }
+          # # PowerPC 64 LE
+          # - {
+          #     os: "ubuntu-18.04",
+          #     target: "powerpc64le-unknown-linux-gnu",
+          #     cross: true,
+          #   }
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -179,11 +179,6 @@ jobs:
         run: |
           cp -r ./target/${{ matrix.triple.target }}/release/build/bottom-*/out completion
 
-      - name: Strip release binary (Windows x86-64/i686)
-        if: matrix.triple.os == 'windows-2019' && matrix.triple.target != 'aarch64-unknown-linux-gnu' && matrix.triple.target != 'armv7-unknown-linux-gnueabihf' && matrix.triple.target != 'powerpc64le-unknown-linux-gnu'
-        run: |
-          strip target/${{ matrix.triple.target }}/release/btm.exe
-
       - name: Strip release binary (macOS or Linux x86-64/i686)
         if: matrix.triple.os != 'windows-2019' && matrix.triple.target != 'aarch64-unknown-linux-gnu' && matrix.triple.target != 'armv7-unknown-linux-gnueabihf' && matrix.triple.target != 'powerpc64le-unknown-linux-gnu'
         run: |


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Removes `strip` from the Windows build in deploy/nightly.  It seems to cause VirusTotal to report some [false positives](https://www.virustotal.com/gui/file/97dbaa07d3934166bc1bb50ecea6d1bd9dcd96109a20d3ecc0dfe506e8442c6c/detection).

[Meanwhile](https://www.virustotal.com/gui/file/8c320c2594c882c2b89df95e52810e20e6b6a3c0e1b82c592f1b2310bc63f0f6/detection), without `strip`.

Also updates some small stuff in the script.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Other (something else - please specify)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [ ] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
