### PR TITLE
bug: forgot to create memory usage string when collapsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - Unreleased
+
+## Bug Fixes
+
+- [#473](https://github.com/ClementTsang/bottom/pull/473): Fix missing string creation for memory usage in collapsed entries.
+
 ## [0.6.0] - 2021-05-09
 
 ## Features

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -1202,6 +1202,8 @@ pub fn tree_process_data(
                             p.tw_f64 as u64,
                         );
 
+                        p.mem_usage_str = get_binary_bytes(p.mem_usage_bytes);
+
                         p.read_per_sec = disk_io_strings.0;
                         p.write_per_sec = disk_io_strings.1;
                         p.total_read = disk_io_strings.2;


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds a line to actually *build* the string of the summed memory usage.  I forgot to make the string after summing the values.

Before:
![image](https://user-images.githubusercontent.com/34804052/117762292-dcd5c380-b1f6-11eb-8ae3-c7bcdf3c84c0.png)

After:
![image](https://user-images.githubusercontent.com/34804052/117762315-e5c69500-b1f6-11eb-9f36-1bb9e5e2af4a.png)


## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Bug fix (non-breaking change which fixes an issue)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Change has been tested to work, and does not cause new breakage unless intended_
- [x] _Code has been self-reviewed_
- [x] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
