### PR TITLE
Implement PgUp and PgDown in the help dialog.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -830,6 +830,10 @@ impl App {
                 0 => KillSignal::Cancel,
                 sig => KillSignal::Kill(sig),
             };
+        } else if self.help_dialog_state.is_showing_help {
+            let current = &mut self.help_dialog_state.scroll_state.current_scroll_index;
+            let amount = self.help_dialog_state.height;
+            *current = current.saturating_sub(amount);
         } else if self.current_widget.widget_type.is_widget_table() {
             if let (Some((_tlc_x, tlc_y)), Some((_brc_x, brc_y))) = (
                 &self.current_widget.top_left_corner,
@@ -853,6 +857,11 @@ impl App {
                 new_signal += 2;
             }
             self.delete_dialog_state.selected_signal = KillSignal::Kill(new_signal);
+        } else if self.help_dialog_state.is_showing_help {
+            let current = self.help_dialog_state.scroll_state.current_scroll_index;
+            let amount = self.help_dialog_state.height;
+
+            self.help_scroll_to_or_max(current + amount);
         } else if self.current_widget.widget_type.is_widget_table() {
             if let (Some((_tlc_x, tlc_y)), Some((_brc_x, brc_y))) = (
                 &self.current_widget.top_left_corner,


### PR DESCRIPTION
## Description

The PageUp and PageDown keys weren't doing anything in the help dialog, so I added some lines to make them work.

## Issue

Easier navigation in the help dialog.

## Testing

I ran `cargo test` after my changes. For the behavior of the keys themselves, I tested it manually.

- [  ] _Windows_
- [  ] _macOS_
- [ x ] _Linux_

## Checklist

- [ x ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ x ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [  ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [  ] _The pull request passes the provided CI pipeline_
- [ x ] _There are no merge conflicts_
- [  ] _If relevant, new tests were added (don't worry too much about coverage)_
