### PR TITLE
ci: try using llvm-cov instead of tarpaulin

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,8 +19,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@38c3738dcac87b41e2b7038775457756c793566e # https://github.com/fkirc/skip-duplicate-actions/commit/38c3738dcac87b41e2b7038775457756c793566e
         with:
           concurrent_skipping: "same_content_newer"
-          skip_after_successful_duplicate: "true"
-          paths: '["tests/**", "src/**", ".github/workflows/coverage.yml", ".cargo/**", "Cargo.toml", "Cargo.lock", "build.rs"]'
+          skip_after_successful_duplicate: "false"
           do_not_skip: '["workflow_dispatch"]'
 
   coverage:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,15 +41,17 @@ jobs:
         with:
           key: ${{ matrix.triple.target }}
 
-      - name: Install tarpaulin
+      - name: Install cargo-llvm-cov
         run: |
-          cargo install cargo-tarpaulin
+          rustup component add llvm-tools-preview
+          cargo install cargo-llvm-cov --version 0.3.0
 
       - name: Generate code coverage
         run: |
-          cargo tarpaulin --verbose --all-features --workspace --run-types AllTargets --timeout 120 --out Xml
+          cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # 2.1.0
         with:
+          files: lcov.info
           fail_ci_if_error: true


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Experiment with [llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) over tarpaulin.

Tarpaulin is supposed to be switching to something similar to how this works in the future as well, so I might switch back then if I switch now.


## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
