### PR TITLE
bug: Fix missing config options in docs and default config

### DIFF
--- a/docs/content/configuration/command-line-flags.md
+++ b/docs/content/configuration/command-line-flags.md
@@ -27,7 +27,7 @@ The following flags can be provided to bottom in the command line to change the 
 | `-h, --help`                          | Prints help information. Use --help for more info.             |
 | `-a, --hide_avg_cpu`                  | Hides the average CPU usage.                                   |
 | `--hide_table_gap`                    | Hides the spacing between table headers and entries.           |
-| `--hide_time`                         | Completely hides the time scaling.                             |
+| `--hide_time`                         | Hides the time scale.                                          |
 | `-k, --kelvin`                        | Sets the temperature type to Kelvin.                           |
 | `-l, --left_legend`                   | Puts the CPU chart legend to the left side.                    |
 | `--mem_as_value`                      | Defaults to showing process memory usage by value.             |

--- a/docs/content/configuration/config-file/flags.md
+++ b/docs/content/configuration/config-file/flags.md
@@ -22,6 +22,7 @@ Most of the [command line flags](../../command-line-flags) have config file equi
 | `rate`                       | Unsigned Int (represents milliseconds)                                                         | Sets a refresh rate in ms.                                     |
 | `default_time_value`         | Unsigned Int (represents milliseconds)                                                         | Default time value for graphs in ms.                           |
 | `time_delta`                 | Unsigned Int (represents milliseconds)                                                         | The amount in ms changed upon zooming.                         |
+| `hide_time`                  | Boolean                                                                                        | Hides the time scaling.                                        |
 | `temperature_type`           | String (one of ["k", "f", "c", "kelvin", "fahrenheit", "celsius"])                             | Sets the temperature unit type.                                |
 | `default_widget_type`        | String (one of ["cpu", "proc", "net", "temp", "mem", "disk"], same as layout options)          | Sets the default widget type, use --help for more info.        |
 | `default_widget_count`       | Unsigned Int (represents which `default_widget_type`)                                          | Sets the n'th selected widget type as the default.             |

--- a/src/clap.rs
+++ b/src/clap.rs
@@ -146,7 +146,7 @@ Hides the spacing between table headers and entries.\n\n",
 
     let hide_time = Arg::with_name("hide_time")
         .long("hide_time")
-        .help("Completely hides the time scaling.")
+        .help("Hides the time scale.")
         .long_help(
             "\
 Completely hides the time scaling from being shown.\n\n",

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -480,6 +480,8 @@ pub const CONFIG_TEXT: &str = r##"# This is a default config file for bottom.  A
 #use_old_network_legend = false
 # Remove space in tables
 #hide_table_gap = false
+# Show the battery widgets
+#battery = false
 # Disable mouse clicks
 #disable_click = false
 # Built-in themes.  Valid values are "default", "default-light", "gruvbox", "gruvbox-light", "nord", "nord-light"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -469,6 +469,8 @@ pub const CONFIG_TEXT: &str = r##"# This is a default config file for bottom.  A
 #default_time_value = 60000
 # The time delta on each zoom in/out action (in milliseconds).
 #time_delta = 15000
+# Hides the time scale.
+#hide_time = false
 # Override layout default widget
 #default_widget_type = "proc"
 #default_widget_count = 1

--- a/src/options.rs
+++ b/src/options.rs
@@ -80,9 +80,6 @@ pub struct ConfigFlags {
     pub regex: Option<bool>,
 
     #[builder(default, setter(strip_option))]
-    pub default_widget: Option<String>,
-
-    #[builder(default, setter(strip_option))]
     pub basic: Option<bool>,
 
     #[builder(default, setter(strip_option))]
@@ -145,6 +142,7 @@ pub struct ConfigFlags {
     #[builder(default, setter(strip_option))]
     pub search_regex_enabled_widgets: Option<Vec<WidgetIdEnabled>>,
 
+    // End hack
     #[builder(default, setter(strip_option))]
     pub mem_as_value: Option<bool>,
 


### PR DESCRIPTION

## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds the missing `hide_time` and `battery` config option to the default config and corresponding documentation.

Should probably automate the generation of this somehow tbh, though this might change when I add in-app config (soon™)

## Issue

_If applicable, what issue does this address?_

Closes: #541 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Furthermore, mark which platforms this change was tested on. All platforms directly affected by the change **must** be tested_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
