### PR TITLE
ci: reduce the number of tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,18 +91,18 @@ jobs:
               cross: true,
               rust: stable,
             }
-          - {
-              os: "ubuntu-latest",
-              target: "x86_64-unknown-linux-musl",
-              cross: false,
-              rust: stable,
-            }
-          - {
-              os: "ubuntu-latest",
-              target: "i686-unknown-linux-musl",
-              cross: true,
-              rust: stable,
-            }
+          # - {
+          #     os: "ubuntu-latest",
+          #     target: "x86_64-unknown-linux-musl",
+          #     cross: false,
+          #     rust: stable,
+          #   }
+          # - {
+          #     os: "ubuntu-latest",
+          #     target: "i686-unknown-linux-musl",
+          #     cross: true,
+          #     rust: stable,
+          #   }
           - {
               os: "macOS-latest",
               target: "x86_64-apple-darwin",
@@ -119,12 +119,6 @@ jobs:
           #   }
           - {
               os: "windows-2019",
-              target: "i686-pc-windows-msvc",
-              cross: true,
-              rust: stable,
-            }
-          - {
-              os: "windows-2019",
               target: "x86_64-pc-windows-msvc",
               cross: false,
               rust: stable,
@@ -132,10 +126,16 @@ jobs:
             }
           - {
               os: "windows-2019",
-              target: "x86_64-pc-windows-gnu",
-              cross: false,
+              target: "i686-pc-windows-msvc",
+              cross: true,
               rust: stable,
             }
+          # - {
+          #     os: "windows-2019",
+          #     target: "x86_64-pc-windows-gnu",
+          #     cross: false,
+          #     rust: stable,
+          #   }
 
           # aarch64
           - {


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Seems like we have a few too many tests that aren't really needed for just asserting CI is passing.

The goal for CI (IMO) is just to ensure things still build on the various supported platforms after changes are made.  However, there were a few tested scenarios like Windows GNU or musl which I feel weren't really too important in this regard, and added extra time to an already long CI process.

Commented out the following tests since there aren't any architecture-specific features that require running these in addition to other already-existing tests:
- Windows GNU
- Linux musl (both x86 and x86_64)

Of course, should we add changes that directly affect these architectures, then we should add the tests back.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
