### PR TITLE
fix wrong unit being used for memory in sysinfo data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "mach",
- "ntapi",
+ "ntapi 0.3.7",
  "smol",
  "winapi",
 ]
@@ -1000,7 +1000,7 @@ dependencies = [
  "libc",
  "log",
  "miow",
- "ntapi",
+ "ntapi 0.3.7",
  "winapi",
 ]
 
@@ -1060,6 +1060,15 @@ name = "ntapi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
 dependencies = [
  "winapi",
 ]
@@ -1536,14 +1545,14 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae2421f3e16b3afd4aa692d23b83d0ba42ee9b0081d5deeb7d21428d7195fb1"
+checksum = "7890fff842b8db56f2033ebee8f6efe1921475c3830c115995552914fb967580"
 dependencies = [
  "cfg-if",
  "core-foundation-sys 0.8.3",
  "libc",
- "ntapi",
+ "ntapi 0.4.0",
  "once_cell",
  "rayon",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ once_cell = "1.5.2"
 regex = "1.5.5"
 serde = { version = "1.0.136", features = ["derive"] }
 starship-battery = { version = "0.7.9", optional = true }
-sysinfo = "0.26.2"
+sysinfo = "0.26.4"
 thiserror = "1.0.30"
 time = { version = "0.3.9", features = ["formatting", "macros"] }
 toml = "0.5.9"

--- a/src/app/data_harvester/memory/general/sysinfo.rs
+++ b/src/app/data_harvester/memory/general/sysinfo.rs
@@ -20,7 +20,7 @@ pub async fn get_mem_data(
 }
 
 pub async fn get_ram_data(sys: &System) -> crate::utils::error::Result<Option<MemHarvest>> {
-    let (mem_total_in_kib, mem_used_in_kib) = (sys.total_memory(), sys.used_memory());
+    let (mem_total_in_kib, mem_used_in_kib) = (sys.total_memory() / 1024, sys.used_memory()) / 1024;
 
     Ok(Some(MemHarvest {
         mem_total_in_kib,
@@ -34,7 +34,7 @@ pub async fn get_ram_data(sys: &System) -> crate::utils::error::Result<Option<Me
 }
 
 pub async fn get_swap_data(sys: &System) -> crate::utils::error::Result<Option<MemHarvest>> {
-    let (mem_total_in_kib, mem_used_in_kib) = (sys.total_swap(), sys.used_swap());
+    let (mem_total_in_kib, mem_used_in_kib) = (sys.total_swap() / 1024, sys.used_swap() / 1024);
 
     Ok(Some(MemHarvest {
         mem_total_in_kib,

--- a/src/app/data_harvester/processes/macos_freebsd.rs
+++ b/src/app/data_harvester/processes/macos_freebsd.rs
@@ -76,7 +76,7 @@ pub fn get_process_data(
             } else {
                 0.0
             },
-            mem_usage_bytes: process_val.memory() * 1024,
+            mem_usage_bytes: process_val.memory(),
             cpu_usage_percent: process_cpu_usage,
             read_bytes_per_sec: disk_usage.read_bytes,
             write_bytes_per_sec: disk_usage.written_bytes,

--- a/src/app/data_harvester/processes/windows.rs
+++ b/src/app/data_harvester/processes/windows.rs
@@ -66,7 +66,7 @@ pub fn get_process_data(
             } else {
                 0.0
             },
-            mem_usage_bytes: process_val.memory() * 1024,
+            mem_usage_bytes: process_val.memory(),
             cpu_usage_percent: process_cpu_usage,
             read_bytes_per_sec: disk_usage.read_bytes,
             write_bytes_per_sec: disk_usage.written_bytes,


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

During a sysinfo update, the default unit changed from kilobytes -> bytes in memory contexts, which wasn't accounted for.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
