### PR TITLE
ci: adds cloudflare pages deploy hook

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,3 +40,7 @@ jobs:
         run: |
           cd docs
           mike deploy nightly --push
+
+      - name: Deploy to CF Pages
+        run: |
+          curl -X POST ${CFP_HOOK}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -52,6 +52,10 @@ jobs:
           cd docs
           mike deploy --push --update-aliases ${RELEASE_VERSION} stable
 
+      - name: Deploy to CF Pages
+        run: |
+          curl -X POST ${CFP_HOOK}
+
   packaging:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds a CFP hook to deploy.  This is a workaround since we currently cannot disable non-production branch builds.

