### PR TITLE
deps: migrate to starship-battery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,23 +183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "battery"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b624268937c0e0a3edb7c27843f9e547c320d730c610d3b8e6e8e95b2026e4"
-dependencies = [
- "cfg-if",
- "core-foundation 0.7.0",
- "lazycell",
- "libc",
- "mach",
- "nix 0.19.1",
- "num-traits",
- "uom",
- "winapi",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,7 +209,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "backtrace",
- "battery",
  "cargo-husky",
  "cfg-if",
  "clap",
@@ -252,6 +234,7 @@ dependencies = [
  "regex",
  "serde",
  "smol",
+ "starship-battery",
  "sysinfo",
  "thiserror",
  "time",
@@ -1042,6 +1025,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
@@ -1448,6 +1444,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
+ "winapi",
+]
+
+[[package]]
+name = "starship-battery"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3336198ad004af4447ae69be4f4e562c26814570f8f0c1e37858405a294e015d"
+dependencies = [
+ "cfg-if",
+ "core-foundation 0.7.0",
+ "lazycell",
+ "libc",
+ "mach",
+ "nix 0.23.1",
+ "num-traits",
+ "uom",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ strip = "symbols"
 
 [features]
 default = ["fern", "log", "battery", "gpu"]
+battery = ["starship-battery"]
 deploy = ["battery", "gpu"]
 gpu = ["nvidia"]
 nvidia = ["nvml-wrapper"]
@@ -64,7 +65,7 @@ unicode-width = "0.1.9"
 
 fern = { version = "0.6.1", optional = true }
 log = { version = "0.4.16", optional = true }
-battery = { version = "0.7.8", optional = true }
+starship-battery = { version = "0.7.9", optional = true }
 nvml-wrapper = { version = "0.7.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -9,7 +9,7 @@ use fxhash::FxHashMap;
 use sysinfo::{System, SystemExt};
 
 #[cfg(feature = "battery")]
-use battery::{Battery, Manager};
+use starship_battery::{Battery, Manager};
 
 use crate::app::layout_manager::UsedWidgets;
 

--- a/src/app/data_harvester/batteries/battery.rs
+++ b/src/app/data_harvester/batteries/battery.rs
@@ -7,9 +7,9 @@
 //! - FreeBSD
 //! - DragonFlyBSD
 //!
-//! For more information, see https://github.com/svartalf/rust-battery
+//! For more information, see https://github.com/starship/rust-battery
 
-use battery::{
+use starship_battery::{
     units::{power::watt, ratio::percent, time::second},
     Battery, Manager,
 };


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Migrates the `battery` dependency to the more actively maintained [`starship-battery` fork](https://github.com/starship/rust-battery). See https://github.com/svartalf/rust-battery/pull/92 for more information.

## Issue

_If applicable, what issue does this address?_

Partially addresses: #597 

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
