### PR TITLE
bug: Divide Windows process cpu usage by number of processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#504](https://github.com/ClementTsang/bottom/pull/504): Fixes two bugs causing the battery widget colours and mouse events to be broken.
 
+- [#525](https://github.com/ClementTsang/bottom/pull/525): Fixes Windows process CPU usage not being divided by the number of cores.
+
 ## [0.6.1] - 2021-05-11
 
 ## Bug Fixes

--- a/src/app/data_harvester/processes/macos.rs
+++ b/src/app/data_harvester/processes/macos.rs
@@ -40,7 +40,7 @@ pub fn get_process_data(
     let mut process_vector: Vec<ProcessHarvest> = Vec::new();
     let process_hashmap = sys.get_processes();
     let cpu_usage = sys.get_global_processor_info().get_cpu_usage() as f64 / 100.0;
-    let num_cpus = sys.get_processors().len() as f64;
+    let num_processors = sys.get_processors().len() as f64;
     for process_val in process_hashmap.values() {
         let name = if process_val.name().is_empty() {
             let process_cmd = process_val.cmd();
@@ -72,7 +72,7 @@ pub fn get_process_data(
         };
 
         let pcu = {
-            let p = process_val.cpu_usage() as f64 / num_cpus;
+            let p = process_val.cpu_usage() as f64 / num_processors;
             if p.is_nan() {
                 process_val.cpu_usage() as f64
             } else {

--- a/src/app/data_harvester/processes/macos.rs
+++ b/src/app/data_harvester/processes/macos.rs
@@ -117,10 +117,10 @@ pub fn get_process_data(
     let cpu_usages = get_macos_process_cpu_usage(&cpu_usage_unknown_pids)?;
     for process in &mut process_vector {
         if cpu_usages.contains_key(&process.pid) {
-            process.cpu_usage_percent = if num_cpus == 0.0 {
+            process.cpu_usage_percent = if num_processors == 0.0 {
                 *cpu_usages.get(&process.pid).unwrap()
             } else {
-                *cpu_usages.get(&process.pid).unwrap() / num_cpus
+                *cpu_usages.get(&process.pid).unwrap() / num_processors
             };
         }
     }

--- a/src/app/data_harvester/processes/windows.rs
+++ b/src/app/data_harvester/processes/windows.rs
@@ -9,6 +9,7 @@ pub fn get_process_data(
     let mut process_vector: Vec<ProcessHarvest> = Vec::new();
     let process_hashmap = sys.get_processes();
     let cpu_usage = sys.get_global_processor_info().get_cpu_usage() as f64 / 100.0;
+    let num_processors = sys.get_processors().len() as f64;
     for process_val in process_hashmap.values() {
         let name = if process_val.name().is_empty() {
             let process_cmd = process_val.cmd();
@@ -39,7 +40,14 @@ pub fn get_process_data(
             }
         };
 
-        let pcu = process_val.cpu_usage() as f64;
+        let pcu = {
+            let p = process_val.cpu_usage() as f64 / num_processors;
+            if p.is_nan() {
+                process_val.cpu_usage() as f64
+            } else {
+                p
+            }
+        };
         let process_cpu_usage = if use_current_cpu_total && cpu_usage > 0.0 {
             pcu / cpu_usage
         } else {


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Fixes a bug displaying the CPU usage of a process in Windows due to not dividing by the number of processors.

## Issue

_If applicable, what issue does this address?_

Closes: #523

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Furthermore, mark which platforms this change was tested on. All platforms directly affected by the change **must** be tested_

- [x] _Windows_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
