### PR TITLE
feature: add check for whether the output is to a terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#676](https://github.com/ClementTsang/bottom/pull/676): Adds support for NVIDIA GPU temperature sensors.
 
-- [](): Adds a check for whether bottom is being run in a terminal.
+- [#760](https://github.com/ClementTsang/bottom/pull/760): Adds a check for whether bottom is being run in a terminal.
 
 ## [0.6.8] - 2022-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#711](https://github.com/ClementTsang/bottom/pull/711): Fix building in Rust beta 1.61 due to `as_ref()` calls
   causing type inference issues.
 
-  - [#717](https://github.com/ClementTsang/bottom/pull/717): Fix clicking on empty space in tables selecting the very last entry of a list in some cases.
+- [#717](https://github.com/ClementTsang/bottom/pull/717): Fix clicking on empty space in tables selecting the very last entry of a list in some cases.
 
 ## Changes
 
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Features
 
 - [#676](https://github.com/ClementTsang/bottom/pull/676): Adds support for NVIDIA GPU temperature sensors.
+
+- [](): Adds a check for whether bottom is being run in a terminal.
 
 ## [0.6.8] - 2022-02-01
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -57,6 +57,11 @@ fn main() -> Result<()> {
     let mut painter =
         canvas::Painter::init(widget_layout, &config, get_color_scheme(&matches, &config)?)?;
 
+    // Check if the current environment is in a terminal.
+    if !check_if_terminal_and_wait() {
+        return Ok(());
+    }
+
     // Create termination mutex and cvar
     #[allow(clippy::mutex_atomic)]
     let thread_termination_lock = Arc::new(Mutex::new(false));
@@ -109,6 +114,7 @@ fn main() -> Result<()> {
     enable_raw_mode()?;
 
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout_val))?;
+
     terminal.clear()?;
     terminal.hide_cursor()?;
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -33,6 +33,10 @@ fn main() -> Result<()> {
         utils::logging::init_logger(log::LevelFilter::Debug, std::ffi::OsStr::new("debug.log"))?;
     }
 
+    // Check if the current environment is in a terminal.
+    check_if_terminal();
+
+    // Read from config file.
     let config_path = read_config(matches.value_of("config_location"))
         .context("Unable to access the given config file location.")?;
     let mut config: Config = create_or_get_config(&config_path)
@@ -56,11 +60,6 @@ fn main() -> Result<()> {
     // Create painter and set colours.
     let mut painter =
         canvas::Painter::init(widget_layout, &config, get_color_scheme(&matches, &config)?)?;
-
-    // Check if the current environment is in a terminal.
-    if !check_if_terminal_and_wait() {
-        return Ok(());
-    }
 
     // Create termination mutex and cvar
     #[allow(clippy::mutex_atomic)]
@@ -114,7 +113,6 @@ fn main() -> Result<()> {
     enable_raw_mode()?;
 
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout_val))?;
-
     terminal.clear()?;
     terminal.hide_cursor()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ extern crate log;
 use std::{
     boxed::Box,
     fs,
-    io::{stdout, Write},
+    io::{stderr, stdout, Write},
     panic::PanicInfo,
     path::PathBuf,
     sync::Arc,
@@ -278,11 +278,12 @@ pub fn cleanup_terminal(
 pub fn check_if_terminal() {
     use crossterm::tty::IsTty;
 
-    let out = stdout();
-    if !out.is_tty() {
-        println!(
+    if !stdout().is_tty() {
+        eprintln!(
             "Warning: bottom is not being output to a terminal. Things might not work properly."
         );
+        stderr().flush().unwrap();
+        thread::sleep(Duration::from_secs(1));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,9 +274,8 @@ pub fn cleanup_terminal(
     Ok(())
 }
 
-/// Check and report to the user if the current environment is not a terminal. If it isn't a terminal, wait
-/// for user input and return `false` if the caller should bail. Otherwise, return `true`.
-pub fn check_if_terminal_and_wait() -> bool {
+/// Check and report to the user if the current environment is not a terminal.
+pub fn check_if_terminal() {
     use crossterm::tty::IsTty;
 
     let out = stdout();
@@ -284,18 +283,6 @@ pub fn check_if_terminal_and_wait() -> bool {
         println!(
             "Warning: bottom is not being output to a terminal. Things might not work properly."
         );
-        println!("Press Ctrl-c or input q to exit, or any other key to continue.");
-
-        match read().unwrap() {
-            Event::Key(event) => match event.modifiers {
-                KeyModifiers::NONE => !matches!(event.code, KeyCode::Char('q')),
-                KeyModifiers::CONTROL => !matches!(event.code, KeyCode::Char('c')),
-                _ => true,
-            },
-            _ => true,
-        }
-    } else {
-        true
     }
 }
 


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds a warning if the user is calling bottom from an environment where the output is not a terminal.

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_Please also indicate which platforms were tested. All platforms directly affected by the change **must** be tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
