### PR TITLE
bug: remove incorrect shortcut from docs/help

### DIFF
--- a/docs/content/usage/widgets/process.md
+++ b/docs/content/usage/widgets/process.md
@@ -198,7 +198,6 @@ Note that key bindings are generally case-sensitive.
 | ------------------------------------- | -------------------------------------------- |
 | ++left++ <br/> ++h++ <br/> ++alt+h++  | Moves the cursor left                        |
 | ++right++ <br/> ++l++ <br/> ++alt+l++ | Moves the cursor right                       |
-| ++tab++                               | Toggle between searching by PID or name      |
 | ++esc++                               | Close the search widget (retains the filter) |
 | ++ctrl+a++                            | Skip to the start of the search query        |
 | ++ctrl+e++                            | Skip to the end of the search query          |

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -287,9 +287,8 @@ pub const PROCESS_HELP_TEXT: [&str; 15] = [
     "click on header  Sorts the entries by that column, click again to invert the sort",
 ];
 
-pub const SEARCH_HELP_TEXT: [&str; 49] = [
+pub const SEARCH_HELP_TEXT: [&str; 48] = [
     "4 - Process search widget",
-    "Tab              Toggle between searching for PID and name",
     "Esc              Close the search widget (retains the filter)",
     "Ctrl-a           Skip to the start of the search query",
     "Ctrl-e           Skip to the end of the search query",


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Removes an incorrect shortcut. No idea when that got there.

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Furthermore, mark which platforms this change was tested on. All platforms directly affected by the change **must** be tested_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
