### PR TITLE
feature: add note on how to exit if running in non-terminal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,6 +282,7 @@ pub fn check_if_terminal() {
         eprintln!(
             "Warning: bottom is not being output to a terminal. Things might not work properly."
         );
+        eprintln!("If you're stuck, press 'q' or 'Ctrl-c' to quit the program.");
         stderr().flush().unwrap();
         thread::sleep(Duration::from_secs(1));
     }


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Addition to #760, adds an extra message so users know how to exit in this scenario.

![image](https://user-images.githubusercontent.com/34804052/176348933-5c8389bd-25bf-4378-b07c-1e100056936e.png)

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Should simply pass CI.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
