### PR TITLE
Add support for nvidia GPUs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "itertools",
  "libc",
  "log",
+ "nvml-wrapper",
  "once_cell",
  "predicates 1.0.8",
  "procfs",
@@ -324,7 +325,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -460,6 +461,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.9.3",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +583,12 @@ checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
@@ -840,6 +882,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +938,16 @@ name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+
+[[package]]
+name = "libloading"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "lock_api"
@@ -1049,6 +1107,29 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "nvml-wrapper"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6fb95ab904553d1b8914d340cadd0b34bee1cc984668eaa096a018f04ed8b8"
+dependencies = [
+ "bitflags",
+ "libloading",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be195fa681ad2a9c903a866bc3f97f174333f04fb7b9e7c1f2413452f698484"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -1376,10 +1457,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
@@ -1590,3 +1683,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bcc065c85ad2c3bd12aa4118bf164835712e25080c392557801a13292c60aec"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ opt-level = 3
 codegen-units = 1
 
 [features]
-default = ["fern", "log", "battery"]
+default = ["fern", "log", "battery", "gpu"]
+gpu = ["nvidia"]
+nvidia = ["nvml-wrapper"]
 
 [dependencies]
 anyhow = "1.0.40"
@@ -64,6 +66,7 @@ unicode-width = "0.1"
 fern = { version = "0.6.0", optional = true }
 log = { version = "0.4.14", optional = true }
 battery = { version = "0.7.8", optional = true }
+nvml-wrapper = { version = "0.7.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.86"

--- a/src/app/data_harvester/temperature/heim.rs
+++ b/src/app/data_harvester/temperature/heim.rs
@@ -49,6 +49,11 @@ pub async fn get_temperature_data(
         }
     }
 
+    #[cfg(feature = "nvidia")]
+    {
+        super::nvidia::add_nvidia_data(&mut temperature_vec, temp_type, filter)?;
+    }
+
     temp_vec_sort(&mut temperature_vec);
     Ok(Some(temperature_vec))
 }

--- a/src/app/data_harvester/temperature/mod.rs
+++ b/src/app/data_harvester/temperature/mod.rs
@@ -13,6 +13,9 @@ cfg_if::cfg_if! {
     }
 }
 
+#[cfg(feature = "nvidia")]
+pub mod nvidia;
+
 use std::cmp::Ordering;
 
 use crate::app::Filter;
@@ -33,6 +36,18 @@ pub enum TemperatureType {
 impl Default for TemperatureType {
     fn default() -> Self {
         TemperatureType::Celsius
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(any(feature = "nvidia", target_os = "macos", target_os = "windows"))] {
+        fn convert_celsius_to_kelvin(celsius: f32) -> f32 {
+            celsius + 273.15
+        }
+
+        fn convert_celsius_to_fahrenheit(celsius: f32) -> f32 {
+            (celsius * (9.0 / 5.0)) + 32.0
+        }
     }
 }
 

--- a/src/app/data_harvester/temperature/nvidia.rs
+++ b/src/app/data_harvester/temperature/nvidia.rs
@@ -1,0 +1,39 @@
+use crate::app::Filter;
+
+use super::{
+    convert_celsius_to_fahrenheit, convert_celsius_to_kelvin, is_temp_filtered, TempHarvest,
+    TemperatureType,
+};
+
+use nvml_wrapper::{enum_wrappers::device::TemperatureSensor, NVML};
+
+pub fn add_nvidia_data(
+    temperature_vec: &mut Vec<TempHarvest>, temp_type: &TemperatureType, filter: &Option<Filter>,
+) -> crate::utils::error::Result<()> {
+    if let Ok(nvml) = NVML::init() {
+        if let Ok(ngpu) = nvml.device_count() {
+            for i in 0..ngpu {
+                if let Ok(device) = nvml.device_by_index(i) {
+                    if let (Ok(name), Ok(temperature)) =
+                        (device.name(), device.temperature(TemperatureSensor::Gpu))
+                    {
+                        if is_temp_filtered(filter, &name) {
+                            let temperature = temperature as f32;
+                            let temperature = match temp_type {
+                                TemperatureType::Celsius => temperature,
+                                TemperatureType::Kelvin => convert_celsius_to_kelvin(temperature),
+                                TemperatureType::Fahrenheit => {
+                                    convert_celsius_to_fahrenheit(temperature)
+                                }
+                            };
+
+                            temperature_vec.push(TempHarvest { name, temperature });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/app/data_harvester/temperature/sysinfo.rs
+++ b/src/app/data_harvester/temperature/sysinfo.rs
@@ -1,6 +1,9 @@
 //! Gets temperature data via sysinfo.
 
-use super::{is_temp_filtered, temp_vec_sort, TempHarvest, TemperatureType};
+use super::{
+    convert_celsius_to_fahrenheit, convert_celsius_to_kelvin, is_temp_filtered, temp_vec_sort,
+    TempHarvest, TemperatureType,
+};
 use crate::app::Filter;
 
 pub async fn get_temperature_data(
@@ -10,14 +13,6 @@ pub async fn get_temperature_data(
 
     if !actually_get {
         return Ok(None);
-    }
-
-    fn convert_celsius_to_kelvin(celsius: f32) -> f32 {
-        celsius + 273.15
-    }
-
-    fn convert_celsius_to_fahrenheit(celsius: f32) -> f32 {
-        (celsius * (9.0 / 5.0)) + 32.0
     }
 
     let mut temperature_vec: Vec<TempHarvest> = Vec::new();
@@ -38,6 +33,11 @@ pub async fn get_temperature_data(
                 },
             });
         }
+    }
+
+    #[cfg(feature = "nvidia")]
+    {
+        super::nvidia::add_nvidia_data(&mut temperature_vec, temp_type, filter)?;
     }
 
     temp_vec_sort(&mut temperature_vec);


### PR DESCRIPTION
## Description

I added the support for nvidia's GPUs temperature using the crate nvml-wrapper that load the nvml library only if it exists, so you can use it optionally even if the nvidia flag is setted. Interestingly on my test on my Windows machine no sensors are found except the nvidia's one. I tested it on Windows 10 with GeForce 1080, on the same machine with ArchLinux and on a Mid 2014 MacBook Pro 14" Retina. I let the tests run on Github Actions' CI and seems that nothing brokes.

Here some screenshots:

- Windows 10:
![image](https://user-images.githubusercontent.com/203655/153810055-b0d1bd94-1ae4-4da1-878b-83f8f03b923d.png)

- ArchLinux:
![image](https://user-images.githubusercontent.com/203655/153810085-0ba8065e-c148-47da-aa25-c19d1aecc329.png)

- MacOS:
![image](https://user-images.githubusercontent.com/203655/153810125-5f642b4b-4d53-4f1e-9e52-3dbfe1d5c8af.png)


