### PR TITLE
ci: fix deploy script for completion directory copy

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -225,7 +225,7 @@ jobs:
         shell: bash
         run: |
           mkdir completion
-          cp -r ./target/${{ matrix.triple.target }}/release/build/bottom-*/out/ completion
+          cp -r ./target/${{ matrix.triple.target }}/release/build/bottom-*/out/. completion
 
       - name: Strip release binary (macOS or Linux x86-64/i686)
         if: matrix.triple.strip == true

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -224,7 +224,8 @@ jobs:
       - name: Move autocomplete to working directory
         shell: bash
         run: |
-          cp -r ./target/${{ matrix.triple.target }}/release/build/bottom-*/out completion
+          mkdir completion
+          cp -r ./target/${{ matrix.triple.target }}/release/build/bottom-*/out/ completion
 
       - name: Strip release binary (macOS or Linux x86-64/i686)
         if: matrix.triple.strip == true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -218,7 +218,8 @@ jobs:
       - name: Move autocomplete to working directory
         shell: bash
         run: |
-          cp -r ./target/${{ matrix.triple.target }}/release/build/bottom-*/out completion
+          mkdir completion
+          cp -r ./target/${{ matrix.triple.target }}/release/build/bottom-*/out/ completion
 
       - name: Strip release binary (macOS or Linux x86-64/i686)
         if: matrix.triple.strip == true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -219,7 +219,7 @@ jobs:
         shell: bash
         run: |
           mkdir completion
-          cp -r ./target/${{ matrix.triple.target }}/release/build/bottom-*/out/ completion
+          cp -r ./target/${{ matrix.triple.target }}/release/build/bottom-*/out/. completion
 
       - name: Strip release binary (macOS or Linux x86-64/i686)
         if: matrix.triple.strip == true


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds an explicit `mkdir` to the completions directory. No idea why it was bugging out before though, it worked fine on nightly builds.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Tested with a test run: https://github.com/ClementTsang/bottom/actions/runs/1227180644

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
