### PR TITLE
docs: re-enable lib docs for development purposes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ doc = false
 
 [lib]
 test = true
-doctest = false
-doc = false
+doctest = true
+doc = true
 
 [profile.release]
 debug = 0

--- a/src/app/data_harvester/batteries/battery.rs
+++ b/src/app/data_harvester/batteries/battery.rs
@@ -7,7 +7,7 @@
 //! - FreeBSD
 //! - DragonFlyBSD
 //!
-//! For more information, see https://github.com/starship/rust-battery
+//! For more information, refer to the [starship_battery](https://github.com/starship/rust-battery) repo/docs.
 
 use starship_battery::{
     units::{power::watt, ratio::percent, time::second},

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -59,7 +59,7 @@ impl FromStr for ColourScheme {
     }
 }
 
-/// Handles the canvas' state.  TODO: [OPT] implement this.
+/// Handles the canvas' state.
 pub struct Painter {
     pub colours: CanvasColours,
     height: u16,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+//! A customizable cross-platform graphical process/system monitor for the terminal.
+//! Supports Linux, macOS, and Windows. Inspired by gtop, gotop, and htop.
+//!
+//! **Note:** The following documentation is primarily intended for people to refer to for development purposes rather
+//! than the actual usage of the application. If you are instead looking for documentation regarding the *usage* of
+//! bottom, refer to [here](https://clementtsang.github.io/bottom/stable/).
+
 #![warn(rust_2018_idioms)]
 #[allow(unused_imports)]
 #[cfg(feature = "log")]
@@ -273,7 +280,8 @@ pub fn cleanup_terminal(
     Ok(())
 }
 
-/// Based on https://github.com/Rigellute/spotify-tui/blob/master/src/main.rs
+/// A panic hook to properly restore the terminal in the case of a panic.
+/// Based on [spotify-tui's implementation](https://github.com/Rigellute/spotify-tui/blob/master/src/main.rs).
 pub fn panic_hook(panic_info: &PanicInfo<'_>) {
     let mut stdout = stdout();
 


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Enables lib docs, primarily intended for dev use. Also change some existing documentation based on warnings (mainly broken/bare links).

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Tested locally to properly generate.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
