### PR TITLE
enable gpu mem cli and update docs for arc/gpu mem

### DIFF
--- a/docs/content/configuration/command-line-flags.md
+++ b/docs/content/configuration/command-line-flags.md
@@ -43,3 +43,4 @@ The following flags can be provided to bottom in the command line to change the 
 | `--use_old_network_legend`            | DEPRECATED - uses the older network legend.                    |
 | `-V, --version`                       | Prints version information.                                    |
 | `-W, --whole_word`                    | Enables whole-word matching by default.                        |
+| `--enable_gpu_memory`                 | Enable collecting and displaying GPU memory usage.             |

--- a/docs/content/configuration/config-file/flags.md
+++ b/docs/content/configuration/config-file/flags.md
@@ -36,3 +36,4 @@ Most of the [command line flags](../../command-line-flags) have config file equi
 | `network_use_binary_prefix`  | Boolean                                                                                        | Displays the network widget with binary prefixes.              |
 | `network_use_bytes`          | Boolean                                                                                        | Displays the network widget using bytes.                       |
 | `network_use_log`            | Boolean                                                                                        | Displays the network widget with a log scale.                  |
+| `enable_gpu_memory`          | Boolean                                                                                        | Shows the GPU memory widget.                                   |

--- a/docs/content/configuration/config-file/theming.md
+++ b/docs/content/configuration/config-file/theming.md
@@ -29,3 +29,5 @@ Supported named colours are one of the following strings: `Reset, Black, Red, Gr
 | High battery level colour       | The colour used for a high battery level (100% to 50%)  | `high_battery_color="green"`                            |
 | Medium battery level colour     | The colour used for a medium battery level (50% to 10%) | `medium_battery_color="yellow"`                         |
 | Low battery level colour        | The colour used for a low battery level (10% to 0%)     | `low_battery_color="red"`                               |
+| GPU colour per gpu              | Colour of each gpu. Read in order.                      | `gpu_core_colors=["#ffffff", "white", "255, 255, 255"]` |
+| ARC                             | The colour ARC will use                                 | `arc_color="#ffffff"`                                   |

--- a/sample_configs/default_config.toml
+++ b/sample_configs/default_config.toml
@@ -69,6 +69,8 @@
 #network_use_log = false
 # Hides advanced options to stop a process on Unix-like systems.
 #disable_advanced_kill = false
+# Shows GPU(s) memory
+#enable_gpu_memory = false
 
 # These are all the components that support custom theming.  Note that colour support
 # will depend on terminal support.
@@ -86,6 +88,10 @@
 #ram_color="LightMagenta"
 # Represents the colour SWAP will use in the memory legend and graph.
 #swap_color="LightYellow"
+# Represents the colour ARC will use in the memory legend and graph.
+#arc_color="LightCyan"
+# Represents the colour the GPU will use in the memory legend and graph.
+#gpu_core_colors=["LightGreen", "LightBlue", "LightRed", "Cyan", "Green", "Blue", "Red"]
 # Represents the colour rx will use in the network legend and graph.
 #rx_color="LightCyan"
 # Represents the colour tx will use in the network legend and graph.
@@ -113,7 +119,7 @@
 # [[row.child.child]] represents a widget.
 #
 # All widgets must have the type value set to one of ["cpu", "mem", "proc", "net", "temp", "disk", "empty"].
-# All layout components have a ratio value - if this is not set, then it defaults to 1. 
+# All layout components have a ratio value - if this is not set, then it defaults to 1.
 # The default widget layout:
 #[[row]]
 #  ratio=30

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -546,6 +546,8 @@ pub const CONFIG_TEXT: &str = r##"# This is a default config file for bottom.  A
 #network_use_log = false
 # Hides advanced options to stop a process on Unix-like systems.
 #disable_advanced_kill = false
+# Shows GPU(s) memory
+#enable_gpu_memory = false
 
 # These are all the components that support custom theming.  Note that colour support
 # will depend on terminal support.

--- a/src/options.rs
+++ b/src/options.rs
@@ -380,12 +380,7 @@ pub fn build_app(
     let used_widgets = UsedWidgets {
         use_cpu: used_widget_set.get(&Cpu).is_some() || used_widget_set.get(&BasicCpu).is_some(),
         use_mem,
-        use_gpu: use_mem
-            && config
-                .flags
-                .as_ref()
-                .and_then(|f| f.enable_gpu_memory)
-                .unwrap_or(false),
+        use_gpu: use_mem && get_enable_gpu_memory(matches, config),
         use_net: used_widget_set.get(&Net).is_some() || used_widget_set.get(&BasicNet).is_some(),
         use_proc: used_widget_set.get(&Proc).is_some(),
         use_disk: used_widget_set.get(&Disk).is_some(),


### PR DESCRIPTION
## Description

Enables use of cli argument `enable_gpu_memory` and adds it to the default config file.
Updates some of the docs for arc/gpu styles, gpu flag and gpu cli flag.

## Issue

Follow-up to https://github.com/ClementTsang/bottom/pull/794 and https://github.com/ClementTsang/bottom/pull/835

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [X] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [X] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [X] _The change has been tested and doesn't appear to cause any unintended breakage_
- [X] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [X] _The pull request passes the provided CI pipeline_
- [X] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_

I did **NOT** update the changelog.

Feel free to close if unwanted.