### PR TITLE
deployment: force usage of cross 0.2.1 for now

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -278,6 +278,11 @@ jobs:
       - name: Enable Rust cache
         uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # 1.4.0
 
+      - name: Install cross if needed
+        if: matrix.info.cross == true
+        run: |
+          cargo install cross --locked --version=0.2.1
+
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -132,6 +132,11 @@ jobs:
         with:
           key: ${{ matrix.info.target }}
 
+      - name: Install cross if needed
+        if: matrix.info.cross == true
+        run: |
+          cargo install cross --locked --version=0.2.1
+
       - name: Build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Locks cross in deployment builds to 0.2.1, as 0.2.2 seems to break some things for now.

First noted in [this scheduled nightly run](https://github.com/ClementTsang/bottom/actions/runs/2562433609). Some investigation seems to point to the current configuration ignoring env passthrough unless I specify for every single target.


## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

[Manually running a nightly workflow should pass with these changes](https://github.com/ClementTsang/bottom/actions/runs/2562658767).

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
