### PR TITLE
deps: update regex to 1.5.5 due to CVE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ fxhash = "0.2.1"
 indexmap = "1.6.2"
 itertools = "0.10.0"
 once_cell = "1.5.2"
-regex = "1.5.4"
+regex = "1.5.5"
 serde = { version = "1.0.125", features = ["derive"] }
 sysinfo = "0.23.4"
 thiserror = "1.0.24"


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Addresses [this CVE](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html) with the recommended fix of updating to 1.5.5.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Please also indicate which platforms were tested. All platforms directly affected by the change **must** be tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
