### PR TITLE
bug: fix issues caused by having a width that is too small

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/bin/main.rs"
 doc = false
 
 [lib]
-test = false
+test = true
 doctest = false
 doc = false
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -556,44 +556,62 @@ impl Painter {
                     .direction(Direction::Horizontal)
                     .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
                     .split(vertical_chunks[1]);
-                self.draw_basic_cpu(f, app_state, vertical_chunks[0], 1);
-                self.draw_basic_memory(f, app_state, middle_chunks[0], 2);
-                self.draw_basic_network(f, app_state, middle_chunks[1], 3);
+
+                if vertical_chunks[0].width >= 2 {
+                    self.draw_basic_cpu(f, app_state, vertical_chunks[0], 1);
+                }
+                if middle_chunks[0].width >= 2 {
+                    self.draw_basic_memory(f, app_state, middle_chunks[0], 2);
+                }
+                if middle_chunks[1].width >= 2 {
+                    self.draw_basic_network(f, app_state, middle_chunks[1], 3);
+                }
 
                 let mut later_widget_id: Option<u64> = None;
                 if let Some(basic_table_widget_state) = &app_state.basic_table_widget_state {
                     let widget_id = basic_table_widget_state.currently_displayed_widget_id;
                     later_widget_id = Some(widget_id);
-                    match basic_table_widget_state.currently_displayed_widget_type {
-                        Disk => {
-                            self.draw_disk_table(f, app_state, vertical_chunks[3], false, widget_id)
-                        }
-                        Proc | ProcSort => {
-                            let wid = widget_id
-                                - match basic_table_widget_state.currently_displayed_widget_type {
-                                    ProcSearch => 1,
-                                    ProcSort => 2,
-                                    _ => 0,
-                                };
-                            self.draw_process_features(
+                    if vertical_chunks[3].width >= 2 {
+                        match basic_table_widget_state.currently_displayed_widget_type {
+                            Disk => self.draw_disk_table(
                                 f,
                                 app_state,
                                 vertical_chunks[3],
                                 false,
-                                wid,
-                            );
+                                widget_id,
+                            ),
+                            Proc | ProcSort => {
+                                let wid = widget_id
+                                    - match basic_table_widget_state.currently_displayed_widget_type
+                                    {
+                                        ProcSearch => 1,
+                                        ProcSort => 2,
+                                        _ => 0,
+                                    };
+                                self.draw_process_features(
+                                    f,
+                                    app_state,
+                                    vertical_chunks[3],
+                                    false,
+                                    wid,
+                                );
+                            }
+                            Temp => self.draw_temp_table(
+                                f,
+                                app_state,
+                                vertical_chunks[3],
+                                false,
+                                widget_id,
+                            ),
+                            Battery => self.draw_battery_display(
+                                f,
+                                app_state,
+                                vertical_chunks[3],
+                                false,
+                                widget_id,
+                            ),
+                            _ => {}
                         }
-                        Temp => {
-                            self.draw_temp_table(f, app_state, vertical_chunks[3], false, widget_id)
-                        }
-                        Battery => self.draw_battery_display(
-                            f,
-                            app_state,
-                            vertical_chunks[3],
-                            false,
-                            widget_id,
-                        ),
-                        _ => {}
                     }
                 }
 
@@ -709,32 +727,34 @@ impl Painter {
     ) {
         use BottomWidgetType::*;
         for (widget, widget_draw_loc) in widgets.children.iter().zip(widget_draw_locs) {
-            match &widget.widget_type {
-                Empty => {}
-                Cpu => self.draw_cpu(f, app_state, *widget_draw_loc, widget.widget_id),
-                Mem => self.draw_memory_graph(f, app_state, *widget_draw_loc, widget.widget_id),
-                Net => self.draw_network(f, app_state, *widget_draw_loc, widget.widget_id),
-                Temp => {
-                    self.draw_temp_table(f, app_state, *widget_draw_loc, true, widget.widget_id)
+            if widget_draw_loc.width >= 2 && widget_draw_loc.height >= 2 {
+                match &widget.widget_type {
+                    Empty => {}
+                    Cpu => self.draw_cpu(f, app_state, *widget_draw_loc, widget.widget_id),
+                    Mem => self.draw_memory_graph(f, app_state, *widget_draw_loc, widget.widget_id),
+                    Net => self.draw_network(f, app_state, *widget_draw_loc, widget.widget_id),
+                    Temp => {
+                        self.draw_temp_table(f, app_state, *widget_draw_loc, true, widget.widget_id)
+                    }
+                    Disk => {
+                        self.draw_disk_table(f, app_state, *widget_draw_loc, true, widget.widget_id)
+                    }
+                    Proc => self.draw_process_features(
+                        f,
+                        app_state,
+                        *widget_draw_loc,
+                        true,
+                        widget.widget_id,
+                    ),
+                    Battery => self.draw_battery_display(
+                        f,
+                        app_state,
+                        *widget_draw_loc,
+                        true,
+                        widget.widget_id,
+                    ),
+                    _ => {}
                 }
-                Disk => {
-                    self.draw_disk_table(f, app_state, *widget_draw_loc, true, widget.widget_id)
-                }
-                Proc => self.draw_process_features(
-                    f,
-                    app_state,
-                    *widget_draw_loc,
-                    true,
-                    widget.widget_id,
-                ),
-                Battery => self.draw_battery_display(
-                    f,
-                    app_state,
-                    *widget_draw_loc,
-                    true,
-                    widget.widget_id,
-                ),
-                _ => {}
             }
         }
     }

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -282,9 +282,6 @@ impl Painter {
         self.styled_help_text = styled_help_spans.into_iter().map(Spans::from).collect();
     }
 
-    // FIXME: [CONFIG] write this, should call painter init and any changed colour functions...
-    pub fn update_painter_colours(&mut self) {}
-
     fn draw_frozen_indicator<B: Backend>(&self, f: &mut Frame<'_, B>, draw_loc: Rect) {
         f.render_widget(
             Paragraph::new(Span::styled(

--- a/src/canvas/drawing_utils.rs
+++ b/src/canvas/drawing_utils.rs
@@ -89,25 +89,15 @@ pub fn get_column_widths(
             }
         }
 
-        let mut filtered_column_widths: Vec<u16> = vec![];
-        let mut still_seeing_zeros = true;
-        column_widths.iter().rev().for_each(|width| {
-            if still_seeing_zeros {
-                if *width != 0 {
-                    still_seeing_zeros = false;
-                    filtered_column_widths.push(*width);
-                }
-            } else {
-                filtered_column_widths.push(*width);
-            }
-        });
-        filtered_column_widths.reverse();
+        while let Some(0) = column_widths.last() {
+            column_widths.pop();
+        }
 
-        if !filtered_column_widths.is_empty() {
+        if !column_widths.is_empty() {
             // Redistribute remaining.
-            let amount_per_slot = total_width_left / filtered_column_widths.len() as u16;
+            let amount_per_slot = total_width_left / column_widths.len() as u16;
             total_width_left %= column_widths.len() as u16;
-            for (index, width) in filtered_column_widths.iter_mut().enumerate() {
+            for (index, width) in column_widths.iter_mut().enumerate() {
                 if (index as u16) < total_width_left {
                     *width += amount_per_slot + 1;
                 } else {
@@ -116,17 +106,11 @@ pub fn get_column_widths(
             }
         }
 
-        filtered_column_widths
+        column_widths
     } else {
         vec![]
     }
 }
-
-/// FIXME: [command move] This is a greedy method of determining column widths.  This is reserved for columns where we are okay with
-/// shoving information as far right as required.
-// pub fn greedy_get_column_widths() -> Vec<u16> {
-//     vec![]
-// }
 
 pub fn get_search_start_position(
     num_columns: usize, cursor_direction: &app::CursorDirection, cursor_bar: &mut usize,

--- a/src/canvas/drawing_utils.rs
+++ b/src/canvas/drawing_utils.rs
@@ -205,3 +205,56 @@ pub fn interpolate_points(point_one: &(f64, f64), point_two: &(f64, f64), time: 
 
     (point_one.1 + (time - point_one.0) * slope).max(0.0)
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_zero_width() {
+        assert_eq!(
+            get_column_widths(
+                0,
+                &[Some(1), None, None],
+                &[None, Some(1), Some(2)],
+                &[None, Some(0.125), Some(0.5)],
+                &[None, Some(10), Some(10)],
+                true
+            ),
+            vec![],
+            "vector should be empty"
+        );
+    }
+
+    #[test]
+    fn test_two_width() {
+        assert_eq!(
+            get_column_widths(
+                2,
+                &[Some(1), None, None],
+                &[None, Some(1), Some(2)],
+                &[None, Some(0.125), Some(0.5)],
+                &[None, Some(10), Some(10)],
+                true
+            ),
+            vec![],
+            "vector should be empty"
+        );
+    }
+
+    #[test]
+    fn test_non_zero_width() {
+        assert_eq!(
+            get_column_widths(
+                16,
+                &[Some(1), None, None],
+                &[None, Some(1), Some(2)],
+                &[None, Some(0.125), Some(0.5)],
+                &[None, Some(10), Some(10)],
+                true
+            ),
+            vec![2, 2, 7],
+            "vector should not be empty"
+        );
+    }
+}


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Due to a missing check, you could resize the window to a width that was too small, and it would trigger an endless while-loop for any table while trying to redistribute remaining space. This has been rectified with an explicit check, as well as a smarter method of redistributing remaining space borrowed from the rewrite.

This also adds explicit width checks for widgets that have borders; if the width is <2, before, it would panic.

Note that the rewrite I have kinda fixes all these issues already, so I don't want to invest too hard into this, but this should be fine as a patch for now.

Also note that minimal heights don't seem to be causing any issues, it just seems to be minimal widths.

## Issue

_If applicable, what issue does this address?_

Closes: #664 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Please also indicate which platforms were tested. All platforms directly affected by the change **must** be tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
