### PR TITLE
bug: Fix process command flag breaking sorting

### DIFF
--- a/src/app/states.rs
+++ b/src/app/states.rs
@@ -510,6 +510,10 @@ impl ProcWidgetState {
             columns.toggle(&ProcessSorting::Mem);
             columns.toggle(&ProcessSorting::MemPercent);
         }
+        if is_using_command {
+            columns.toggle(&ProcessSorting::ProcessName);
+            columns.toggle(&ProcessSorting::Command);
+        }
 
         ProcWidgetState {
             process_search_state,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -118,7 +118,7 @@ fn main() -> Result<()> {
     terminal.hide_cursor()?;
 
     // Set panic hook
-    panic::set_hook(Box::new(|info| panic_hook(info)));
+    panic::set_hook(Box::new(panic_hook));
 
     // Set termination hook
     let is_terminated = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Fixes the `process_command` flag/config not properly toggling off the `name` column and on the `command` column on initialization.  This would cause sorting of that column to bug out.

## Issue

_If applicable, what issue does this address?_

Closes: #626

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Furthermore, mark which platforms this change was tested on. All platforms directly affected by the change **must** be tested_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
