### PR TITLE
add arrows to help_title of help_dialog

### DIFF
--- a/src/canvas/dialogs/help_dialog.rs
+++ b/src/canvas/dialogs/help_dialog.rs
@@ -10,7 +10,7 @@ use tui::{
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 
-const HELP_BASE: &str = " Help ── Esc to close ";
+const HELP_BASE: &str = " Help \u{1F815}\u{1F817} ── Esc to close ";
 
 pub trait HelpDialog {
     fn draw_help_dialog<B: Backend>(
@@ -24,7 +24,7 @@ impl HelpDialog for Painter {
         &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect,
     ) {
         let help_title = Spans::from(vec![
-            Span::styled(" Help ", self.colours.widget_title_style),
+            Span::styled(" Help \u{1F815}\u{1F817} ", self.colours.widget_title_style),
             Span::styled(
                 format!(
                     "─{}─ Esc to close ",


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds arrows to title of help_dialog window to indicate that the list/window continues and how to navigate (even though it's obvious, I didn't realize it right away first time using bottom, so I think it might be worthwhile to at least propose this change to make it slightly more user-friendly). Not sure if my edit of HELP_BASE is the most suitable, I also considered adding "UD" instead of the Unicode.

## Closes

If applicable, what issue does this address?

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Please also indicate which platforms were tested. All platforms directly affected by the change **must** be tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
