### PR TITLE
bug: fix total read/write units having /s

### DIFF
--- a/src/app/widgets/process_table_widget.rs
+++ b/src/app/widgets/process_table_widget.rs
@@ -9,7 +9,9 @@ use crate::{
         CellContent, SortOrder, SortableState, TableComponentColumn, TableComponentHeader,
         TableComponentState, WidthBounds,
     },
-    data_conversion::{binary_byte_string, dec_bytes_per_second_string, TableData, TableRow},
+    data_conversion::{
+        binary_byte_string, dec_bytes_per_second_string, dec_bytes_per_string, TableData, TableRow,
+    },
     utils::gen_util::sort_partial_fn,
     Pid,
 };
@@ -788,10 +790,10 @@ impl ProcWidget {
                             dec_bytes_per_second_string(process.write_bytes_per_sec).into()
                         }
                         ProcWidgetColumn::TotalRead => {
-                            dec_bytes_per_second_string(process.total_read_bytes).into()
+                            dec_bytes_per_string(process.total_read_bytes).into()
                         }
                         ProcWidgetColumn::TotalWrite => {
-                            dec_bytes_per_second_string(process.total_write_bytes).into()
+                            dec_bytes_per_string(process.total_write_bytes).into()
                         }
                         ProcWidgetColumn::State => CellContent::HasAlt {
                             main: process.process_state.0.clone().into(),

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -583,6 +583,17 @@ pub fn binary_byte_string(value: u64) -> String {
     }
 }
 
+/// Returns a string given a value that is converted to the closest SI-variant.
+/// If the value is greater than a giga-X, then it will return a decimal place.
+pub fn dec_bytes_per_string(value: u64) -> String {
+    let converted_values = get_decimal_bytes(value);
+    if value >= GIGA_LIMIT {
+        format!("{:.*}{}", 1, converted_values.0, converted_values.1)
+    } else {
+        format!("{:.*}{}", 0, converted_values.0, converted_values.1)
+    }
+}
+
 /// Returns a string given a value that is converted to the closest SI-variant, per second.
 /// If the value is greater than a giga-X, then it will return a decimal place.
 pub fn dec_bytes_per_second_string(value: u64) -> String {


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Fixes the total read/write columns in processes using the wrong unit (having /s).


## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
