### PR TITLE
ci: move winget/msi and deb gen to separate steps

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -165,8 +165,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-python@v2
-
       - name: Get release download URL
         uses: actions/download-artifact@v2
         with:
@@ -354,8 +352,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-
-      - uses: actions/setup-python@v2
 
       - name: Get release download URL
         uses: actions/download-artifact@v2

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -308,16 +308,16 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-          key: x86_64-pc-windows-msvc
+          key: x86_64-pc-windows-msvc-msi
 
-      - name: Build msi file (Windows x86-64 MSVC)
+      - name: Build msi file
         shell: powershell
         run: |
           cargo install cargo-wix --version 0.3.1 --locked
           cargo wix init
           cargo wix
 
-      - name: Upload msi file (Windows x86-64 MSVC)
+      - name: Upload msi file
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -327,13 +327,13 @@ jobs:
           asset_name: bottom_x86_64_installer.msi
           asset_content_type: application/octet-stream
 
-      - name: Build winget (Windows x86-64 MSVC)
+      - name: Build winget
         run: |
           python "./deployment/packager.py" ${{ env.RELEASE_VERSION }} "./deployment/windows/winget/winget.yaml.template" "Clement.bottom.yaml" "SHA256" "./bottom_x86_64_installer.msi"
           $Code = powershell ./deployment/windows/winget/get_product_code.ps1 ./bottom_x86_64_installer.msi
           python "./deployment/windows/winget/product_code.py" Clement.bottom.yaml $Code
 
-      - name: Upload winget file (Windows x86-64 MSVC)
+      - name: Upload winget file
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -386,7 +386,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-          key: x86_64-unknown-linux-gnu
+          key: x86_64-unknown-linux-gnu-deb
 
       - name: Build Debian release (Linux x86-64 GNU)
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -254,6 +254,23 @@ jobs:
           name: artifacts
           path: artifacts
 
+      - name: Compress completion files (Linux x86-64 GNU)
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == ''
+        shell: bash
+        run: |
+          tar -C ./completion -czvf completion.tar.gz .
+
+      - name: Release completion files (Linux x86-64 GNU)
+        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == ''
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
+          asset_path: completion.tar.gz
+          asset_name: completion.tar.gz
+          asset_content_type: application/octet-stream
+
   build-msi:
     name: build-msi
     needs: [create-github-release]
@@ -444,19 +461,4 @@ jobs:
           upload_url: ${{ env.RELEASE_UPLOAD_URL }}
           asset_path: choco.zip
           asset_name: choco.zip
-          asset_content_type: application/octet-stream
-
-      - name: Compress completion files (Linux x86-64 GNU)
-        shell: bash
-        run: |
-          tar -C ./completion -czvf completion.tar.gz .
-
-      - name: Release completion files (Linux x86-64 GNU)
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
-          asset_path: completion.tar.gz
-          asset_name: completion.tar.gz
           asset_content_type: application/octet-stream

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -186,22 +186,6 @@ jobs:
           echo "Release upload url: ${{ env.RELEASE_UPLOAD_URL }}"
           echo "Release version: ${{ env.RELEASE_VERSION }}"
 
-      - name: Install Net-Framework-Core (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc'
-        shell: powershell
-        run: Install-WindowsFeature Net-Framework-Core
-
-      - name: Install wixtoolset (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc'
-        uses: crazy-max/ghaction-chocolatey@v1.4.0
-        with:
-          args: install -y wixtoolset
-
-      # - name: Export wixtoolset to path (Windows x86-64 MSVC)
-      #   if: matrix.triple.target == 'x86_64-pc-windows-msvc'
-      #   shell: powershell
-      #   run: export PATH=${PATH}:"/c/Program Files (x86)/WiX Toolset v3.11/bin"
-
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -272,8 +256,61 @@ jobs:
           name: artifacts
           path: artifacts
 
+  build-msi:
+    name: build-msi
+    needs: [create-github-release]
+    runs-on: "windows-2019"
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v2
+
+      - name: Get release download URL
+        uses: actions/download-artifact@v2
+        with:
+          name: artifacts
+          path: artifacts
+
+      - name: Set release upload URL and release version
+        shell: bash
+        run: |
+          release_upload_url="$(cat ./artifacts/release-upload-url)"
+          echo "RELEASE_UPLOAD_URL=$release_upload_url" >> $GITHUB_ENV
+          release_version="$(cat ./artifacts/release-version)"
+          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
+
+      - name: Validate release environment variables
+        run: |
+          echo "Release upload url: ${{ env.RELEASE_UPLOAD_URL }}"
+          echo "Release version: ${{ env.RELEASE_VERSION }}"
+
+      - name: Install Net-Framework-Core (Windows x86-64 MSVC)
+        shell: powershell
+        run: Install-WindowsFeature Net-Framework-Core
+
+      - name: Install wixtoolset (Windows x86-64 MSVC)
+        uses: crazy-max/ghaction-chocolatey@v1.4.0
+        with:
+          args: install -y wixtoolset
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: x86_64-pc-windows-msvc
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: x86_64-pc-windows-msvc
+
       - name: Build msi file (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc'
         shell: powershell
         run: |
           cargo install cargo-wix --version 0.3.1 --locked
@@ -281,7 +318,6 @@ jobs:
           cargo wix
 
       - name: Upload msi file (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -292,14 +328,12 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Build winget (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc'
         run: |
           python "./deployment/packager.py" ${{ env.RELEASE_VERSION }} "./deployment/windows/winget/winget.yaml.template" "Clement.bottom.yaml" "SHA256" "./bottom_x86_64_installer.msi"
           $Code = powershell ./deployment/windows/winget/get_product_code.ps1 ./bottom_x86_64_installer.msi
           python "./deployment/windows/winget/product_code.py" Clement.bottom.yaml $Code
 
       - name: Upload winget file (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -309,15 +343,58 @@ jobs:
           asset_name: Clement.bottom.yaml
           asset_content_type: application/octet-stream
 
+  build-deb:
+    name: build-deb
+    needs: [create-github-release]
+    runs-on: "ubuntu-18.04"
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v2
+
+      - name: Get release download URL
+        uses: actions/download-artifact@v2
+        with:
+          name: artifacts
+          path: artifacts
+
+      - name: Set release upload URL and release version
+        shell: bash
+        run: |
+          release_upload_url="$(cat ./artifacts/release-upload-url)"
+          echo "RELEASE_UPLOAD_URL=$release_upload_url" >> $GITHUB_ENV
+          release_version="$(cat ./artifacts/release-version)"
+          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
+
+      - name: Validate release environment variables
+        run: |
+          echo "Release upload url: ${{ env.RELEASE_UPLOAD_URL }}"
+          echo "Release version: ${{ env.RELEASE_VERSION }}"
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: x86_64-unknown-linux-gnu
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: x86_64-unknown-linux-gnu
+
       - name: Build Debian release (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == ''
         run: |
           cargo install cargo-deb --version 1.29.0 --locked
           cargo deb
           cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
 
       - name: Upload Debian file (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == ''
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -374,13 +451,11 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Compress completion files (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == ''
         shell: bash
         run: |
           tar -C ./completion -czvf completion.tar.gz .
 
       - name: Release completion files (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == ''
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -305,7 +305,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-          key: x86_64-pc-windows-msvc
+          key: x86_64-pc-windows-msvc-msi
 
       - name: Build msi file
         shell: powershell
@@ -366,7 +366,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-          key: x86_64-unknown-linux-gnu
+          key: x86_64-unknown-linux-gnu-deb
 
       - name: Build Debian release
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -164,8 +164,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-python@v2
-
       - name: Get release download URL
         uses: actions/download-artifact@v2
         with:
@@ -184,17 +182,6 @@ jobs:
         run: |
           echo "Release upload url: ${{ env.RELEASE_UPLOAD_URL }}"
           echo "Release version: ${{ env.RELEASE_VERSION }}"
-
-      - name: Install Net-Framework-Core (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc'
-        shell: powershell
-        run: Install-WindowsFeature Net-Framework-Core
-
-      - name: Install wixtoolset (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc'
-        uses: crazy-max/ghaction-chocolatey@v1.4.0
-        with:
-          args: install -y wixtoolset
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
@@ -245,8 +232,6 @@ jobs:
           tar -czvf bottom_${{ matrix.triple.target }}${{ matrix.triple.suffix }}.tar.gz btm completion
           echo "ASSET=bottom_${{ matrix.triple.target }}${{ matrix.triple.suffix }}.tar.gz" >> $GITHUB_ENV
 
-      # TODO: Move this elsewhere; do this all at once, and do not continue if any fails.  Store artifacts.  Do the same for deployment.
-
       - name: Upload main release
         if: github.event.inputs.isMock != 'mock'
         uses: actions/upload-release-asset@v1.0.1
@@ -259,49 +244,6 @@ jobs:
           asset_name: ${{ env.ASSET }}
           asset_content_type: application/octet-stream
 
-      - name: Build msi file (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc'
-        shell: powershell
-        run: |
-          cargo install cargo-wix --version 0.3.1 --locked
-          cargo wix init
-          cargo wix
-
-      - name: Upload msi file (Windows x86-64 MSVC)
-        if: matrix.triple.target == 'x86_64-pc-windows-msvc' && github.event.inputs.isMock != 'mock'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
-          asset_path: bottom_x86_64_installer.msi
-          asset_name: bottom_x86_64_installer.msi
-          asset_content_type: application/octet-stream
-
-      - name: Build Debian release (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == ''
-        run: |
-          cargo install cargo-deb --version 1.29.0 --locked
-          cargo deb
-          cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
-
-      - name: Upload Debian file (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == '' && github.event.inputs.isMock != 'mock'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
-          asset_path: bottom_${{ env.RELEASE_VERSION }}_amd64.deb
-          asset_name: bottom_${{ env.RELEASE_VERSION }}_amd64.deb
-          asset_content_type: application/octet-stream
-
-      - name: Compress completion files (Linux x86-64 GNU)
-        if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == ''
-        shell: bash
-        run: |
-          tar -C ./completion -czvf completion.tar.gz .
-
       - name: Release completion files (Linux x86-64 GNU)
         if: matrix.triple.target == 'x86_64-unknown-linux-gnu' && matrix.triple.container == '' && github.event.inputs.isMock != 'mock'
         uses: actions/upload-release-asset@v1.0.1
@@ -311,4 +253,134 @@ jobs:
           upload_url: ${{ env.RELEASE_UPLOAD_URL }}
           asset_path: completion.tar.gz
           asset_name: completion.tar.gz
+          asset_content_type: application/octet-stream
+
+  build-msi:
+    name: build-msi
+    needs: [create-github-release]
+    runs-on: "windows-2019"
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Get release download URL
+        uses: actions/download-artifact@v2
+        with:
+          name: artifacts
+          path: artifacts
+
+      - name: Set release upload URL and release version
+        shell: bash
+        run: |
+          release_upload_url="$(cat ./artifacts/release-upload-url)"
+          echo "RELEASE_UPLOAD_URL=$release_upload_url" >> $GITHUB_ENV
+          release_version="$(cat ./artifacts/release-version)"
+          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
+
+      - name: Validate release environment variables
+        run: |
+          echo "Release upload url: ${{ env.RELEASE_UPLOAD_URL }}"
+          echo "Release version: ${{ env.RELEASE_VERSION }}"
+
+      - name: Install Net-Framework-Core
+        shell: powershell
+        run: Install-WindowsFeature Net-Framework-Core
+
+      - name: Install wixtoolset
+        uses: crazy-max/ghaction-chocolatey@v1.4.0
+        with:
+          args: install -y wixtoolset
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: x86_64-pc-windows-msvc
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: x86_64-pc-windows-msvc
+
+      - name: Build msi file
+        shell: powershell
+        run: |
+          cargo install cargo-wix --version 0.3.1 --locked
+          cargo wix init
+          cargo wix
+
+      - name: Upload msi file
+        if: github.event.inputs.isMock != 'mock'
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
+          asset_path: bottom_x86_64_installer.msi
+          asset_name: bottom_x86_64_installer.msi
+          asset_content_type: application/octet-stream
+
+  build-deb:
+    name: build-deb
+    needs: [create-github-release]
+    runs-on: "ubuntu-18.04"
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Get release download URL
+        uses: actions/download-artifact@v2
+        with:
+          name: artifacts
+          path: artifacts
+
+      - name: Set release upload URL and release version
+        shell: bash
+        run: |
+          release_upload_url="$(cat ./artifacts/release-upload-url)"
+          echo "RELEASE_UPLOAD_URL=$release_upload_url" >> $GITHUB_ENV
+          release_version="$(cat ./artifacts/release-version)"
+          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
+
+      - name: Validate release environment variables
+        run: |
+          echo "Release upload url: ${{ env.RELEASE_UPLOAD_URL }}"
+          echo "Release version: ${{ env.RELEASE_VERSION }}"
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: x86_64-unknown-linux-gnu
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: x86_64-unknown-linux-gnu
+
+      - name: Build Debian release
+        run: |
+          cargo install cargo-deb --version 1.29.0 --locked
+          cargo deb
+          cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
+
+      - name: Upload Debian file if not mock
+        if: github.event.inputs.isMock != 'mock'
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
+          asset_path: bottom_${{ env.RELEASE_VERSION }}_amd64.deb
+          asset_name: bottom_${{ env.RELEASE_VERSION }}_amd64.deb
           asset_content_type: application/octet-stream

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,16 +92,20 @@ assets = [
     ["target/release/btm", "usr/bin/", "755"],
     ["LICENSE", "usr/share/doc/btm/", "644"],
     [
-        "completion/btm.bash",
+        "target/release/build/bottom-*/out/btm.bash",
         "usr/share/bash-completion/completions/btm",
         "644",
     ],
     [
-        "completion/btm.fish",
+        "target/release/build/bottom-*/out/btm.fish",
         "usr/share/fish/vendor_completions.d/btm.fish",
         "644",
     ],
-    ["completion/_btm", "usr/share/zsh/vendor-completions/", "644"],
+    [
+        "target/release/build/bottom-*/out/_btm",
+        "usr/share/zsh/vendor-completions/",
+        "644",
+    ],
 ]
 extended-description = """\
 A cross-platform graphical process/system monitor with a customizable interface and a multitude of


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Moves debian and winget/msi generation to a separate job, so it can run in parallel to the other jobs.

## Testing

Nightly test: https://github.com/ClementTsang/bottom/actions/runs/1267798598
Deploy test: https://github.com/ClementTsang/bottom/actions/runs/1267798112

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
