### PR TITLE
Refresh sysinfo CPU

### DIFF
--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -211,6 +211,7 @@ impl DataCollector {
         #[cfg(not(target_os = "linux"))]
         {
             if self.widgets_to_harvest.use_proc {
+                self.sys.refresh_cpu();
                 self.sys.refresh_processes();
             }
             if self.widgets_to_harvest.use_temp {


### PR DESCRIPTION
## Description

Without this now sysinfo `sys.processors().len()` returns 0, and makes a lot of CPU usages in process list `inf%`.

## Issue

N/A

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Please also indicate which platforms were tested. All platforms directly affected by the change **must** be tested:_

- [ ] _Windows_
- [x] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
