### PR TITLE
docs: bump mkdocs to fix markdown breaking exts

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs == 1.3.0
+mkdocs == 1.3.1
 mkdocs-material == 8.3.9
 mkdocs-material-extensions == 1.0.3
 mdx_truly_sane_lists == 1.2


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

The markdown Python lib seems to be causing some issues with certain extensions. Bumping mkdocs to 1.3.1 seems to resolve this issue (the alternative is pinning markdown to < 8.4.0).

For more info, see https://github.com/mkdocs/mkdocs/issues/2892

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
