### PR TITLE
Replace heim with sysfs and dont wake devices

### DIFF
--- a/src/app/data_harvester/temperature/heim.rs
+++ b/src/app/data_harvester/temperature/heim.rs
@@ -57,12 +57,15 @@ pub async fn get_temperature_data(
 
         // Whether the temperature should *actually* be read during enumeration
         // Set to false if the device is in ACPI D3cold
-        let mut should_read_temp = true;
-        // Documented at https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-power_state
-        let power_state = path.join("device").join("power_state");
-        if power_state.exists() {
-            should_read_temp = fs::read_to_string(power_state)?.trim() == "D0";
-        }
+        let should_read_temp = {
+            // Documented at https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-power_state
+            let power_state = path.join("device").join("power_state");
+            if power_state.exists() {
+                fs::read_to_string(power_state)?.trim() == "D0"
+            } else {
+                true
+            }
+        };
 
         // Enumerate the devices temperature sensors
         for entry in path.read_dir()? {

--- a/src/app/data_harvester/temperature/heim.rs
+++ b/src/app/data_harvester/temperature/heim.rs
@@ -3,11 +3,25 @@
 use super::{is_temp_filtered, temp_vec_sort, TempHarvest, TemperatureType};
 use crate::app::Filter;
 
+/// Get temperature sensors from the linux sysfs interface `/sys/class/hwmon`
+///
+/// This method will return `0` as the temperature for devices, such as GPUs,
+/// that support power management features and power themselves off.
+///
+/// Specifically, in laptops with iGPUs and dGPUs, if the dGPU is capable of
+/// entering ACPI D3cold, reading the temperature sensors will wake it,
+/// and keep it awake, wasting power.
+///
+/// For such devices, this method will only query the sensors IF the
+/// device is already in ACPI D0
+///
+/// This has the notable issue that once this happens,
+/// the device will be *kept* on through the sensor reading,
+/// and not be able to re-enter ACPI D3cold.
 pub async fn get_temperature_data(
     temp_type: &TemperatureType, actually_get: bool, filter: &Option<Filter>,
 ) -> crate::utils::error::Result<Option<Vec<TempHarvest>>> {
-    use futures::StreamExt;
-    use heim::units::thermodynamic_temperature;
+    use std::{fs, path::Path};
 
     if !actually_get {
         return Ok(None);
@@ -15,34 +29,88 @@ pub async fn get_temperature_data(
 
     let mut temperature_vec: Vec<TempHarvest> = Vec::new();
 
-    let mut sensor_data = heim::sensors::temperatures().boxed_local();
-    while let Some(sensor) = sensor_data.next().await {
-        if let Ok(sensor) = sensor {
-            let component_name = Some(sensor.unit().to_string());
-            let component_label = sensor.label().map(|label| label.to_string());
+    // Documented at https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-hwmon
+    let path = Path::new("/sys/class/hwmon");
 
-            let name = match (component_name, component_label) {
-                (Some(name), Some(label)) => format!("{}: {}", name, label),
+    // NOTE: Technically none of this is async, *but* sysfs is in memory,
+    // so in theory none of this should block if we're slightly careful.
+    // Of note is that reading the temperature sensors of a device that has
+    // `/sys/class/hwmon/hwmon*/device/d3cold_allowed` can potentially
+    // wake the device up, waiting to return data until it is.
+    //
+    // Reading the `d3cold_allowed`, `power_state`, or `tempY_label` properties
+    // will not wake the device, and thus not block.
+    //
+    // It would probably be more ideal to use a proper async runtime..
+    for entry in path.read_dir()? {
+        let file = entry?;
+        let path = file.path();
+        // hwmon includes many sensors, we only want ones with at least one temperature sensor
+        // Reading this file will wake the device, but we're only checking existence.
+        let has_temp = path.join("temp1_input").exists();
+        let hwmon_name = path.join("name");
+        let hwmon_name = Some(fs::read_to_string(&hwmon_name)?);
+
+        // Skip ones without temperature sensors early
+        if !has_temp {
+            continue;
+        }
+
+        // Whether the temperature should *actually* be read during enumeration
+        // Set to false if the device is in ACPI D3cold
+        let mut should_read_temp = true;
+        // Documented at https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-power_state
+        let power_state = path.join("device").join("power_state");
+        if power_state.exists() {
+            should_read_temp = fs::read_to_string(power_state)?.trim() == "D0";
+        }
+
+        // Enumerate the devices temperature sensors
+        for entry in path.read_dir()? {
+            let file = entry?;
+            let name = file.file_name();
+            // This should always be ASCII
+            let name = name.to_str().unwrap();
+            // We only want temperature sensors, skip others early
+            if !(name.starts_with("temp") && name.ends_with("input")) {
+                continue;
+            }
+            let temp = file.path();
+            let temp_label = path.join(name.replace("input", "label"));
+            let temp_label = fs::read_to_string(temp_label).ok();
+
+            let name = match (&hwmon_name, &temp_label) {
+                (Some(name), Some(label)) => format!("{}: {}", name.trim(), label.trim()),
                 (None, Some(label)) => label.to_string(),
                 (Some(name), None) => name.to_string(),
                 (None, None) => String::default(),
             };
 
             if is_temp_filtered(filter, &name) {
+                use heim::units::{thermodynamic_temperature, ThermodynamicTemperature};
+                let temp = if should_read_temp {
+                    let temp = fs::read_to_string(temp)?;
+                    let temp = temp.trim_end().parse::<f32>().map_err(|e| {
+                        crate::utils::error::BottomError::ConversionError(e.to_string())
+                    })?;
+                    temp / 1_000.0
+                } else {
+                    0.0
+                };
+                let temp = ThermodynamicTemperature::new::<thermodynamic_temperature::degree_celsius>(
+                    temp,
+                );
+
                 temperature_vec.push(TempHarvest {
                     name,
                     temperature: match temp_type {
-                        TemperatureType::Celsius => sensor
-                            .current()
-                            .get::<thermodynamic_temperature::degree_celsius>(
-                        ),
-                        TemperatureType::Kelvin => {
-                            sensor.current().get::<thermodynamic_temperature::kelvin>()
+                        TemperatureType::Celsius => {
+                            temp.get::<thermodynamic_temperature::degree_celsius>()
                         }
-                        TemperatureType::Fahrenheit => sensor
-                            .current()
-                            .get::<thermodynamic_temperature::degree_fahrenheit>(
-                        ),
+                        TemperatureType::Kelvin => temp.get::<thermodynamic_temperature::kelvin>(),
+                        TemperatureType::Fahrenheit => {
+                            temp.get::<thermodynamic_temperature::degree_fahrenheit>()
+                        }
                     },
                 });
             }

--- a/src/app/data_harvester/temperature/heim.rs
+++ b/src/app/data_harvester/temperature/heim.rs
@@ -48,14 +48,12 @@ pub async fn get_temperature_data(
         let path = file.path();
         // hwmon includes many sensors, we only want ones with at least one temperature sensor
         // Reading this file will wake the device, but we're only checking existence.
-        let has_temp = path.join("temp1_input").exists();
-        let hwmon_name = path.join("name");
-        let hwmon_name = Some(fs::read_to_string(&hwmon_name)?);
-
-        // Skip ones without temperature sensors early
-        if !has_temp {
+        if !path.join("temp1_input").exists() {
             continue;
         }
+
+        let hwmon_name = path.join("name");
+        let hwmon_name = Some(fs::read_to_string(&hwmon_name)?);
 
         // Whether the temperature should *actually* be read during enumeration
         // Set to false if the device is in ACPI D3cold

--- a/src/app/data_harvester/temperature/heim.rs
+++ b/src/app/data_harvester/temperature/heim.rs
@@ -35,11 +35,12 @@ pub async fn get_temperature_data(
     // NOTE: Technically none of this is async, *but* sysfs is in memory,
     // so in theory none of this should block if we're slightly careful.
     // Of note is that reading the temperature sensors of a device that has
-    // `/sys/class/hwmon/hwmon*/device/d3cold_allowed` can potentially
-    // wake the device up, waiting to return data until it is.
+    // `/sys/class/hwmon/hwmon*/device/power_state` == `D3cold` will
+    // wake the device up, and will block until it initializes.
     //
-    // Reading the `d3cold_allowed`, `power_state`, or `tempY_label` properties
-    // will not wake the device, and thus not block.
+    // Reading the `hwmon*/device/power_state` or `hwmon*/temp*_label` properties
+    // will not wake the device, and thus not block,
+    // and meaning no sensors have to be hidden depending on `power_state`
     //
     // It would probably be more ideal to use a proper async runtime..
     for entry in path.read_dir()? {


### PR DESCRIPTION
## Description

This commit replaces heim sensor reading with manual sysfs sensor reading, and skips reading sensors for any device that is in ACPI D3cold, instead returning 0.

This has the notable downside of still keeping a device awake, which I hope to solve in a later commit or PR

Another notable potential issue with this PR is that, while heim has its own method for async reading of files, bottom itself does not seem to, and I didnt want to arbitrarily pull in a dependency to do that, so even though `get_temperature_data` is async, I used the normal sync I/O methods. I justify this by the fact that sysfs is in-memory and presumably shouldnt block for the operations being done here.

Changing this should be relatively easy if need be and a path is decided

To the best of my knowledge, this change has no other user-visible affect, all sensors that appeared before will continue to appear. This sysfs reading is what heim does under the hood anyway, nothing fancy.

Screenshot:

![Screenshot_20220914_015509](https://user-images.githubusercontent.com/5275194/190110611-b8ef2f70-f5de-4eb2-8daa-a3e5fe4bf7c2.png)

## Issue

#803 

Closes: #803

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_ Manually checked that the GPU was not woken up, and that when it was by an external source, bottom started displaying the real sensor values

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [X] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [X] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [X] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [x] _If relevant, new tests were added (don't worry too much about coverage)_
