### PR TITLE
bug: switch over to procfs for linux mem usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Bug Fixes
 
 - [#542](https://github.com/ClementTsang/bottom/pull/542): Fixes missing config options in the default generated config file.
-- [#545](https://github.com/ClementTsang/bottom/pull/545): Fixes inaccurate memory usage/totals in macOS and Linux.
+- [#545](https://github.com/ClementTsang/bottom/pull/545): Fixes inaccurate memory usage/totals in macOS and Linux, switch unit to binary prefix.
+
+## Changes
+
+- [#547](https://github.com/ClementTsang/bottom/pull/547): Switch memory usage calculation to match htop.
 
 ## [0.6.2] - 2021-06-26
 

--- a/docs/content/usage/widgets/memory.md
+++ b/docs/content/usage/widgets/memory.md
@@ -28,3 +28,11 @@ Note that key bindings are generally case-sensitive.
 | Binding      | Action                                                         |
 | ------------ | -------------------------------------------------------------- |
 | ++"Scroll"++ | Scrolling up or down zooms in or out of the graph respectively |
+
+## Calculations
+
+Memory usage is calculated using the following formula:
+
+```
+
+```

--- a/docs/content/usage/widgets/memory.md
+++ b/docs/content/usage/widgets/memory.md
@@ -31,8 +31,10 @@ Note that key bindings are generally case-sensitive.
 
 ## Calculations
 
-Memory usage is calculated using the following formula:
+Memory usage is calculated using the following formula based on values from `/proc/meminfo` (based on [htop's implementation](https://github.com/htop-dev/htop/blob/976c6123f41492aaf613b9d172eef1842fb7b0a3/linux/LinuxProcessList.c#L1584)):
 
 ```
-
+MemTotal - MemFree - Buffers - (Cached + SReclaimable - Shmem)
 ```
+
+You can find more info on `/proc/meminfo` and its fields [here](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/s2-proc-meminfo).

--- a/src/app/data_harvester/memory/mod.rs
+++ b/src/app/data_harvester/memory/mod.rs
@@ -4,7 +4,7 @@
 
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))] {
-        pub mod heim;
-        pub use self::heim::*;
+        pub mod general;
+        pub use self::general::*;
     }
 }


### PR DESCRIPTION
Swap to manually calculating the mem total and usage via procfs.  The usage calculation is now:

```
total - (free + cached + buffers + slab_reclaimable - shmem)
```

This follows the same usage calculation as htop.  See the PR for more details.

## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_


## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Furthermore, mark which platforms this change was tested on. All platforms directly affected by the change **must** be tested_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
