### PR TITLE
Feature: clamp scrolling

### DIFF
--- a/src/components/text_table/state.rs
+++ b/src/components/text_table/state.rs
@@ -478,18 +478,16 @@ impl<H: TableComponentHeader> TableComponentState<H> {
 
         let csp: Result<i64, _> = self.current_scroll_position.try_into();
         if let Ok(csp) = csp {
-            let proposed: Result<usize, _> = (csp + change).try_into();
+            let proposed: Result<usize, _> = (csp + change).max(0).try_into();
             if let Ok(proposed) = proposed {
-                if proposed < num_entries {
-                    self.current_scroll_position = proposed;
-                    if change < 0 {
-                        self.scroll_direction = ScrollDirection::Up;
-                    } else {
-                        self.scroll_direction = ScrollDirection::Down;
-                    }
-
-                    return Some(self.current_scroll_position);
+                self.current_scroll_position = proposed.min(num_entries - 1);
+                if change < 0 {
+                    self.scroll_direction = ScrollDirection::Up;
+                } else {
+                    self.scroll_direction = ScrollDirection::Down;
                 }
+
+                return Some(self.current_scroll_position);
             }
         }
 

--- a/src/components/text_table/state.rs
+++ b/src/components/text_table/state.rs
@@ -473,7 +473,7 @@ impl<H: TableComponentHeader> TableComponentState<H> {
     /// Updates the position if possible, and if there is a valid change, returns the new position.
     pub fn update_position(&mut self, change: i64, num_entries: usize) -> Option<usize> {
         if change == 0
-            || (change > 0 && self.current_scroll_position == num_entries - 1)
+            || (change > 0 && self.current_scroll_position == num_entries.saturating_sub(1))
             || (change < 0 && self.current_scroll_position == 0)
         {
             return None;

--- a/src/components/text_table/state.rs
+++ b/src/components/text_table/state.rs
@@ -481,17 +481,16 @@ impl<H: TableComponentHeader> TableComponentState<H> {
 
         let csp: Result<i64, _> = self.current_scroll_position.try_into();
         if let Ok(csp) = csp {
-            let proposed: Result<usize, _> = (csp + change).max(0).try_into();
-            if let Ok(proposed) = proposed {
-                self.current_scroll_position = proposed.min(num_entries.saturating_sub(1));
-                if change < 0 {
-                    self.scroll_direction = ScrollDirection::Up;
-                } else {
-                    self.scroll_direction = ScrollDirection::Down;
-                }
+            self.current_scroll_position =
+                (csp + change).clamp(0, num_entries.saturating_sub(1) as i64) as usize;
 
-                return Some(self.current_scroll_position);
+            if change < 0 {
+                self.scroll_direction = ScrollDirection::Up;
+            } else {
+                self.scroll_direction = ScrollDirection::Down;
             }
+
+            return Some(self.current_scroll_position);
         }
 
         None

--- a/src/components/text_table/state.rs
+++ b/src/components/text_table/state.rs
@@ -483,7 +483,7 @@ impl<H: TableComponentHeader> TableComponentState<H> {
         if let Ok(csp) = csp {
             let proposed: Result<usize, _> = (csp + change).max(0).try_into();
             if let Ok(proposed) = proposed {
-                self.current_scroll_position = proposed.min(num_entries - 1);
+                self.current_scroll_position = proposed.min(num_entries.saturating_sub(1));
                 if change < 0 {
                     self.scroll_direction = ScrollDirection::Up;
                 } else {

--- a/src/components/text_table/state.rs
+++ b/src/components/text_table/state.rs
@@ -472,7 +472,10 @@ impl<H: TableComponentHeader> TableComponentState<H> {
 
     /// Updates the position if possible, and if there is a valid change, returns the new position.
     pub fn update_position(&mut self, change: i64, num_entries: usize) -> Option<usize> {
-        if change == 0 {
+        if change == 0
+            || (change > 0 && self.current_scroll_position == num_entries - 1)
+            || (change < 0 && self.current_scroll_position == 0)
+        {
             return None;
         }
 

--- a/src/components/text_table/state.rs
+++ b/src/components/text_table/state.rs
@@ -529,31 +529,25 @@ mod test {
         // Update by 5. Should increment to index 10.
         check_scroll_update(s, 5, 15, Some(10), 10);
 
-        // Update by 5. Should not change.
-        check_scroll_update(s, 5, 15, None, 10);
+        // Update by 5. Should clamp to max possible scroll index 14.
+        check_scroll_update(s, 5, 15, Some(14), 14);
 
-        // Update by 4. Should increment to index 14 (supposed max).
-        check_scroll_update(s, 4, 15, Some(14), 14);
-
-        // Update by 1. Should do nothing.
+        // Update by 1. Should do nothing (already at max index 14).
         check_scroll_update(s, 1, 15, None, 14);
 
-        // Update by -15. Should do nothing.
-        check_scroll_update(s, -15, 15, None, 14);
+        // Update by -15. Should clamp to index 0.
+        check_scroll_update(s, -15, 15, Some(0), 0);
 
-        // Update by -14. Should land on position 0.
-        check_scroll_update(s, -14, 15, Some(0), 0);
-
-        // Update by -1. Should do nothing.
+        // Update by -1. Should do nothing (already at min index 0).
         check_scroll_update(s, -15, 15, None, 0);
 
         // Update by 0. Should do nothing.
         check_scroll_update(s, 0, 15, None, 0);
 
-        // Update by 15. Should do nothing.
-        check_scroll_update(s, 15, 15, None, 0);
+        // Update by 15. Should clamp to 14.
+        check_scroll_update(s, 15, 15, Some(14), 14);
 
-        // Update by 15 but with a larger bound. Should increment to 15.
+        // Update by 15 but with a larger bound. Should clamp to 15.
         check_scroll_update(s, 15, 16, Some(15), 15);
     }
 


### PR DESCRIPTION
## Description

Clamp scrolling to the top/bottom when trying to scroll past the top/bottom.
This makes the scrolling behaviour correspond more to how other applications handle scrolling.

## Issue

_If applicable, what issue does this address?_

~Closes: #~

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_ 
adjusted the `test_scroll_update_position` test

_Please also indicate which platforms were tested. All platforms directly affected by the change **must** be tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
