### PR TITLE
ci: disable 32-bit in choco generation

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -389,7 +389,7 @@ jobs:
 
       - name: Execute choco packaging script
         run: |
-          python "./deployment/windows/choco/choco_packager.py" "./release/bottom_i686-pc-windows-msvc.zip" "./release/bottom_x86_64-pc-windows-msvc.zip" ${{ env.RELEASE_VERSION }} "./deployment/windows/choco/bottom.nuspec.template" "./deployment/windows/choco/chocolateyinstall.ps1.template" "bottom.nuspec" "tools/chocolateyinstall.ps1" "tools/"
+          python "./deployment/windows/choco/choco_packager.py" "./release/bottom_x86_64-pc-windows-msvc.zip" ${{ env.RELEASE_VERSION }} "./deployment/windows/choco/bottom.nuspec.template" "./deployment/windows/choco/chocolateyinstall.ps1.template" "bottom.nuspec" "tools/chocolateyinstall.ps1" "tools/"
           zip -r choco.zip "bottom.nuspec" "tools"
 
       - name: Move release file into release directory

--- a/deployment/windows/choco/choco_packager.py
+++ b/deployment/windows/choco/choco_packager.py
@@ -7,17 +7,15 @@ from string import Template
 import os
 
 args = sys.argv
-deployment_file_path_32 = args[1]
-deployment_file_path_64 = args[2]
-version = args[3]
-nuspec_template = args[4]
-ps1_template = args[5]
-generated_nuspec = args[6]
-generated_ps1 = args[7]
-generated_ps1_dir = args[8]
+deployment_file_path_64 = args[1]
+version = args[2]
+nuspec_template = args[3]
+ps1_template = args[4]
+generated_nuspec = args[5]
+generated_ps1 = args[6]
+generated_ps1_dir = args[7]
 
 print("Generating Chocolatey package for:")
-print("     32-bit: %s" % deployment_file_path_32)
 print("     64-bit: %s" % deployment_file_path_64)
 print("     VERSION: %s" % version)
 print("     NUSPEC TEMPLATE: %s" % nuspec_template)
@@ -26,14 +24,10 @@ print("     GENERATED NUSPEC: %s" % generated_nuspec)
 print("     GENERATED PS1: %s" % generated_ps1)
 print("     GENERATED PS1 DIR: %s" % generated_ps1_dir)
 
-with open(deployment_file_path_32, "rb") as deployment_file_32, open(
-    deployment_file_path_64, "rb"
-) as deployment_file_64:
-    hash_32 = hashlib.sha1(deployment_file_32.read()).hexdigest()
+with open(deployment_file_path_64, "rb") as deployment_file_64:
     hash_64 = hashlib.sha1(deployment_file_64.read()).hexdigest()
 
-    print("Generated 32 hash: %s" % str(hash_32))
-    print("Generated 64 hash: %s" % str(hash_64))
+    print("Generated hash for 64-bit program: %s" % str(hash_64))
 
     with open(nuspec_template, "r") as template_file:
         template = Template(template_file.read())
@@ -48,7 +42,7 @@ with open(deployment_file_path_32, "rb") as deployment_file_32, open(
     os.makedirs(generated_ps1_dir)
     with open(ps1_template, "r") as template_file:
         template = Template(template_file.read())
-        substitute = template.safe_substitute(version=version, hash_32=hash_32, hash_64=hash_64)
+        substitute = template.safe_substitute(version=version, hash_64=hash_64)
         print("\n================== Generated chocolatey-install file ==================\n")
         print(substitute)
         print("\n============================================================\n")

--- a/deployment/windows/choco/chocolateyinstall.ps1.template
+++ b/deployment/windows/choco/chocolateyinstall.ps1.template
@@ -1,7 +1,6 @@
 $ErrorActionPreference = 'Stop';
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://github.com/ClementTsang/bottom/releases/download/$version/bottom_i686-pc-windows-msvc.zip'
-$url64      = 'https://github.com/ClementTsang/bottom/releases/download/$version/bottom_x86_64-pc-windows-msvc.zip'
+$url        = 'https://github.com/ClementTsang/bottom/releases/download/$version/bottom_x86_64-pc-windows-msvc.zip'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
@@ -9,12 +8,9 @@ $packageArgs = @{
   unzipLocation = $toolsDir
   fileType      = 'exe'
   url           = $url
-  url64bit      = $url64
-
-  checksum      = '$hash_32'
+  checksum      = '$hash_64'
   checksumType  = 'sha1'
-  checksum64    = '$hash_64'
-  checksumType64= 'sha1'
 
 }
 Install-ChocolateyZipPackage @packageArgs
+j


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Seems like the 32-bit binary triggers false positives on VirusTotal. Going to disable this for now.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
