### PR TITLE
bug/ci: fix debian file generation breaking completions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -338,9 +338,9 @@ jobs:
           mkdir completion
           cp -r ./target/release/build/bottom-*/out/. completion
 
-      - name: Build Debian release (Linux x86-64 GNU)
+      - name: Build Debian release
         run: |
-          cargo install cargo-deb --version 1.29.0 --locked
+          cargo install cargo-deb --version 1.34.0 --locked
           cargo deb --no-build
           cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -331,7 +331,6 @@ jobs:
         with:
           command: build
           args: --release --verbose --features "battery"
-          use-cross: ${{ matrix.triple.cross }}
 
       - name: Move autocomplete to working directory
         shell: bash

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -326,10 +326,23 @@ jobs:
         with:
           key: x86_64-unknown-linux-gnu-deb
 
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --verbose --features "battery"
+          use-cross: ${{ matrix.triple.cross }}
+
+      - name: Move autocomplete to working directory
+        shell: bash
+        run: |
+          mkdir completion
+          cp -r ./target/release/build/bottom-*/out/. completion
+
       - name: Build Debian release (Linux x86-64 GNU)
         run: |
           cargo install cargo-deb --version 1.29.0 --locked
-          cargo deb
+          cargo deb --no-build
           cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
 
       - name: Create release directory for artifact, move file

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -318,7 +318,6 @@ jobs:
         with:
           command: build
           args: --release --verbose --features "battery"
-          use-cross: ${{ matrix.triple.cross }}
 
       - name: Move autocomplete to working directory
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -327,7 +327,7 @@ jobs:
 
       - name: Build Debian release
         run: |
-          cargo install cargo-deb --version 1.29.0 --locked
+          cargo install cargo-deb --version 1.34.0 --locked
           cargo deb --no-build
           cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -313,10 +313,23 @@ jobs:
         with:
           key: x86_64-unknown-linux-gnu-deb
 
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --verbose --features "battery"
+          use-cross: ${{ matrix.triple.cross }}
+
+      - name: Move autocomplete to working directory
+        shell: bash
+        run: |
+          mkdir completion
+          cp -r ./target/release/build/bottom-*/out/. completion
+
       - name: Build Debian release
         run: |
           cargo install cargo-deb --version 1.29.0 --locked
-          cargo deb
+          cargo deb --no-build
           cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
 
       - name: Create release directory for artifact, move file

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,20 +92,16 @@ assets = [
     ["target/release/btm", "usr/bin/", "755"],
     ["LICENSE", "usr/share/doc/btm/", "644"],
     [
-        "target/release/build/bottom-*/out/btm.bash",
+        "completion/btm.bash",
         "usr/share/bash-completion/completions/btm",
         "644",
     ],
     [
-        "target/release/build/bottom-*/out/btm.fish",
+        "completion/btm.fish",
         "usr/share/fish/vendor_completions.d/btm.fish",
         "644",
     ],
-    [
-        "target/release/build/bottom-*/out/_btm",
-        "usr/share/zsh/vendor-completions/",
-        "644",
-    ],
+    ["completion/_btm", "usr/share/zsh/vendor-completions/", "644"],
 ]
 extended-description = """\
 A cross-platform graphical process/system monitor with a customizable interface and a multitude of


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Fixes completion file generation being broken while the `.deb` file is made, due to using an incorrect path.

## Issue

_If applicable, what issue does this address?_

Closes: #644

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Please also indicate which platforms were tested. All platforms directly affected by the change **must** be tested:_

Tested by running the nightly pipeline in mock, which will trigger the `.deb` file generation.

Action run: https://github.com/ClementTsang/bottom/actions/runs/1628351846

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
