### PR TITLE
ci: go back to a paths_ignore for ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           concurrent_skipping: "same_content_newer"
           skip_after_successful_duplicate: "true"
-          paths: '["tests/**", "src/**", ".github/workflows/ci.yml", ".cargo/**", "Cargo.toml", "Cargo.lock", "build.rs", "clippy.toml", "rustfmt.toml"]'
+          paths_ignore: '["**/README.md", "**/docs/**", "assets/**", ".cargo-husky/**", ".all-contributorsrc", ".gitignore", ".markdownlint.json", "deployment/**", ".github/ISSUE_TEMPLATE/**", "CHANGELOG.md", "CONTRIBUTING.md"]'
           do_not_skip: '["workflow_dispatch"]'
 
   rustfmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,8 @@ jobs:
 
   # Run cargo --check on all platforms
   check:
-    needs: [rustfmt, clippy]
+    needs: [pre_job, rustfmt, clippy]
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.triple.os }}
     continue-on-error: true
     strategy:
@@ -207,7 +208,8 @@ jobs:
 
   # Check without the battery feature enabled on x86-64 for supported operating systems
   check-without-battery:
-    needs: [rustfmt, clippy]
+    needs: [pre_job, rustfmt, clippy]
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.triple.os }}
     continue-on-error: true
     strategy:
@@ -257,7 +259,8 @@ jobs:
 
   # Run tests x86-64 for supported operating systems
   test:
-    needs: [rustfmt, clippy]
+    needs: [pre_job, rustfmt, clippy]
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.triple.os }}
     continue-on-error: true
     strategy:


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Reverts to using `paths_ignore` for CI workflow.