### PR TITLE
refactor: switch to manual implementation of meminfo parse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "procfs",
  "regex",
  "serde",
+ "smol",
  "sysinfo",
  "thiserror",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,8 +68,9 @@ log = { version = "0.4.14", optional = true }
 libc = "0.2.86"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-heim = { version = "0.1.0-rc.1", features = ["cpu", "disk", "memory", "net", "sensors"] }
+heim = { version = "0.1.0-rc.1", features = ["cpu", "disk", "net", "sensors"] }
 procfs = "0.9.1"
+smol = "1.2.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 heim = { version = "0.1.0-rc.1", features = ["cpu", "disk", "memory", "net"] }

--- a/docs/content/usage/widgets/memory.md
+++ b/docs/content/usage/widgets/memory.md
@@ -8,7 +8,7 @@ The memory widget provides a visual representation of RAM and swap usage over ti
 
 ## Features
 
-The legend displays the current usage in terms of percentage and actual usage.
+The legend displays the current usage in terms of percentage and actual usage in binary units (KiB, MiB, GiB, etc.).
 If the total RAM or swap available is 0, then it is automatically hidden from the legend and graph.
 
 One can also adjust the displayed time range through either the keyboard or mouse, with a range of 30s to 600s.


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Manually parse `/proc/meminfo` for the purposes of memory usage.

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Tested by observing the values and comparing to htop and the previous master build.

_Furthermore, mark which platforms this change was tested on. All platforms directly affected by the change **must** be tested_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
