### PR TITLE
bug: change as_ref() calls as needed to build in Rust beta 1.61.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,26 @@ jobs:
               rust: stable,
             }
 
+          # Beta; should be allowed to fail.
+          - {
+              os: "ubuntu-latest",
+              target: "x86_64-unknown-linux-gnu",
+              cross: false,
+              rust: beta,
+            }
+          - {
+              os: "macOS-latest",
+              target: "x86_64-apple-darwin",
+              cross: false,
+              rust: beta,
+            }
+          - {
+              os: "windows-2019",
+              target: "x86_64-pc-windows-msvc",
+              cross: false,
+              rust: beta,
+            }
+
           # aarch64
           - {
               os: "ubuntu-latest",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.9] / [0.7.0] - Unreleased
 
+## Bug Fixes
+
+- [#711](https://github.com/ClementTsang/bottom/pull/711): Fix building in Rust beta 1.61 due to `as_ref()` calls
+  causing type inference issues.
+
+## Changes
+
+- [#690](https://github.com/ClementTsang/bottom/pull/690): Adds some colour to `-h`/`--help` as part of updating to clap 3.0.
+
 ## Features
 
 - [#676](https://github.com/ClementTsang/bottom/pull/676): Adds support for NVIDIA GPU temperature sensors.

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -627,7 +627,7 @@ impl Painter {
                 if self.derived_widget_draw_locs.is_empty() || app_state.is_force_redraw {
                     let draw_locs = Layout::default()
                         .margin(0)
-                        .constraints(self.row_constraints.as_ref())
+                        .constraints(self.row_constraints.as_slice())
                         .direction(Direction::Vertical)
                         .split(terminal_size);
 
@@ -648,7 +648,7 @@ impl Painter {
                         )| {
                             izip!(
                                 Layout::default()
-                                    .constraints(col_constraint.as_ref())
+                                    .constraints(col_constraint.as_slice())
                                     .direction(Direction::Horizontal)
                                     .split(draw_loc)
                                     .into_iter(),
@@ -659,7 +659,7 @@ impl Painter {
                             .map(|(split_loc, constraint, col_constraint_vec, col_rows)| {
                                 izip!(
                                     Layout::default()
-                                        .constraints(constraint.as_ref())
+                                        .constraints(constraint.as_slice())
                                         .direction(Direction::Vertical)
                                         .split(split_loc)
                                         .into_iter(),
@@ -669,7 +669,7 @@ impl Painter {
                                 .map(|(draw_loc, col_row_constraint_vec, widgets)| {
                                     // Note that col_row_constraint_vec CONTAINS the widget constraints
                                     let widget_draw_locs = Layout::default()
-                                        .constraints(col_row_constraint_vec.as_ref())
+                                        .constraints(col_row_constraint_vec.as_slice())
                                         .direction(Direction::Horizontal)
                                         .split(draw_loc);
 

--- a/src/canvas/dialogs/dd_dialog.rs
+++ b/src/canvas/dialogs/dd_dialog.rs
@@ -376,14 +376,11 @@ impl KillDialog for Painter {
             // Now draw buttons if needed...
             let split_draw_loc = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints(
-                    if app_state.dd_err.is_some() {
-                        vec![Constraint::Percentage(100)]
-                    } else {
-                        vec![Constraint::Min(3), Constraint::Length(btn_height)]
-                    }
-                    .as_ref(),
-                )
+                .constraints(if app_state.dd_err.is_some() {
+                    vec![Constraint::Percentage(100)]
+                } else {
+                    vec![Constraint::Min(3), Constraint::Length(btn_height)]
+                })
                 .split(draw_loc);
 
             // This being true implies that dd_err is none.


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

This changes various `as_ref()` calls as needed in order for bottom to successfully build in Rust beta 1.61, as they were causing type inference issues. These calls were either removed or changed to an alternative that does build (e.g. `as_slice()`).

Functionally, there should be no change.

## Issue

_If applicable, what issue does this address?_

Closes: #708 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Please also indicate which platforms were tested. All platforms directly affected by the change **must** be tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
