### PR TITLE
README.md: bottom is in Homebrew proper now

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,7 @@ sudo eopkg it bottom
 ### Homebrew
 
 ```bash
-brew tap clementtsang/bottom
 brew install bottom
-
-# If you need to be more specific, use:
-brew install clementtsang/bottom/bottom
 ```
 
 ### MacPorts


### PR DESCRIPTION
## Description

Now that bottom is [in Homebrew](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/bottom.rb), people don't need to bother with the `brew cask` stuff anymore.

## Issue

This doesn't address any preexisting issues.

## Testing

This change was not tested.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
