### PR TITLE
docs: center the title/description in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# bottom (btm)
+<div align="center">
+  <h1>bottom (btm)</h1>
+
+  <p>
+  A cross-platform graphical process/system monitor with a customizable interface and a multitude of features.<br />Supports Linux, macOS, and Windows. Inspired by <a href=https://github.com/aksakalli/gtop>gtop</a>, <a href=https://github.com/xxxserxxx/gotop>gotop</a>, and <a href=https://github.com/htop-dev/htop/>htop</a>.
+  </p>
 
 [<img src="https://img.shields.io/github/workflow/status/ClementTsang/bottom/ci/master?style=flat-square&logo=github" alt="CI status">](https://github.com/ClementTsang/bottom/actions?query=branch%3Amaster)
 [<img src="https://img.shields.io/codecov/c/github/ClementTsang/bottom?color=%23d9634d&logo=codecov&style=flat-square&token=IDD43CO0FP" alt="Codecov">](https://app.codecov.io/gh/ClementTsang/bottom)
@@ -6,7 +11,7 @@
 [<img src="https://img.shields.io/badge/docs-nightly-88c0d0?style=flat-square&labelColor=555555&logoColor=white" alt="Nightly documentation">](https://clementtsang.github.io/bottom/nightly)
 [<img src="https://img.shields.io/badge/docs-stable-66c2a5?style=flat-square&labelColor=555555&logoColor=white" alt="Stable documentation">](https://clementtsang.github.io/bottom/stable)
 
-A cross-platform graphical process/system monitor with a customizable interface and a multitude of features. Supports Linux, macOS, and Windows. Inspired by [gtop](https://github.com/aksakalli/gtop), [gotop](https://github.com/xxxserxxx/gotop), and [htop](https://github.com/htop-dev/htop/).
+</div>
 
 <figure>
     <img src="assets/demo.gif" alt="Quick demo recording showing off searching, expanding, and process killing."/>

--- a/README.md
+++ b/README.md
@@ -13,14 +13,12 @@
 
 </div>
 
-<figure>
-    <img src="assets/demo.gif" alt="Quick demo recording showing off searching, expanding, and process killing."/>
-    <center>
-    <figcaption>
-      Demo GIF using the <a href="https://github.com/morhetz/gruvbox">Gruvbox</a> theme (<code>--color gruvbox</code>), along with <a href="https://www.ibm.com/plex/">IBM Plex Mono</a> and <a href="https://sw.kovidgoyal.net/kitty/">Kitty</a>
-    </figcaption>
-    </center>
-</figure>
+<img src="assets/demo.gif" alt="Quick demo recording showing off bottom's searching, expanding, and process killing."/>
+<div align="center">
+  <p>
+    Demo GIF using the <a href="https://github.com/morhetz/gruvbox">Gruvbox</a> theme (<code>--color gruvbox</code>), along with <a href="https://www.ibm.com/plex/">IBM Plex Mono</a> and <a href="https://sw.kovidgoyal.net/kitty/">Kitty</a>
+  </p>
+</div>
 
 ## Features
 


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Centers the title and description in the README via some ugly HTML.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
