### PR TITLE
Prominently display the binary name in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bottom
+# bottom (btm)
 
 [<img src="https://img.shields.io/github/workflow/status/ClementTsang/bottom/ci/master?style=flat-square&logo=github" alt="CI status">](https://github.com/ClementTsang/bottom/actions?query=branch%3Amaster)
 [<img src="https://img.shields.io/crates/v/bottom.svg?style=flat-square" alt="crates.io link">](https://crates.io/crates/bottom)


### PR DESCRIPTION
## Description

This is purely a documentation change to prominently feature the name of the binary. The formatting was adopted from the [ripgrep](https://github.com/BurntSushi/ripgrep) project, which also has a mismatch between the project and binary name, but any other placement of the binary name in the title or first few lines of the README would also be a good fix.

## Issue

Currently the only mention of the binary name is in the `Usage` section, near the bottom of the README. A more prominent placement of the name of the binary is probably a good idea from a usability perspective.
