### PR TITLE
ci: enable strip on release builds with Cargo.toml

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -59,7 +59,6 @@ jobs:
               os: "ubuntu-18.04",
               target: "x86_64-unknown-linux-gnu",
               cross: false,
-              strip: true,
             }
           - {
               os: "ubuntu-18.04",
@@ -67,31 +66,26 @@ jobs:
               cross: false,
               container: quay.io/pypa/manylinux2014_x86_64,
               suffix: "2-17",
-              strip: true,
             }
           - {
               os: "ubuntu-18.04",
               target: "i686-unknown-linux-gnu",
               cross: true,
-              strip: true,
             }
           - {
               os: "ubuntu-18.04",
               target: "x86_64-unknown-linux-musl",
               cross: false,
-              strip: true,
             }
           - {
               os: "ubuntu-18.04",
               target: "i686-unknown-linux-musl",
               cross: true,
-              strip: true,
             }
           - {
               os: "macOS-latest",
               target: "x86_64-apple-darwin",
               cross: false,
-              strip: true,
             }
           - {
               os: "windows-2019",
@@ -163,13 +157,6 @@ jobs:
         run: |
           mkdir completion
           cp -r ./target/${{ matrix.triple.target }}/release/build/bottom-*/out/. completion
-
-      - name: Strip release binary (macOS or Linux x86-64/i686)
-        if: matrix.triple.strip == true
-        run: |
-          strip target/${{ matrix.triple.target }}/release/btm
-
-      # TODO: Strip ARM
 
       - name: Bundle release and completion (Windows)
         if: matrix.triple.os == 'windows-2019'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,7 +55,6 @@ jobs:
               os: "ubuntu-18.04",
               target: "x86_64-unknown-linux-gnu",
               cross: false,
-              strip: true,
             }
           - {
               os: "ubuntu-18.04",
@@ -63,32 +62,23 @@ jobs:
               cross: false,
               container: quay.io/pypa/manylinux2014_x86_64,
               suffix: "2-17",
-              strip: true,
             }
           - {
               os: "ubuntu-18.04",
               target: "i686-unknown-linux-gnu",
               cross: true,
-              strip: true,
             }
           - {
               os: "ubuntu-18.04",
               target: "x86_64-unknown-linux-musl",
               cross: false,
-              strip: true,
             }
           - {
               os: "ubuntu-18.04",
               target: "i686-unknown-linux-musl",
               cross: true,
-              strip: true,
             }
-          - {
-              os: "macOS-latest",
-              target: "x86_64-apple-darwin",
-              cross: false,
-              strip: true,
-            }
+          - { os: "macOS-latest", target: "x86_64-apple-darwin", cross: false }
           - {
               os: "windows-2019",
               target: "x86_64-pc-windows-msvc",
@@ -159,13 +149,6 @@ jobs:
         run: |
           mkdir completion
           cp -r ./target/${{ matrix.triple.target }}/release/build/bottom-*/out/. completion
-
-      - name: Strip release binary (macOS or Linux x86-64/i686)
-        if: matrix.triple.strip == true
-        run: |
-          strip target/${{ matrix.triple.target }}/release/btm
-
-      # TODO: Strip ARM
 
       - name: Bundle release and completion (Windows)
         if: matrix.triple.os == 'windows-2019'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ lto = true
 # lto = false
 opt-level = 3
 codegen-units = 1
+strip = "symbols"
 
 [features]
 default = ["fern", "log", "battery", "gpu"]


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Removes the manual `strip` used in favour of the now native functionality in Cargo.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Please also indicate which platforms were tested. All platforms directly affected by the change **must** be tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
