### PR TITLE
refactor: switch to associated type for SortsRow

### DIFF
--- a/src/app/widgets/process_table/proc_widget_column.rs
+++ b/src/app/widgets/process_table/proc_widget_column.rs
@@ -64,7 +64,9 @@ impl ColumnHeader for ProcColumn {
     }
 }
 
-impl SortsRow<ProcWidgetData> for ProcColumn {
+impl SortsRow for ProcColumn {
+    type DataType = ProcWidgetData;
+
     fn sort_data(&self, data: &mut [ProcWidgetData], descending: bool) {
         match self {
             ProcColumn::CpuPercent => {


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Use an associated type for `SortsRow`.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
