### PR TITLE
other: make the graph legend the same color as the graph

### DIFF
--- a/src/canvas/components/time_graph.rs
+++ b/src/canvas/components/time_graph.rs
@@ -153,6 +153,7 @@ impl<'a> TimeGraph<'a> {
                 .block(block)
                 .x_axis(x_axis)
                 .y_axis(y_axis)
+                .legend_style(self.graph_style)
                 .hidden_legend_constraints(
                     self.legend_constraints
                         .unwrap_or(super::DEFAULT_LEGEND_CONSTRAINTS),


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

This makes the graph legend the same color as the rest of the graph.

![image](https://user-images.githubusercontent.com/34804052/168780671-856607dd-e390-46d8-988f-e242fd4d6220.png)


## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
