### PR TITLE
github: add old Linux build to nightly/deploy for older glibc

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -63,6 +63,7 @@ jobs:
     name: build-release
     needs: [create-github-release]
     runs-on: ${{ matrix.triple.os }}
+    container: ${{ matrix.triple.container }}
     env:
       RUST_BACKTRACE: 1
     strategy:
@@ -74,6 +75,13 @@ jobs:
               os: "ubuntu-18.04",
               target: "x86_64-unknown-linux-gnu",
               cross: false,
+            }
+          - {
+              os: "ubuntu-18.04",
+              target: "x86_64-unknown-linux-gnu",
+              cross: false,
+              container: quay.io/pypa/manylinux2014_x86_64,
+              suffix: "2-17",
             }
           - {
               os: "ubuntu-18.04",
@@ -213,8 +221,8 @@ jobs:
         shell: bash
         run: |
           cp target/${{ matrix.triple.target }}/release/btm ./btm
-          tar -czvf bottom_${{ matrix.triple.target }}.tar.gz btm completion
-          echo "ASSET=bottom_${{ matrix.triple.target }}.tar.gz" >> $GITHUB_ENV
+          tar -czvf bottom_${{ matrix.triple.target }}${{ matrix.triple.suffix }}.tar.gz btm completion
+          echo "ASSET=bottom_${{ matrix.triple.target }}${{ matrix.triple.suffix }}.tar.gz" >> $GITHUB_ENV
 
       - name: Upload main release
         uses: actions/upload-release-asset@v1.0.1
@@ -273,14 +281,14 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Build Debian release (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu'
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == ''
         run: |
           cargo install cargo-deb --version 1.29.0
           cargo deb
           cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
 
       - name: Upload Debian file (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu'
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == ''
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,6 +63,7 @@ jobs:
     name: build-release
     needs: [create-github-release]
     runs-on: ${{ matrix.triple.os }}
+    container: ${{ matrix.triple.container }}
     env:
       RUST_BACKTRACE: 1
     strategy:
@@ -74,6 +75,13 @@ jobs:
               os: "ubuntu-18.04",
               target: "x86_64-unknown-linux-gnu",
               cross: false,
+            }
+          - {
+              os: "ubuntu-18.04",
+              target: "x86_64-unknown-linux-gnu",
+              cross: false,
+              container: quay.io/pypa/manylinux2014_x86_64,
+              suffix: "2-17",
             }
           - {
               os: "ubuntu-18.04",
@@ -208,8 +216,8 @@ jobs:
         shell: bash
         run: |
           cp target/${{ matrix.triple.target }}/release/btm ./btm
-          tar -czvf bottom_${{ matrix.triple.target }}.tar.gz btm completion
-          echo "ASSET=bottom_${{ matrix.triple.target }}.tar.gz" >> $GITHUB_ENV
+          tar -czvf bottom_${{ matrix.triple.target }}${{ matrix.triple.suffix }}.tar.gz btm completion
+          echo "ASSET=bottom_${{ matrix.triple.target }}${{ matrix.triple.suffix }}.tar.gz" >> $GITHUB_ENV
 
       # TODO: Move this elsewhere; do this all at once, and do not continue if any fails.  Store artifacts.  Do the same for deployment.
 
@@ -245,14 +253,14 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Build Debian release (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && github.event.inputs.isMock == 'false'
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container != ""
         run: |
           cargo install cargo-deb --version 1.29.0
           cargo deb
           cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
 
       - name: Upload Debian file (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && github.event.inputs.isMock == 'false'
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container != "" && github.event.inputs.isMock == 'false'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -260,80 +268,4 @@ jobs:
           upload_url: ${{ env.RELEASE_UPLOAD_URL }}
           asset_path: bottom_${{ env.RELEASE_VERSION }}_amd64.deb
           asset_name: bottom_${{ env.RELEASE_VERSION }}_amd64.deb
-          asset_content_type: application/octet-stream
-
-  # I don't like doing it like this but it's the most convenient...
-  old-glibc-build-release:
-    name: old-glibc-build-release
-    needs: [create-github-release]
-    runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2014_x86_64
-    env:
-      RUST_BACKTRACE: 1
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - uses: actions/setup-python@v2
-
-      - name: Get release download URL
-        uses: actions/download-artifact@v2
-        with:
-          name: artifacts
-          path: artifacts
-
-      - name: Set release upload URL and release version
-        shell: bash
-        run: |
-          release_upload_url="$(cat ./artifacts/release-upload-url)"
-          echo "RELEASE_UPLOAD_URL=$release_upload_url" >> $GITHUB_ENV
-          release_version="$(cat ./artifacts/release-version)"
-          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
-
-      - name: Validate release environment variables
-        run: |
-          echo "Release upload url: ${{ env.RELEASE_UPLOAD_URL }}"
-          echo "Release version: ${{ env.RELEASE_VERSION }}"
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          target: x86_64-unknown-linux-gnu
-
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --verbose --target=x86_64-unknown-linux-gnu --no-default-features
-          use-cross: ${{ matrix.triple.cross }}
-
-      - name: Move autocomplete to working directory
-        shell: bash
-        run: |
-          cp -r ./target/x86_64-unknown-linux-gnu/release/build/bottom-*/out completion
-
-      - name: Bundle release and completion
-        shell: bash
-        run: |
-          cp target/x86_64-unknown-linux-gnu/release/btm ./btm
-          tar -czvf bottom_x86_64-unknown-linux-gnu_glibc_2-17.tar.gz btm completion
-          echo "ASSET=bottom_x86_64-unknown-linux-gnu_glibc_2-17" >> $GITHUB_ENV
-
-      - name: Upload main release
-        if: github.event.inputs.isMock == 'false'
-        uses: actions/upload-release-asset@v1.0.1
-        id: upload
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
-          asset_path: ${{ env.ASSET }}
-          asset_name: ${{ env.ASSET }}
           asset_content_type: application/octet-stream

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -253,14 +253,14 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Build Debian release (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container != ''
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == ''
         run: |
           cargo install cargo-deb --version 1.29.0
           cargo deb
           cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
 
       - name: Upload Debian file (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container != '' && github.event.inputs.isMock == 'false'
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == '' && github.event.inputs.isMock == 'false'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Create artifacts directory
         run: mkdir artifacts
 
+      - name: Check if mock
+        run: echo ${{ github.events.inputs.isMock }}
+
       - name: Delete tag and release
         uses: dev-drprasad/delete-tag-and-release@v0.1.3
         if: ${{ github.events.inputs.isMock }} == 'false'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+    inputs:
+      isMock:
+        description: "Mock nightly run"
+        default: "false"
 
 jobs:
   create-github-release:
@@ -18,6 +22,7 @@ jobs:
 
       - name: Delete tag and release
         uses: dev-drprasad/delete-tag-and-release@v0.1.3
+        if: ${{ github.events.inputs.isMock }} == 'false'
         with:
           delete_release: true
           tag_name: nightly
@@ -30,6 +35,7 @@ jobs:
       - name: Create nightly GitHub release
         id: release
         uses: actions/create-release@v1
+        if: ${{ github.events.inputs.isMock }} == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -205,6 +211,7 @@ jobs:
       # TODO: Move this elsewhere; do this all at once, and do not continue if any fails.  Store artifacts.  Do the same for deployment.
 
       - name: Upload main release
+        if: ${{ github.events.inputs.isMock }} == 'false'
         uses: actions/upload-release-asset@v1.0.1
         id: upload
         env:
@@ -216,7 +223,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Build msi file (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc'
+        if: matrix.triple.target == 'x86_64-pc-windows-msvc' && ${{ github.events.inputs.isMock }} == 'false'
         shell: powershell
         run: |
           cargo install cargo-wix
@@ -224,7 +231,7 @@ jobs:
           cargo wix
 
       - name: Upload msi file (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc'
+        if: matrix.triple.target == 'x86_64-pc-windows-msvc' && ${{ github.events.inputs.isMock }} == 'false'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -235,14 +242,14 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Build Debian release (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu'
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && ${{ github.events.inputs.isMock }} == 'false'
         run: |
           cargo install cargo-deb --version 1.29.0
           cargo deb
           cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
 
       - name: Upload Debian file (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu'
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && ${{ github.events.inputs.isMock }} == 'false'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -317,6 +324,7 @@ jobs:
           echo "ASSET=bottom_x86_64-unknown-linux-gnu_glibc_2-17" >> $GITHUB_ENV
 
       - name: Upload main release
+        if: ${{ github.events.inputs.isMock }} == 'false'
         uses: actions/upload-release-asset@v1.0.1
         id: upload
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -253,14 +253,14 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Build Debian release (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container != ""
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container != ''
         run: |
           cargo install cargo-deb --version 1.29.0
           cargo deb
           cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
 
       - name: Upload Debian file (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container != "" && github.event.inputs.isMock == 'false'
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container != '' && github.event.inputs.isMock == 'false'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,11 +21,11 @@ jobs:
         run: mkdir artifacts
 
       - name: Check if mock
-        run: echo ${{ github.events.inputs.isMock }}
+        run: echo "${{ github.event.inputs.isMock }}"
 
       - name: Delete tag and release
         uses: dev-drprasad/delete-tag-and-release@v0.1.3
-        if: ${{ github.events.inputs.isMock }} == 'false'
+        if: ${{ github.event.inputs.isMock }} == 'false'
         with:
           delete_release: true
           tag_name: nightly
@@ -38,7 +38,7 @@ jobs:
       - name: Create nightly GitHub release
         id: release
         uses: actions/create-release@v1
-        if: ${{ github.events.inputs.isMock }} == 'false'
+        if: ${{ github.event.inputs.isMock }} == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -214,7 +214,7 @@ jobs:
       # TODO: Move this elsewhere; do this all at once, and do not continue if any fails.  Store artifacts.  Do the same for deployment.
 
       - name: Upload main release
-        if: ${{ github.events.inputs.isMock }} == 'false'
+        if: ${{ github.event.inputs.isMock }} == 'false'
         uses: actions/upload-release-asset@v1.0.1
         id: upload
         env:
@@ -226,7 +226,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Build msi file (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc' && ${{ github.events.inputs.isMock }} == 'false'
+        if: matrix.triple.target == 'x86_64-pc-windows-msvc' && ${{ github.event.inputs.isMock }} == 'false'
         shell: powershell
         run: |
           cargo install cargo-wix
@@ -234,7 +234,7 @@ jobs:
           cargo wix
 
       - name: Upload msi file (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc' && ${{ github.events.inputs.isMock }} == 'false'
+        if: matrix.triple.target == 'x86_64-pc-windows-msvc' && ${{ github.event.inputs.isMock }} == 'false'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -245,14 +245,14 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Build Debian release (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && ${{ github.events.inputs.isMock }} == 'false'
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && ${{ github.event.inputs.isMock }} == 'false'
         run: |
           cargo install cargo-deb --version 1.29.0
           cargo deb
           cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
 
       - name: Upload Debian file (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && ${{ github.events.inputs.isMock }} == 'false'
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && ${{ github.event.inputs.isMock }} == 'false'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -327,7 +327,7 @@ jobs:
           echo "ASSET=bottom_x86_64-unknown-linux-gnu_glibc_2-17" >> $GITHUB_ENV
 
       - name: Upload main release
-        if: ${{ github.events.inputs.isMock }} == 'false'
+        if: ${{ github.event.inputs.isMock }} == 'false'
         uses: actions/upload-release-asset@v1.0.1
         id: upload
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       isMock:
-        description: "Mock nightly run"
+        description: "Mock nightly run, defaults to 'false'"
         default: "false"
 
 jobs:
@@ -21,11 +21,11 @@ jobs:
         run: mkdir artifacts
 
       - name: Check if mock
-        run: echo "${{ github.event.inputs.isMock }}"
+        run: echo "github.event.inputs.isMock"
 
       - name: Delete tag and release
         uses: dev-drprasad/delete-tag-and-release@v0.1.3
-        if: ${{ github.event.inputs.isMock }} == 'false'
+        if: github.event.inputs.isMock == 'false'
         with:
           delete_release: true
           tag_name: nightly
@@ -38,7 +38,7 @@ jobs:
       - name: Create nightly GitHub release
         id: release
         uses: actions/create-release@v1
-        if: ${{ github.event.inputs.isMock }} == 'false'
+        if: github.event.inputs.isMock == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -214,7 +214,7 @@ jobs:
       # TODO: Move this elsewhere; do this all at once, and do not continue if any fails.  Store artifacts.  Do the same for deployment.
 
       - name: Upload main release
-        if: ${{ github.event.inputs.isMock }} == 'false'
+        if: github.event.inputs.isMock == 'false'
         uses: actions/upload-release-asset@v1.0.1
         id: upload
         env:
@@ -226,7 +226,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Build msi file (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc' && ${{ github.event.inputs.isMock }} == 'false'
+        if: matrix.triple.target == 'x86_64-pc-windows-msvc' && github.event.inputs.isMock == 'false'
         shell: powershell
         run: |
           cargo install cargo-wix
@@ -234,7 +234,7 @@ jobs:
           cargo wix
 
       - name: Upload msi file (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc' && ${{ github.event.inputs.isMock }} == 'false'
+        if: matrix.triple.target == 'x86_64-pc-windows-msvc' && github.event.inputs.isMock == 'false'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -245,14 +245,14 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Build Debian release (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && ${{ github.event.inputs.isMock }} == 'false'
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && github.event.inputs.isMock == 'false'
         run: |
           cargo install cargo-deb --version 1.29.0
           cargo deb
           cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
 
       - name: Upload Debian file (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && ${{ github.event.inputs.isMock }} == 'false'
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && github.event.inputs.isMock == 'false'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -327,7 +327,7 @@ jobs:
           echo "ASSET=bottom_x86_64-unknown-linux-gnu_glibc_2-17" >> $GITHUB_ENV
 
       - name: Upload main release
-        if: ${{ github.event.inputs.isMock }} == 'false'
+        if: github.event.inputs.isMock == 'false'
         uses: actions/upload-release-asset@v1.0.1
         id: upload
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -234,7 +234,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Build msi file (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc' && github.event.inputs.isMock == 'false'
+        if: matrix.triple.target == 'x86_64-pc-windows-msvc'
         shell: powershell
         run: |
           cargo install cargo-wix

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -251,3 +251,78 @@ jobs:
           asset_path: bottom_${{ env.RELEASE_VERSION }}_amd64.deb
           asset_name: bottom_${{ env.RELEASE_VERSION }}_amd64.deb
           asset_content_type: application/octet-stream
+
+  # I don't like doing it like this but it's the most convenient...
+  old-glibc-build-release:
+    name: old-glibc-build-release
+    needs: [create-github-release]
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux2014_x86_64
+    env:
+      RUST_BACKTRACE: 1
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v2
+
+      - name: Get release download URL
+        uses: actions/download-artifact@v2
+        with:
+          name: artifacts
+          path: artifacts
+
+      - name: Set release upload URL and release version
+        shell: bash
+        run: |
+          release_upload_url="$(cat ./artifacts/release-upload-url)"
+          echo "RELEASE_UPLOAD_URL=$release_upload_url" >> $GITHUB_ENV
+          release_version="$(cat ./artifacts/release-version)"
+          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
+
+      - name: Validate release environment variables
+        run: |
+          echo "Release upload url: ${{ env.RELEASE_UPLOAD_URL }}"
+          echo "Release version: ${{ env.RELEASE_VERSION }}"
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: x86_64-unknown-linux-gnu
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --verbose --target=x86_64-unknown-linux-gnu --no-default-features
+          use-cross: ${{ matrix.triple.cross }}
+
+      - name: Move autocomplete to working directory
+        shell: bash
+        run: |
+          cp -r ./target/x86_64-unknown-linux-gnu/release/build/bottom-*/out completion
+
+      - name: Bundle release and completion
+        shell: bash
+        run: |
+          cp target/x86_64-unknown-linux-gnu/release/btm ./btm
+          tar -czvf bottom_x86_64-unknown-linux-gnu_glibc_2-17.tar.gz btm completion
+          echo "ASSET=bottom_x86_64-unknown-linux-gnu_glibc_2-17" >> $GITHUB_ENV
+
+      - name: Upload main release
+        uses: actions/upload-release-asset@v1.0.1
+        id: upload
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
+          asset_path: ${{ env.ASSET }}
+          asset_name: ${{ env.ASSET }}
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Since we're moving all 16.04 ubuntu builds to 18.04, I thought this would be a good idea in case anyone needed it.

Not sure if we should have just made ALL Linux builds use the older Linux container... for now I'll just make one extra build.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Type of change

_Remove the irrelevant ones:_

- [x] _Other (something else - please specify)_

## Test methodology

_If relevant, please state how this was tested:_

_Furthermore, please tick which platforms this change was tested on:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

_If relevant, all of these platforms should be tested._

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Change has been tested to work, and does not cause new breakage unless intended_
- [ ] _Code has been self-reviewed_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _Passes CI pipeline (clippy check and `cargo test` check)_
- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _No merge conflicts arise from the change_

## Other information

_Provide any other relevant information to this change:_
