### PR TITLE
ci: add basic Cirrus CI testing for FreeBSD + M1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,12 +15,22 @@ task:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y
     - . $HOME/.cargo/env
+    - rustc --version
+  registry_cache:
+    folder: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock
+  target_cache:
+    folder: target
+    fingerprint_script:
+      - . $HOME/.cargo/env && rustc --version
+      - cat Cargo.lock
   test_script:
     - . $HOME/.cargo/env
     - cargo fmt --all -- --check
     - cargo test --no-run --locked
     - cargo test --no-fail-fast -- --nocapture --quiet
     - cargo clippy --all-targets --workspace -- -D warnings
+  before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 task:
   name: macOS M1 Test
@@ -29,10 +39,20 @@ task:
   setup_script:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y
-    - . $HOME/.cargo/env
+    - source $HOME/.cargo/env
+    - rustc --version
+  registry_cache:
+    folder: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock
+  target_cache:
+    folder: target
+    fingerprint_script:
+      - source $HOME/.cargo/env && rustc --version
+      - cat Cargo.lock
   test_script:
-    - . $HOME/.cargo/env
+    - source $HOME/.cargo/env
     - cargo fmt --all -- --check
     - cargo test --no-run --locked
     - cargo test --no-fail-fast -- --nocapture --quiet
     - cargo clippy --all-targets --workspace -- -D warnings
+  before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,11 @@
 # Configuration for CirrusCI. This is primarily used for
 # FreeBSD and macOS M1 testing and building.
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_HUSKY_DONT_INSTALL_HOOKS: true
+
 task:
   name: FreeBSD 13 Test
   freebsd_instance:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,6 @@ task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-base:latest
   setup_script:
-    - pkg install -y curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y
     - . $HOME/.cargo/env

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,34 @@
+# Configuration for CirrusCI. This is primarily used for
+# FreeBSD and macOS M1 testing and building.
+
+task:
+  name: FreeBSD 13 Test
+  freebsd_instance:
+    image_family: freebsd-13-1
+  setup_script:
+    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh --default-toolchain stable -y
+    - . $HOME/.cargo/env
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo fmt --all -- --check
+    - cargo test --no-run --locked
+    - cargo test --no-fail-fast -- --nocapture --quiet
+    - cargo clippy --all-targets --workspace -- -D warnings
+
+task:
+  name: macOS M1 Test
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-base:latest
+  setup_script:
+    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh --default-toolchain stable -y
+    - . $HOME/.cargo/env
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo fmt --all -- --check
+    - cargo test --no-run --locked
+    - cargo test --no-fail-fast -- --nocapture --quiet
+    - cargo clippy --all-targets --workspace -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,7 @@ jobs:
               target: "x86_64-pc-windows-msvc",
               cross: false,
             }
-        features: [
-            "--all-features",
-            # "--features battery",
-            # "--features gpu",
-            "--no-default-features",
-          ]
+        features: ["--all-features", "--no-default-features"]
     steps:
       - name: Check if this action should be skipped
         id: skip_check


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds CirrusCI testing for FreeBSD and M1 platforms. 

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
