### PR TITLE
refactor: replace heim temp conversion code

### DIFF
--- a/src/app/data_harvester/temperature.rs
+++ b/src/app/data_harvester/temperature.rs
@@ -39,16 +39,12 @@ impl Default for TemperatureType {
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(any(feature = "nvidia", target_os = "macos", target_os = "windows"))] {
-        fn convert_celsius_to_kelvin(celsius: f32) -> f32 {
-            celsius + 273.15
-        }
+fn convert_celsius_to_kelvin(celsius: f32) -> f32 {
+    celsius + 273.15
+}
 
-        fn convert_celsius_to_fahrenheit(celsius: f32) -> f32 {
-            (celsius * (9.0 / 5.0)) + 32.0
-        }
-    }
+fn convert_celsius_to_fahrenheit(celsius: f32) -> f32 {
+    (celsius * (9.0 / 5.0)) + 32.0
 }
 
 fn is_temp_filtered(filter: &Option<Filter>, text: &str) -> bool {


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Since we no longer rely on heim to do temperatures in Linux, we can skip using their conversion code and just use some pre-existing temp conversion code.

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
