### PR TITLE
docs: indicate stable version in selector on deploy

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -47,10 +47,14 @@ jobs:
           echo Name: $(git config --get user.name)
           echo Email: $(git config --get user.email)
 
-      - name: Build and deploy docs with mike
+      - name: Build and deploy docs with mike as the latest stable branch
         run: |
           cd docs
+          OLD_STABLE_VERSION=$(mike list stable | grep -Po '([0-9]+.[0-9]+.[0-9]+)' | head -n1)
+          echo ${OLD_STABLE_VERSION}
+          mike retitle --push stable ${OLD_STABLE_VERSION}
           mike deploy --push --update-aliases ${RELEASE_VERSION} stable
+          mike retitle --push ${RELEASE_VERSION} "${RELEASE_VERSION} (stable)"
 
       # - name: Deploy to CF Pages
       #   run: |


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds an indicator in the form of `$version (stable)` to make it easier to see which is the most recent stable version.

This is done via CI and mike:

1. Set the previous title to just `$version`. We can get this value by `mike list stable` and grepping for valid version tags (otherwise this might have issues with `$version (stable)`).
2. Deploy `$new_version` and alias to stable.
3. Update the `$new_version` to have a new title of `$new_version (stable)`.

This is what it looks like:

![image](https://user-images.githubusercontent.com/34804052/147863843-ecd6a28e-8317-4a52-8f52-11b324a53e63.png)


## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Tested via manually executing the commands in the deploy script for version 0.6.6... so it _should_ be fine.

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
