### PR TITLE
docs: bump mkdocs-material to 8.3.9

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs == 1.3.0
-mkdocs-material == 8.3.8
+mkdocs-material == 8.3.9
 mkdocs-material-extensions == 1.0.3
 mdx_truly_sane_lists == 1.2
 mike == 1.1.2


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Bumps mkdocs-material to [8.3.9](https://github.com/squidfunk/mkdocs-material/releases/tag/8.3.9).


## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
