### PR TITLE
ci: use locked builds in deploy and nightly

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -145,7 +145,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --verbose --target=${{ matrix.triple.target }} --features "battery"
+          args: --release --verbose --locked --target=${{ matrix.triple.target }} --features "battery"
           use-cross: ${{ matrix.triple.cross }}
 
       - name: Build autocompletion and manpage
@@ -313,7 +313,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --verbose --features "battery"
+          args: --release --locked --verbose --features "battery"
 
       - name: Build autocompletion and manpage
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -141,7 +141,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --verbose --target=${{ matrix.triple.target }} --features "battery"
+          args: --release --locked --verbose --target=${{ matrix.triple.target }} --features "battery"
           use-cross: ${{ matrix.triple.cross }}
 
       - name: Build autocompletion and manpage
@@ -307,7 +307,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --verbose --features "battery"
+          args: --release --locked --verbose --features "battery"
 
       - name: Build autocompletion and manpage
         shell: bash

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Installation via cargo is done by installing the `bottom` crate:
 # If required, update Rust on the stable channel
 rustup update stable
 
-cargo install bottom
-
-# Alternatively, --locked may be required due to how cargo install works
 cargo install bottom --locked
+
+# Alternatively, --locked may be omitted if you wish to not used locked dependencies:
+cargo install bottom
 ```
 
 ### Arch Linux


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds `--locked` to the build process for nightly and deploy workflows.

Deploy: https://github.com/ClementTsang/bottom/actions/runs/2142876557

Nightly: https://github.com/ClementTsang/bottom/actions/runs/2142876145


## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Tested both workflows:

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
