### PR TITLE
add option to sort cpus by values

### DIFF
--- a/docs/content/configuration/command-line-flags.md
+++ b/docs/content/configuration/command-line-flags.md
@@ -16,6 +16,7 @@ The following flags can be provided to bottom in the command line to change the 
 | `--color <COLOR SCHEME>`              | Use a color scheme, use --help for supported values.           |
 | `-C, --config <CONFIG PATH>`          | Sets the location of the config file.                          |
 | `-u, --current_usage`                 | Sets process CPU% to be based on current CPU%.                 |
+| `-s, --cpu_sort`                      | Orders CPUs by value.                                          |
 | `-t, --default_time_value <MS>`       | Default time value for graphs in ms.                           |
 | `--default_widget_count <INT>`        | Sets the n'th selected widget type as the default.             |
 | `--default_widget_type <WIDGET TYPE>` | Sets the default widget type, use --help for more info.        |

--- a/docs/content/configuration/config-file/flags.md
+++ b/docs/content/configuration/config-file/flags.md
@@ -12,6 +12,7 @@ Most of the [command line flags](../../command-line-flags) have config file equi
 | `dot_marker`                 | Boolean                                                                                        | Uses a dot marker for graphs.                                  |
 | `left_legend`                | Boolean                                                                                        | Puts the CPU chart legend to the left side.                    |
 | `current_usage`              | Boolean                                                                                        | Sets process CPU% to be based on current CPU%.                 |
+| `cpu_sort`                   | Boolean                                                                                        | Orders CPUs by value.                                          |
 | `group_processes`            | Boolean                                                                                        | Groups processes with the same name by default.                |
 | `case_sensitive`             | Boolean                                                                                        | Enables case sensitivity by default.                           |
 | `whole_word`                 | Boolean                                                                                        | Enables whole-word matching by default.                        |

--- a/sample_configs/default_config.toml
+++ b/sample_configs/default_config.toml
@@ -17,6 +17,8 @@
 #left_legend = false
 # Whether to set CPU% on a process to be based on the total CPU or just current usage.
 #current_usage = false
+# Whether to order CPUs by value.
+#cpu_sort = false
 # Whether to group processes with the same name together by default.
 #group_processes = false
 # Whether to make process searching case sensitive by default.

--- a/src/app.rs
+++ b/src/app.rs
@@ -50,6 +50,7 @@ pub struct AppConfigFields {
     pub left_legend: bool,
     pub show_average_cpu: bool,
     pub use_current_cpu_total: bool,
+    pub cpu_sort: bool,
     pub use_basic_mode: bool,
     pub default_time_value: u64,
     pub time_interval: u64,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -207,6 +207,7 @@ fn main() -> Result<()> {
                                 &app.data_collection,
                                 &mut app.canvas_data.cpu_data,
                                 false,
+                                app.app_config_fields.cpu_sort,
                             );
                             app.canvas_data.load_avg_data = app.data_collection.load_avg_harvest;
                         }

--- a/src/clap.rs
+++ b/src/clap.rs
@@ -135,6 +135,12 @@ pub fn build_app() -> Command<'static> {
         .help("Sets process CPU% to be based on current CPU%.")
         .long_help("Sets process CPU% usage to be based on the current system CPU% usage rather than total CPU usage.");
 
+    let cpu_sort = Arg::new("cpu_sort")
+        .short('s')
+        .long("cpu_sort")
+        .help("Orders CPUs by value.")
+        .long_help("Orders CPUs in descending order by value.");
+
     // TODO: [DEBUG] Add a proper debugging solution.
 
     let disable_click = Arg::new("disable_click")
@@ -389,6 +395,7 @@ use CPU (3) as the default instead.
         .arg(network_use_log)
         .arg(network_use_binary_prefix)
         .arg(current_usage)
+        .arg(cpu_sort)
         .arg(use_old_network_legend)
         .arg(whole_word);
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -443,6 +443,8 @@ pub const CONFIG_TEXT: &str = r##"# This is a default config file for bottom.  A
 #left_legend = false
 # Whether to set CPU% on a process to be based on the total CPU or just current usage.
 #current_usage = false
+# Whether to order CPUs based on value.
+#cpu_sort = false
 # Whether to group processes with the same name together by default.
 #group_processes = false
 # Whether to make process searching case sensitive by default.

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -238,6 +238,24 @@ pub fn convert_cpu_data_points(
             break;
         }
     }
+
+    // order cpus in descending values excluding All & AVG
+    // better solution if Point is an array instead of tuple
+    // for sorting the graph (i.e the entire timeline)
+    // I need to sort the cpu values as they come in (the above block)
+    existing_cpu_data.sort_by(|a, b| {
+        let default_values = vec!["All".to_string(), "AVG".to_string()];
+        if default_values.contains(&a.cpu_name) || default_values.contains(&b.cpu_name) || a.cpu_data.is_empty() || b.cpu_data.is_empty() {
+            std::cmp::Ordering::Equal
+        } else if a.cpu_data[a.cpu_data.len() - 1].1 < b.cpu_data[b.cpu_data.len() - 1].1 {
+            std::cmp::Ordering::Greater
+        } else if a.cpu_data[a.cpu_data.len() - 1].1 == b.cpu_data[b.cpu_data.len() - 1].1 {
+            std::cmp::Ordering::Equal
+        } else {
+            std::cmp::Ordering::Less
+        }
+    });
+
 }
 
 pub fn convert_mem_data_points(

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -251,6 +251,7 @@ pub fn convert_cpu_data_points(
         for (itx, cpu) in data.cpu_data.iter().enumerate() {
             if let Some(cpu_data) = existing_cpu_data.get_mut(itx + 1) {
                 if itx > 0 { // skip sorting avg
+                    cpu_data.legend_value = format!("{:.0}%", sorted_cpu_data[itx-1].round());
                     cpu_data.cpu_data.push((-time_from_start, sorted_cpu_data[itx-1]));
                 } else {
                     cpu_data.cpu_data.push((-time_from_start, *cpu));

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -162,7 +162,7 @@ pub fn convert_disk_row(current_data: &data_farmer::DataCollection) -> Vec<Vec<S
 
 pub fn convert_cpu_data_points(
     current_data: &data_farmer::DataCollection, existing_cpu_data: &mut Vec<ConvertedCpuData>,
-    is_frozen: bool,
+    is_frozen: bool, cpu_sort: bool
 ) {
     let current_time = if is_frozen {
         if let Some(frozen_instant) = current_data.frozen_instant {
@@ -228,32 +228,40 @@ pub fn convert_cpu_data_points(
     for (time, data) in &current_data.timed_data_vec {
         let time_from_start: f64 = (current_time.duration_since(*time).as_millis() as f64).floor();
 
-        let mut sorted_cpu_data = Vec::new();
-        for (itx, cpu) in data.cpu_data.iter().enumerate() {
-            if let Some(_cpu_data) = existing_cpu_data.get_mut(itx + 1) {
-                if itx > 0 { // skip sorting avg
-                    sorted_cpu_data.push(*cpu);
+        if cpu_sort {
+            let mut sorted_cpu_data = Vec::new();
+            for (itx, cpu) in data.cpu_data.iter().enumerate() {
+                if let Some(_cpu_data) = existing_cpu_data.get_mut(itx + 1) {
+                    if itx > 0 { // skip sorting avg
+                        sorted_cpu_data.push(*cpu);
+                    }
                 }
             }
-        }
 
-        // order cpu data in descending values
-        sorted_cpu_data.sort_by(|a, b| {
-            if a < b {
-                std::cmp::Ordering::Greater
-            } else if a == b {
-                std::cmp::Ordering::Equal
-            } else {
-                std::cmp::Ordering::Less
-            }
-        });
-
-        for (itx, cpu) in data.cpu_data.iter().enumerate() {
-            if let Some(cpu_data) = existing_cpu_data.get_mut(itx + 1) {
-                if itx > 0 { // skip sorting avg
-                    cpu_data.legend_value = format!("{:.0}%", sorted_cpu_data[itx-1].round());
-                    cpu_data.cpu_data.push((-time_from_start, sorted_cpu_data[itx-1]));
+            // order cpu data in descending values
+            sorted_cpu_data.sort_by(|a, b| {
+                if a < b {
+                    std::cmp::Ordering::Greater
+                } else if a == b {
+                    std::cmp::Ordering::Equal
                 } else {
+                    std::cmp::Ordering::Less
+                }
+            });
+
+            for (itx, cpu) in data.cpu_data.iter().enumerate() {
+                if let Some(cpu_data) = existing_cpu_data.get_mut(itx + 1) {
+                    if itx > 0 { // skip sorting avg
+                        cpu_data.legend_value = format!("{:.0}%", sorted_cpu_data[itx-1].round());
+                        cpu_data.cpu_data.push((-time_from_start, sorted_cpu_data[itx-1]));
+                    } else {
+                        cpu_data.cpu_data.push((-time_from_start, *cpu));
+                    }
+                }
+            }
+        } else {
+            for (itx, cpu) in data.cpu_data.iter().enumerate() {
+                if let Some(cpu_data) = existing_cpu_data.get_mut(itx + 1) {
                     cpu_data.cpu_data.push((-time_from_start, *cpu));
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,6 +318,7 @@ pub fn handle_force_redraws(app: &mut App) {
             &app.data_collection,
             &mut app.canvas_data.cpu_data,
             app.is_frozen,
+            app.app_config_fields.cpu_sort,
         );
         app.canvas_data.load_avg_data = app.data_collection.load_avg_harvest;
         app.cpu_state.force_update = None;

--- a/src/options.rs
+++ b/src/options.rs
@@ -69,6 +69,9 @@ pub struct ConfigFlags {
     pub current_usage: Option<bool>,
 
     #[builder(default, setter(strip_option))]
+    pub cpu_sort: Option<bool>,
+
+    #[builder(default, setter(strip_option))]
     pub group_processes: Option<bool>,
 
     #[builder(default, setter(strip_option))]
@@ -417,6 +420,7 @@ pub fn build_app(
         use_dot: get_use_dot(matches, config),
         left_legend: get_use_left_legend(matches, config),
         use_current_cpu_total: get_use_current_cpu_total(matches, config),
+        cpu_sort: get_cpu_sort(matches, config),
         use_basic_mode,
         default_time_value,
         time_interval: get_time_interval(matches, config)
@@ -685,6 +689,18 @@ fn get_use_current_cpu_total(matches: &clap::ArgMatches, config: &Config) -> boo
     } else if let Some(flags) = &config.flags {
         if let Some(current_usage) = flags.current_usage {
             return current_usage;
+        }
+    }
+
+    false
+}
+
+fn get_cpu_sort(matches: &clap::ArgMatches, config: &Config) -> bool {
+    if matches.is_present("cpu_sort") {
+        return true;
+    } else if let Some(flags) = &config.flags {
+        if let Some(cpu_sort) = flags.cpu_sort{
+            return cpu_sort;
         }
     }
 


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

This patchset adds the option to sort cpus by value.

With `cpu_sort: false`:
![cpu_unsort](https://user-images.githubusercontent.com/17132214/162665889-974f6775-3b27-4ed5-9a93-fc0de7886a59.png)


With `cpu_sort: true`:
![cpu_sort](https://user-images.githubusercontent.com/17132214/162665894-2f1abedd-ff68-44c8-9d85-bf1e98d52bbf.png)

## Issue

_If applicable, what issue does this address?_

Closes: #702 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Tested with `cpu_sort: false` to retain default behavior, tested with `cpu_sort: true` to show ordered CPU values in cpu_legend and ordered/non-intersecting lines in cpu_graph.

_Please also indicate which platforms were tested. All platforms directly affected by the change **must** be tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
