### PR TITLE
refactor: Fix clippy lint for entry vacancy check

### DIFF
--- a/src/app/data_harvester/processes/linux.rs
+++ b/src/app/data_harvester/processes/linux.rs
@@ -1,5 +1,7 @@
 //! Process data collection for Linux.
 
+use std::collections::hash_map::Entry;
+
 use crate::utils::error::{self, BottomError};
 use crate::Pid;
 
@@ -232,9 +234,9 @@ pub fn get_process_data(
                 if let Ok(dir) = dir {
                     if let Ok(pid) = dir.file_name().to_string_lossy().trim().parse::<Pid>() {
                         let mut fresh = false;
-                        if !pid_mapping.contains_key(&pid) {
+                        if let Entry::Vacant(entry) = pid_mapping.entry(pid) {
                             if let Ok(ppd) = PrevProcDetails::new(pid) {
-                                pid_mapping.insert(pid, ppd);
+                                entry.insert(ppd);
                                 fresh = true;
                             } else {
                                 // Bail early.


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Fixes a clippy warning regarding hashmap vacancy check and inserts.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Furthermore, mark which platforms this change was tested on. All platforms directly affected by the change **must** be tested_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (README, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
