### PR TITLE
ci: add ARM macOS to build workflow

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -106,6 +106,9 @@ jobs:
               target: "riscv64gc-unknown-linux-gnu",
               cross: true,
             }
+
+          # macOS ARM
+          - { os: "macOS-latest", target: "aarch64-apple-darwin", cross: true }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds macOS ARM to the build workflow for nightly/release.

## Issue

_If applicable, what issue does this address?_

Related to #382 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Relevant workflows are to be run:

- [ ] [Nightly](https://github.com/ClementTsang/bottom/actions/runs/2852508521)

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
