### PR TITLE
bug: fix crashes for kernel patch versions > 255

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changes
 
-- [#557](https://github.com/ClementTsang/bottom/pull/557): Add '/s' to network usage legend.
+- [#557](https://github.com/ClementTsang/bottom/pull/557): Add '/s' to network usage legend to better indicate that it's a per-second change.
 
 ## Bug Fixes
 
-- [](): Updates the procfs library to not crash on kernel version >255.
+- [#575](https://github.com/ClementTsang/bottom/pull/575): Updates the procfs library to not crash on kernel version >255.
 
 ## Internal Changes
 
 - [#551](https://github.com/ClementTsang/bottom/pull/551): Disable AUR package generation in release pipeline since it's now in community.
+- [#570](https://github.com/ClementTsang/bottom/pull/570): Make battery features optional in compilation.
 
 ## [0.6.3] - 2021-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#557](https://github.com/ClementTsang/bottom/pull/557): Add '/s' to network usage legend.
 
+## Bug Fixes
+
+- [](): Updates the procfs library to not crash on kernel version >255.
+
 ## Internal Changes
 
 - [#551](https://github.com/ClementTsang/bottom/pull/551): Disable AUR package generation in release pipeline since it's now in community.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8809e0c18450a2db0f236d2a44ec0b4c1412d0eb936233579f0990faa5d5cd"
+checksum = "95e344cafeaeefe487300c361654bcfc85db3ac53619eeccced29f5ea18c4c70"
 dependencies = [
  "bitflags",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ libc = "0.2.86"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 heim = { version = "0.1.0-rc.1", features = ["cpu", "disk", "net", "sensors"] }
-procfs = "0.9.1"
+procfs = "0.10.1"
 smol = "1.2.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION


## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Fixes a panic caused by the procfs library where it would crash for kernel patch versions > 255.

## Issue

_If applicable, what issue does this address?_

Closes: #574

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Furthermore, mark which platforms this change was tested on. All platforms directly affected by the change **must** be tested_

- [x] _Windows_
- [x] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
