### PR TITLE
refactor: change max_scroll_index usage to better reflect name

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1017,15 +1017,10 @@ impl App {
 
     pub fn scroll_half_page_down(&mut self) {
         if self.help_dialog_state.is_showing_help {
-            let current = &mut self.help_dialog_state.scroll_state.current_scroll_index;
+            let current = self.help_dialog_state.scroll_state.current_scroll_index;
             let amount = self.help_dialog_state.height / 2;
 
-            *current = (*current + amount).min(
-                self.help_dialog_state
-                    .scroll_state
-                    .max_scroll_index
-                    .saturating_sub(1),
-            );
+            self.help_scroll_to_or_max(current + amount);
         } else if self.current_widget.widget_type.is_widget_table() {
             if let (Some((_tlc_x, tlc_y)), Some((_brc_x, brc_y))) = (
                 &self.current_widget.top_left_corner,
@@ -2098,11 +2093,8 @@ impl App {
             }
             self.reset_multi_tap_keys();
         } else if self.help_dialog_state.is_showing_help {
-            self.help_dialog_state.scroll_state.current_scroll_index = self
-                .help_dialog_state
-                .scroll_state
-                .max_scroll_index
-                .saturating_sub(1);
+            self.help_dialog_state.scroll_state.current_scroll_index =
+                self.help_dialog_state.scroll_state.max_scroll_index;
         } else if self.delete_dialog_state.is_showing_dd {
             self.delete_dialog_state.selected_signal = KillSignal::Kill(MAX_SIGNAL);
         }
@@ -2201,7 +2193,7 @@ impl App {
     }
 
     fn help_scroll_down(&mut self) {
-        if self.help_dialog_state.scroll_state.current_scroll_index + 1
+        if self.help_dialog_state.scroll_state.current_scroll_index
             < self.help_dialog_state.scroll_state.max_scroll_index
         {
             self.help_dialog_state.scroll_state.current_scroll_index += 1;
@@ -2209,11 +2201,11 @@ impl App {
     }
 
     fn help_scroll_to_or_max(&mut self, new_position: u16) {
-        if new_position < self.help_dialog_state.scroll_state.max_scroll_index {
+        if new_position <= self.help_dialog_state.scroll_state.max_scroll_index {
             self.help_dialog_state.scroll_state.current_scroll_index = new_position;
         } else {
             self.help_dialog_state.scroll_state.current_scroll_index =
-                self.help_dialog_state.scroll_state.max_scroll_index - 1;
+                self.help_dialog_state.scroll_state.max_scroll_index;
         }
     }
 

--- a/src/canvas/dialogs/help_dialog.rs
+++ b/src/canvas/dialogs/help_dialog.rs
@@ -76,28 +76,19 @@ impl Painter {
                     overflow_buffer += buffer;
                 });
 
-            app_state.help_dialog_state.scroll_state.max_scroll_index =
-                (self.styled_help_text.len() as u16
-                    + (constants::HELP_TEXT.len() as u16 - 5)
-                    + overflow_buffer)
-                    .saturating_sub(draw_loc.height);
+            let max_scroll_index = &mut app_state.help_dialog_state.scroll_state.max_scroll_index;
+            *max_scroll_index = (self.styled_help_text.len() as u16
+                + (constants::HELP_TEXT.len() as u16 - 5)
+                + overflow_buffer)
+                .saturating_sub(draw_loc.height + 1);
 
             // Fix if over-scrolled
-            if app_state
+            let index = &mut app_state
                 .help_dialog_state
                 .scroll_state
-                .current_scroll_index
-                >= app_state.help_dialog_state.scroll_state.max_scroll_index
-            {
-                app_state
-                    .help_dialog_state
-                    .scroll_state
-                    .current_scroll_index = app_state
-                    .help_dialog_state
-                    .scroll_state
-                    .max_scroll_index
-                    .saturating_sub(1);
-            }
+                .current_scroll_index;
+
+            *index = max(*index, *max_scroll_index);
         }
 
         f.render_widget(


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Tweaks `max_scroll_index` usage in the help menu to better reflect its name of being a max index, not a max index bound.

For example, before, the index could not be equal to or more than `max_scroll_index`, but the name would have implied that it should be less than or equal to it.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested. All platforms directly affected by the change **must** be tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
