### PR TITLE
deployment: deletes the debian folder in case of unwanted leftover files

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -343,7 +343,6 @@ jobs:
           use-cross: ${{ matrix.tuple.cross }}
 
       - name: Zip manpage
-        shell: bash
         run: |
           gzip ./manpage/btm.1
 
@@ -365,6 +364,11 @@ jobs:
         run: |
           dpkg -I ./bottom_${{ matrix.tuple.target }}.deb
           dpkg -I ./bottom_${{ matrix.tuple.target }}.deb | grep ${{ matrix.tuple.dpkg }} && echo "Found correct architecture"
+
+      - name: Delete generated Debian folder
+        run: |
+          sudo chown $USER ./target/${{ matrix.tuple.target }}/debian/ 2>/dev/null || true
+          rm -r ./target/${{ matrix.tuple.target }}/debian/
 
       - name: Create release directory for artifact, move file
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -337,7 +337,6 @@ jobs:
           use-cross: ${{ matrix.tuple.cross }}
 
       - name: Zip manpage
-        shell: bash
         run: |
           gzip ./manpage/btm.1
 
@@ -359,6 +358,11 @@ jobs:
         run: |
           dpkg -I ./bottom_${{ matrix.tuple.target }}.deb
           dpkg -I ./bottom_${{ matrix.tuple.target }}.deb | grep ${{ matrix.tuple.dpkg }} && echo "Found correct architecture"
+
+      - name: Delete generated Debian folder
+        run: |
+          sudo chown $USER ./target/${{ matrix.tuple.target }}/debian/ 2>/dev/null || true
+          rm -r ./target/${{ matrix.tuple.target }}/debian/
 
       - name: Create release directory for artifact, move file
         shell: bash


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Deletes the generated debian folder in nightly/deploy workflows, as I don't want to cache it.

## Testing

Tested on [Nightly](https://github.com/ClementTsang/bottom/actions/runs/2402242758).

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
