### PR TITLE
Feature gate test_default_battery_movement

### DIFF
--- a/tests/layout_management_tests.rs
+++ b/tests/layout_management_tests.rs
@@ -1,7 +1,9 @@
 //! Mocks layout management, so we can check if we broke anything.
 
 use bottom::app::layout_manager::{BottomLayout, BottomWidgetType};
-use bottom::constants::{DEFAULT_BATTERY_LAYOUT, DEFAULT_LAYOUT, DEFAULT_WIDGET_ID};
+#[cfg(feature = "battery")]
+use bottom::constants::DEFAULT_BATTERY_LAYOUT;
+use bottom::constants::{DEFAULT_LAYOUT, DEFAULT_WIDGET_ID};
 use bottom::options::{layout_options::Row, Config};
 use bottom::utils::error;
 
@@ -126,6 +128,7 @@ fn test_default_movement() {
     );
 }
 
+#[cfg(feature = "battery")]
 #[test]
 /// Tests battery movement in the default setup.
 fn test_default_battery_movement() {


### PR DESCRIPTION
## Description

test_default_battery_movement() is now feature gated on the
battery feature.

fixes #581

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>


## Issue

See #581 - Gentoo now passes tests with and without the feature enabled.

Closes: #581

## Testing

I ran the test suite with and without the feature enabled, both on Fedora 33 and Gentoo's ebuild environment.

_Furthermore, mark which platforms this change was tested on. All platforms directly affected by the change **must** be tested_

- [ ] _Windows_
- [ ] _macOS_
- [X] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [X] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [X] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [X] _There are no merge conflicts_
