### PR TITLE
deployment: add aarch64/armv7 gnu .deb generation

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -54,6 +54,7 @@ jobs:
     container: ${{ matrix.triple.container }}
     env:
       RUST_BACKTRACE: 1
+      BTM_GENERATE: true
     strategy:
       fail-fast: false
       matrix:
@@ -161,11 +162,6 @@ jobs:
           command: build
           args: --release --verbose --locked --target=${{ matrix.triple.target }} --features deploy
           use-cross: ${{ matrix.triple.cross }}
-
-      - name: Build autocompletion and manpage
-        shell: bash
-        run: |
-          GENERATE=true cargo build
 
       - name: Bundle release and completion (Windows)
         if: matrix.triple.os == 'windows-2019'
@@ -289,6 +285,7 @@ jobs:
     runs-on: "ubuntu-18.04"
     env:
       RUST_BACKTRACE: 1
+      BTM_GENERATE: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -329,10 +326,9 @@ jobs:
           command: build
           args: --release --locked --verbose --features deploy
 
-      - name: Build autocompletion and manpage
+      - name: Zip manpage
         shell: bash
         run: |
-          GENERATE=true cargo build
           gzip ./manpage/btm.1
 
       - name: Build Debian release

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -283,6 +283,23 @@ jobs:
     name: build-deb
     needs: [initialize-release-job]
     runs-on: "ubuntu-18.04"
+    strategy:
+      fail-fast: false
+      matrix:
+        tuple:
+          - { target: "x86_64-unknown-linux-gnu", cross: false, dpkg: amd64 }
+          - {
+              target: "aarch64-unknown-linux-gnu",
+              cross: true,
+              dpkg: arm64,
+              container: "ghcr.io/clementtsang/cargo-deb-aarch64-unknown-linux-gnu",
+            }
+          - {
+              target: "armv7-unknown-linux-gnueabihf",
+              cross: true,
+              dpkg: armhf,
+              container: "ghcr.io/clementtsang/cargo-deb-armv7-unknown-linux-gnueabihf",
+            }
     env:
       RUST_BACKTRACE: 1
       BTM_GENERATE: true
@@ -314,37 +331,50 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-          target: x86_64-unknown-linux-gnu
+          target: ${{ matrix.tuple.target }}
 
       - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # 1.4.0
         with:
-          key: x86_64-unknown-linux-gnu-deb
+          key: ${{ matrix.tuple.target }}-deb
 
       - name: Build
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --locked --verbose --features deploy
+          args: --release --locked --verbose --features deploy --target ${{ matrix.tuple.target }}
+          use-cross: ${{ matrix.tuple.cross }}
 
       - name: Zip manpage
         shell: bash
         run: |
           gzip ./manpage/btm.1
 
-      - name: Build Debian release
+      - name: Build Debian release (x86-64)
+        if: matrix.tuple.cross == false
         run: |
-          cargo install cargo-deb --version 1.37.0 --locked
-          cargo deb --no-build
-          cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
+          cargo install cargo-deb --version 1.38.0 --locked
+          cargo deb --no-build --target ${{ matrix.tuple.target }}
+
+      - name: Build Debian release (ARM)
+        if: matrix.tuple.cross == true
+        run: |
+          docker pull ${{ matrix.tuple.container }}
+          docker run -t --rm --mount type=bind,source="$(pwd)",target=/volume ${{ matrix.tuple.container }} "--no-build --target ${{ matrix.tuple.target }}" "/volume"
+
+      - name: Move Debian release file
+        run: |
+          cp ./target/${{ matrix.tuple.target }}/debian/bottom_*.deb ./bottom_${{ matrix.tuple.target }}.deb
 
       - name: Test Debian release
-        run: sudo dpkg -i ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
+        run: |
+          dpkg -I ./bottom_${{ matrix.tuple.target }}.deb
+          dpkg -I ./bottom_${{ matrix.tuple.target }}.deb | grep ${{ matrix.tuple.dpkg }} && echo "Found correct architecture"
 
       - name: Create release directory for artifact, move file
         shell: bash
         run: |
           mkdir release
-          mv bottom_${{ env.RELEASE_VERSION }}_amd64.deb release/
+          mv bottom_${{ matrix.tuple.target }}.deb release/
 
       - name: Save release as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -334,8 +334,6 @@ jobs:
           target: ${{ matrix.tuple.target }}
 
       - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # 1.4.0
-        with:
-          key: ${{ matrix.tuple.target }}-deb
 
       - name: Build
         uses: actions-rs/cargo@v1
@@ -354,16 +352,14 @@ jobs:
         run: |
           cargo install cargo-deb --version 1.38.0 --locked
           cargo deb --no-build --target ${{ matrix.tuple.target }}
+          cp ./target/${{ matrix.tuple.target }}/debian/bottom_*.deb ./bottom_${{ matrix.tuple.target }}.deb
 
       - name: Build Debian release (ARM)
         if: matrix.tuple.cross == true
         run: |
           docker pull ${{ matrix.tuple.container }}
-          docker run -t --rm --mount type=bind,source="$(pwd)",target=/volume ${{ matrix.tuple.container }} "--no-build --target ${{ matrix.tuple.target }}" "/volume"
-
-      - name: Move Debian release file
-        run: |
-          cp ./target/${{ matrix.tuple.target }}/debian/bottom_*.deb ./bottom_${{ matrix.tuple.target }}.deb
+          docker run -t --rm --mount type=bind,source="$(pwd)",target=/volume ${{ matrix.tuple.container }} "--variant ${{ matrix.tuple.dpkg }} --target ${{ matrix.tuple.target }} --no-build" "/volume"
+          cp ./target/${{ matrix.tuple.target }}/debian/bottom-*.deb ./bottom_${{ matrix.tuple.target }}.deb
 
       - name: Test Debian release
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,6 +50,7 @@ jobs:
     container: ${{ matrix.triple.container }}
     env:
       RUST_BACKTRACE: 1
+      BTM_GENERATE: true
     strategy:
       fail-fast: false
       matrix:
@@ -157,11 +158,6 @@ jobs:
           command: build
           args: --release --locked --verbose --target=${{ matrix.triple.target }} --features deploy
           use-cross: ${{ matrix.triple.cross }}
-
-      - name: Build autocompletion and manpage
-        shell: bash
-        run: |
-          GENERATE=true cargo build
 
       - name: Bundle release and completion (Windows)
         if: matrix.triple.os == 'windows-2019'
@@ -281,8 +277,26 @@ jobs:
     name: build-deb
     needs: [initialize-job]
     runs-on: "ubuntu-18.04"
+    strategy:
+      fail-fast: false
+      matrix:
+        tuple:
+          - { target: "x86_64-unknown-linux-gnu", cross: false, dpkg: amd64 }
+          - {
+              target: "aarch64-unknown-linux-gnu",
+              cross: true,
+              dpkg: arm64,
+              container: "ghcr.io/clementtsang/cargo-deb-aarch64-unknown-linux-gnu",
+            }
+          - {
+              target: "armv7-unknown-linux-gnueabihf",
+              cross: true,
+              dpkg: armhf,
+              container: "ghcr.io/clementtsang/cargo-deb-armv7-unknown-linux-gnueabihf",
+            }
     env:
       RUST_BACKTRACE: 1
+      BTM_GENERATE: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -311,38 +325,50 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-          target: x86_64-unknown-linux-gnu
+          target: ${{ matrix.tuple.target }}
 
       - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # 1.4.0
         with:
-          key: x86_64-unknown-linux-gnu-deb
+          key: ${{ matrix.tuple.target }}-deb
 
       - name: Build
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --locked --verbose --features deploy
+          args: --release --locked --verbose --features deploy --target ${{ matrix.tuple.target }}
+          use-cross: ${{ matrix.tuple.cross }}
 
-      - name: Build autocompletion and manpage
+      - name: Zip manpage
         shell: bash
         run: |
-          GENERATE=true cargo build
           gzip ./manpage/btm.1
 
-      - name: Build Debian release
+      - name: Build Debian release (x86-64)
+        if: matrix.tuple.cross == false
         run: |
           cargo install cargo-deb --version 1.37.0 --locked
-          cargo deb --no-build
-          cp ./target/debian/bottom_*.deb ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
+          cargo deb --no-build --target ${{ matrix.tuple.target }}
+
+      - name: Build Debian release (ARM)
+        if: matrix.tuple.cross == true
+        run: |
+          docker pull ${{ matrix.tuple.container }}
+          docker run -t --rm --mount type=bind,source="$(pwd)",target=/volume ${{ matrix.tuple.container }} "--no-build --target ${{ matrix.tuple.target }}" "/volume"
+
+      - name: Move Debian release file
+        run: |
+          cp ./target/${{ matrix.tuple.target }}/debian/bottom_*.deb ./bottom_${{ matrix.tuple.target }}.deb
 
       - name: Test Debian release
-        run: sudo dpkg -i ./bottom_${{ env.RELEASE_VERSION }}_amd64.deb
+        run: |
+          dpkg -I ./bottom_${{ matrix.tuple.target }}.deb
+          dpkg -I ./bottom_${{ matrix.tuple.target }}.deb | grep ${{ matrix.tuple.dpkg }} && echo "Found correct architecture"
 
       - name: Create release directory for artifact, move file
         shell: bash
         run: |
           mkdir release
-          mv bottom_${{ env.RELEASE_VERSION }}_amd64.deb release/
+          mv bottom_${{ matrix.tuple.target }}.deb release/
 
       - name: Save Debian file as artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -328,8 +328,6 @@ jobs:
           target: ${{ matrix.tuple.target }}
 
       - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # 1.4.0
-        with:
-          key: ${{ matrix.tuple.target }}-deb
 
       - name: Build
         uses: actions-rs/cargo@v1
@@ -348,16 +346,14 @@ jobs:
         run: |
           cargo install cargo-deb --version 1.38.0 --locked
           cargo deb --no-build --target ${{ matrix.tuple.target }}
+          cp ./target/${{ matrix.tuple.target }}/debian/bottom_*.deb ./bottom_${{ matrix.tuple.target }}.deb
 
       - name: Build Debian release (ARM)
         if: matrix.tuple.cross == true
         run: |
           docker pull ${{ matrix.tuple.container }}
-          docker run -t --rm --mount type=bind,source="$(pwd)",target=/volume ${{ matrix.tuple.container }} "--no-build --target ${{ matrix.tuple.target }}" "/volume"
-
-      - name: Move Debian release file
-        run: |
-          cp ./target/${{ matrix.tuple.target }}/debian/bottom_*.deb ./bottom_${{ matrix.tuple.target }}.deb
+          docker run -t --rm --mount type=bind,source="$(pwd)",target=/volume ${{ matrix.tuple.container }} "--variant ${{ matrix.tuple.dpkg }} --target ${{ matrix.tuple.target }} --no-build" "/volume"
+          cp ./target/${{ matrix.tuple.target }}/debian/bottom-*.deb ./bottom_${{ matrix.tuple.target }}.deb
 
       - name: Test Debian release
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -346,7 +346,7 @@ jobs:
       - name: Build Debian release (x86-64)
         if: matrix.tuple.cross == false
         run: |
-          cargo install cargo-deb --version 1.37.0 --locked
+          cargo install cargo-deb --version 1.38.0 --locked
           cargo deb --no-build --target ${{ matrix.tuple.target }}
 
       - name: Build Debian release (ARM)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,9 +115,15 @@ extended-description = """\
 A customizable cross-platform graphical process/system monitor for the terminal. Supports Linux, macOS, and Windows.
 
 By default, bottom will look for a config file in ~/.config/bottom/bottom.toml.
-If one is not specified it will fall back to defaults.  If a config file does not
+If one is not specified it will fall back to defaults. If a config file does not
 exist at the specified or default location, a blank one will be created for the user.
 """
+
+[package.metadata.deb.variants.arm64]
+depends = "libc6:arm64 (>= 2.28)"
+
+[package.metadata.deb.variants.armhf]
+depends = "libc6:armhf (>= 2.28)"
 
 [package.metadata.wix]
 output = "bottom_x86_64_installer.msi"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[build.env]
+passthrough = ["RUST_BACKTRACE", "BTM_GENERATE"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - [Installation](#installation)
   - [Cargo](#cargo)
   - [Arch Linux](#arch-linux)
-  - [Debian/Ubuntu (x86-64)](#debianubuntu-x86-64)
+  - [Debian/Ubuntu](#debianubuntu)
   - [Snap](#snap)
   - [Fedora/CentOS](#fedoracentos)
   - [Gentoo](#gentoo)
@@ -126,14 +126,20 @@ There is an official package that can be installed with `pacman`:
 sudo pacman -Syu bottom
 ```
 
-### Debian/Ubuntu (x86-64)
+### Debian/Ubuntu
 
-A `.deb` file is provided on each [release](https://github.com/ClementTsang/bottom/releases/latest):
+<!-- FIXME: Update this when bumping version, as the format has changed. -->
+
+A `.deb` file is provided on each [release](https://github.com/ClementTsang/bottom/releases/latest) (currently only for x86-64):
 
 ```bash
 curl -LO https://github.com/ClementTsang/bottom/releases/download/0.6.8/bottom_0.6.8_amd64.deb
 sudo dpkg -i bottom_0.6.8_amd64.deb
 ```
+
+For ARM (aarch64 and armv7), for now, releases are currently only provided on
+[nightly builds](https://github.com/ClementTsang/bottom/releases/tag/nightly), but will be provided alongside the
+x86-64 builds in future releases.
 
 ### Snap
 

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ fn create_dir(dir: &Path) -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    if env::var_os("GENERATE").is_some() {
+    if env::var_os("BTM_GENERATE").is_some() {
         // OUT_DIR is where extra build files are written to for Cargo.
         let completion_out_dir = PathBuf::from("completion");
         let manpage_out_dir = PathBuf::from("manpage");
@@ -49,7 +49,7 @@ fn main() -> Result<()> {
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=./src/clap.rs");
-    println!("cargo:rerun-if-env-changed=GENERATE");
+    println!("cargo:rerun-if-env-changed=BTM_GENERATE");
 
     Ok(())
 }


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds .deb generation for aarch64 and armv7 gnu targets in the nightly and deploy workflows.

## Issue

_If applicable, what issue does this address?_

Closes: #736 

## Testing

The affected workflows were tested:

- [Deployment](https://github.com/ClementTsang/bottom/actions/runs/2402077115)
- [Nightly](https://github.com/ClementTsang/bottom/actions/runs/2402061049)

Also tested the armv7 and aarch64 .deb files was on my local Pis.

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
