### PR TITLE
docs: mention GURU overlay in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,16 @@ sudo dnf install bottom
 
 ### Gentoo
 
-Available in [dm9pZCAq overlay](https://github.com/gentoo-mirror/dm9pZCAq)
+Available in [GURU](https://wiki.gentoo.org/wiki/Project:GURU) and [dm9pZCAq](https://github.com/gentoo-mirror/dm9pZCAq) overlays
+
+```bash
+sudo eselect repository enable guru
+sudo emerge --sync guru
+echo "sys-process/bottom" | sudo tee /etc/portage/package.accept_keywords/10-guru
+sudo emerge sys-process/bottom::guru
+```
+
+or
 
 ```bash
 sudo eselect repository enable dm9pZCAq


### PR DESCRIPTION
## Description

Bottom is available in the GURU project overlay so I added a note for that in the installation instructions for Gentoo.

## Issue

Since [Gentoo wiki](https://wiki.gentoo.org/wiki/Project:GURU) refers to GURU as *an official repository of new Gentoo packages*, more people are likely to prioritise/prefer to enable GURU overlay over others so I think it's a nice idea to mention GURU in the docs.

Some people, such as me, like to use more *official* ways, than *personal* ones ([dm9pZCAq](https://github.com/gentoo-mirror/dm9pZCAq): *personal overlay with different packages*) hence I made this PR.
