### PR TITLE
More human friendly temperature sensor naming

### DIFF
--- a/src/app/data_harvester/temperature/linux.rs
+++ b/src/app/data_harvester/temperature/linux.rs
@@ -139,10 +139,12 @@ fn get_from_hwmon(
                         .map(|f| f.to_str().unwrap_or_default().to_owned())
                         .unwrap();
                     if link.as_bytes()[0].is_ascii_alphabetic() {
-                        Some(link)
+                        if let Some(hwmon_name) = hwmon_name.as_ref() {
+                            Some(format!("{} ({})", link, hwmon_name.trim()))
+                        } else {
+                            Some(link)
+                        }
                     } else {
-                        // No idea why rust thinks this may have been moved
-                        // in a previous loop iteration and needs a clone
                         hwmon_name.clone()
                     }
                 }

--- a/src/app/data_harvester/temperature/linux.rs
+++ b/src/app/data_harvester/temperature/linux.rs
@@ -114,16 +114,20 @@ fn get_from_hwmon(
                 let drm = device.join("drm");
                 if drm.exists() {
                     // This should never actually be empty
-                    let mut gpu = String::new();
+                    let mut gpu = None;
                     for card in drm.read_dir()? {
                         let card = card?;
                         let name = card.file_name().to_str().unwrap_or_default().to_owned();
                         if name.starts_with("card") {
-                            gpu = name;
+                            if let Some(hwmon_name) = hwmon_name.as_ref() {
+                                gpu = Some(format!("{} ({})", name, hwmon_name.trim()));
+                            } else {
+                                gpu = Some(name)
+                            }
                             break;
                         }
                     }
-                    Some(gpu)
+                    gpu
                 } else {
                     // This little mess is to account for stuff like k10temp
                     // This is needed because the `device` symlink

--- a/src/app/data_harvester/temperature/linux.rs
+++ b/src/app/data_harvester/temperature/linux.rs
@@ -100,7 +100,51 @@ fn get_from_hwmon(
             let temp_label = file_path.join(name.replace("input", "label"));
             let temp_label = fs::read_to_string(temp_label).ok();
 
-            let name = match (&hwmon_name, &temp_label) {
+            // Do some messing around to get a more sensible name for sensors
+            //
+            // - For GPUs, this will use the kernel device name, ex `card0`
+            // - For nvme drives, this will also use the kernel name, ex `nvme0`.
+            //   This is found differently than for GPUs
+            // - For whatever acpitz is, on my machine this is now `thermal_zone0`.
+            // - For k10temp, this will still be k10temp, but it has to be handled special.
+            let human_hwmon_name = {
+                let device = path.join("device");
+                // This will exist for GPUs but not others, this is how
+                // we find their kernel name
+                let drm = device.join("drm");
+                if drm.exists() {
+                    // This should never actually be empty
+                    let mut gpu = String::new();
+                    for card in drm.read_dir()? {
+                        let card = card?;
+                        let name = card.file_name().to_str().unwrap_or_default().to_owned();
+                        if name.starts_with("card") {
+                            gpu = name;
+                            break;
+                        }
+                    }
+                    Some(gpu)
+                } else {
+                    // This little mess is to account for stuff like k10temp
+                    // This is needed because the `device` symlink
+                    // points to `nvme*` for nvme drives, but to PCI buses for anything else
+                    // If the first character is alphabetic,
+                    // its an actual name like k10temp or nvme0, not a PCI bus
+                    let link = fs::read_link(device)?
+                        .file_name()
+                        .map(|f| f.to_str().unwrap_or_default().to_owned())
+                        .unwrap();
+                    if link.as_bytes()[0].is_ascii_alphabetic() {
+                        Some(link)
+                    } else {
+                        // No idea why rust thinks this may have been moved
+                        // in a previous loop iteration and needs a clone
+                        hwmon_name.clone()
+                    }
+                }
+            };
+
+            let name = match (&human_hwmon_name, &temp_label) {
                 (Some(name), Some(label)) => format!("{}: {}", name.trim(), label.trim()),
                 (None, Some(label)) => label.to_string(),
                 (Some(name), None) => name.to_string(),

--- a/src/app/data_harvester/temperature/linux.rs
+++ b/src/app/data_harvester/temperature/linux.rs
@@ -108,7 +108,7 @@ fn get_from_hwmon(
             // - For whatever acpitz is, on my machine this is now `thermal_zone0`.
             // - For k10temp, this will still be k10temp, but it has to be handled special.
             let human_hwmon_name = {
-                let device = path.join("device");
+                let device = file_path.join("device");
                 // This will exist for GPUs but not others, this is how
                 // we find their kernel name
                 let drm = device.join("drm");


### PR DESCRIPTION
## Description

This changes how temperature sensors are displayed, in a way I believe to be much better.

This PR is based on top of and requires #805 

Comparison

Before:
![Screenshot_20220914_015509](https://user-images.githubusercontent.com/5275194/190110611-b8ef2f70-f5de-4eb2-8daa-a3e5fe4bf7c2.png)

After:
![Screenshot_20220914_015452](https://user-images.githubusercontent.com/5275194/190110630-4ddc6c0f-fdcf-49fd-8238-55e2ce5f1b18.png)

## Testing

Tested on my personal machine. This will likely need additional testing due to the apparent lack of a standard way to get better sensor names.

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [X] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [X] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
