### PR TITLE
ci: add FreeBSD and macOS M1 builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,6 +13,7 @@ cache_template: &CACHE_TEMPLATE
     fingerprint_script:
       - md5 Cargo.lock
       - echo $CIRRUS_OS
+      - echo $CIRRUS_TASK_NAME
   target_cache:
     folder: target
     reupload_on_changes: true
@@ -20,6 +21,7 @@ cache_template: &CACHE_TEMPLATE
       - . $HOME/.cargo/env && rustc --version
       - md5 Cargo.lock
       - echo $CIRRUS_OS
+      - echo $CIRRUS_TASK_NAME
 
 cleanup_template: &CLEANUP_TEMPLATE
   before_cache_script:
@@ -58,18 +60,31 @@ test_task:
   <<: *CLEANUP_TEMPLATE
 
 build_task:
-  only_if: $CIRRUS_RELEASE != ""
-  trigger_type: manual
+  only_if: $CIRRUS_RELEASE != "" || $CIRRUS_CRON == "nightly"
+  env:
+    BTM_GENERATE: true
+    COMPLETION_DIR: "target/tmp/bottom/completion/"
+    MANPAGE_DIR: "target/tmp/bottom/manpage/"
   matrix:
     - name: "FreeBSD 13 Build"
       freebsd_instance:
         image_family: freebsd-13-1
+      env:
+        TARGET: "x86_64-unknown-freebsd"
     - name: "macOS M1 Build"
       macos_instance:
         image: ghcr.io/cirruslabs/macos-monterey-base:latest
+      env:
+        TARGET: "aarch64-apple-darwin"
   <<: *SETUP_TEMPLATE
   <<: *CACHE_TEMPLATE
   build_script:
     - . $HOME/.cargo/env
     - cargo build --release --verbose --locked --features deploy
+    - mv ./target/release/btm ./
+    - mv "$COMPLETION_DIR" completion
+    - mv "$MANPAGE_DIR" manpage
+    - tar -czvf bottom_$TARGET.tar.gz btm completion
+  binaries_artifacts:
+    path: bottom_$TARGET.tar.gz
   <<: *CLEANUP_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,7 +35,7 @@ env:
   CARGO_HUSKY_DONT_INSTALL_HOOKS: true
 
 test_task:
-  only_if: $CIRRUS_BRANCH == "master" || $CIRRUS_PR != ""
+  only_if: $CIRRUS_CRON == "" && ($CIRRUS_BRANCH == "master" || $CIRRUS_PR != "")
   matrix:
     - name: "FreeBSD 13 Test"
       freebsd_instance:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,25 +1,12 @@
 # Configuration for CirrusCI. This is primarily used for
 # FreeBSD and macOS M1 tests and builds.
 
-env:
-  CARGO_INCREMENTAL: 0
-  CARGO_PROFILE_DEV_DEBUG: 0
-  CARGO_HUSKY_DONT_INSTALL_HOOKS: true
-
-task:
-  only_if: $CIRRUS_BRANCH == "master" || $CIRRUS_PR != ""
-  matrix:
-    - name: "FreeBSD 13 Test"
-      freebsd_instance:
-        image_family: freebsd-13-1
-    - name: "macOS M1 Test"
-      macos_instance:
-        image: ghcr.io/cirruslabs/macos-monterey-base:latest
+setup_template: &SETUP_TEMPLATE
   setup_script:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y
-    - . $HOME/.cargo/env
-    - rustc --version
+
+cache_template: &CACHE_TEMPLATE
   registry_cache:
     folder: $HOME/.cargo/registry
     reupload_on_changes: true
@@ -33,6 +20,29 @@ task:
       - . $HOME/.cargo/env && rustc --version
       - md5 Cargo.lock
       - echo $CIRRUS_OS
+
+cleanup_template: &CLEANUP_TEMPLATE
+  before_cache_script:
+    - rm -rf $HOME/.cargo/registry/index
+    - rm -f ./target/.rustc_info.json
+    - find ./target/debug -maxdepth 1 -type f -delete # Delete stray files
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_HUSKY_DONT_INSTALL_HOOKS: true
+
+test_task:
+  only_if: $CIRRUS_BRANCH == "master" || $CIRRUS_PR != ""
+  matrix:
+    - name: "FreeBSD 13 Test"
+      freebsd_instance:
+        image_family: freebsd-13-1
+    - name: "macOS M1 Test"
+      macos_instance:
+        image: ghcr.io/cirruslabs/macos-monterey-base:latest
+  <<: *SETUP_TEMPLATE
+  <<: *CACHE_TEMPLATE
   test_all_feature_script:
     - . $HOME/.cargo/env
     - cargo fmt --all -- --check
@@ -45,7 +55,21 @@ task:
     - cargo test --no-run --locked --no-default-features
     - cargo test --no-fail-fast --no-default-features -- --nocapture --quiet
     - cargo clippy --all-targets --workspace --no-default-features -- -D warnings
-  before_cache_script:
-    - rm -rf $HOME/.cargo/registry/index
-    - rm -f ./target/.rustc_info.json
-    - find ./target/debug -maxdepth 1 -type f -delete # Delete stray files
+  <<: *CLEANUP_TEMPLATE
+
+build_task:
+  only_if: $CIRRUS_RELEASE != ""
+  trigger_type: manual
+  matrix:
+    - name: "FreeBSD 13 Build"
+      freebsd_instance:
+        image_family: freebsd-13-1
+    - name: "macOS M1 Build"
+      macos_instance:
+        image: ghcr.io/cirruslabs/macos-monterey-base:latest
+  <<: *SETUP_TEMPLATE
+  <<: *CACHE_TEMPLATE
+  build_script:
+    - . $HOME/.cargo/env
+    - cargo build --release --verbose --locked --features deploy
+  <<: *CLEANUP_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,13 +19,16 @@ task:
   registry_cache:
     folder: $HOME/.cargo/registry
     reupload_on_changes: true
-    fingerprint_script: md5 Cargo.lock
+    fingerprint_script:
+      - md5 Cargo.lock
+      - echo $CIRRUS_OS
   target_cache:
     folder: target
     reupload_on_changes: true
     fingerprint_script:
       - . $HOME/.cargo/env && rustc --version
       - md5 Cargo.lock
+      - echo $CIRRUS_OS
   test_all_feature_script:
     - . $HOME/.cargo/env
     - cargo fmt --all -- --check
@@ -56,13 +59,16 @@ task:
   registry_cache:
     folder: $HOME/.cargo/registry
     reupload_on_changes: true
-    fingerprint_script: md5 Cargo.lock
+    fingerprint_script:
+      - md5 Cargo.lock
+      - echo $CIRRUS_OS
   target_cache:
     folder: target
     reupload_on_changes: true
     fingerprint_script:
       - source $HOME/.cargo/env && rustc --version
       - md5 Cargo.lock
+      - echo $CIRRUS_OS
   test_all_feature_script:
     - . $HOME/.cargo/env
     - cargo fmt --all -- --check

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,10 +7,14 @@ env:
   CARGO_HUSKY_DONT_INSTALL_HOOKS: true
 
 task:
-  name: "FreeBSD 13 Test"
   only_if: $CIRRUS_BRANCH == "master" || $CIRRUS_PR != ""
-  freebsd_instance:
-    image_family: freebsd-13-1
+  matrix:
+    - name: "FreeBSD 13 Test"
+      freebsd_instance:
+        image_family: freebsd-13-1
+    - name: "macOS M1 Test"
+      macos_instance:
+        image: ghcr.io/cirruslabs/macos-monterey-base:latest
   setup_script:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y
@@ -33,53 +37,13 @@ task:
     - . $HOME/.cargo/env
     - cargo fmt --all -- --check
     - cargo test --no-run --locked --all-features
-    - cargo test --no-fail-fast --all-features -- --nocapture --quiet 
+    - cargo test --no-fail-fast --all-features -- --nocapture --quiet
     - cargo clippy --all-targets --workspace --all-features -- -D warnings
   test_no_feature_script:
     - . $HOME/.cargo/env
     - cargo fmt --all -- --check
     - cargo test --no-run --locked --no-default-features
-    - cargo test --no-fail-fast --no-default-features -- --nocapture --quiet 
-    - cargo clippy --all-targets --workspace --no-default-features -- -D warnings
-  before_cache_script:
-    - rm -rf $HOME/.cargo/registry/index
-    - rm -f ./target/.rustc_info.json
-    - find ./target/debug -maxdepth 1 -type f -delete # Delete stray files
-
-task:
-  name: "macOS M1 Test"
-  only_if: $CIRRUS_BRANCH == "master" || $CIRRUS_PR != ""
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-base:latest
-  setup_script:
-    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup.sh
-    - sh rustup.sh --default-toolchain stable -y
-    - source $HOME/.cargo/env
-    - rustc --version
-  registry_cache:
-    folder: $HOME/.cargo/registry
-    reupload_on_changes: true
-    fingerprint_script:
-      - md5 Cargo.lock
-      - echo $CIRRUS_OS
-  target_cache:
-    folder: target
-    reupload_on_changes: true
-    fingerprint_script:
-      - source $HOME/.cargo/env && rustc --version
-      - md5 Cargo.lock
-      - echo $CIRRUS_OS
-  test_all_feature_script:
-    - . $HOME/.cargo/env
-    - cargo fmt --all -- --check
-    - cargo test --no-run --locked --all-features
-    - cargo test --no-fail-fast --all-features -- --nocapture --quiet 
-    - cargo clippy --all-targets --workspace --all-features -- -D warnings
-  test_no_feature_script:
-    - . $HOME/.cargo/env
-    - cargo fmt --all -- --check
-    - cargo test --no-run --locked --no-default-features
-    - cargo test --no-fail-fast --no-default-features -- --nocapture --quiet 
+    - cargo test --no-fail-fast --no-default-features -- --nocapture --quiet
     - cargo clippy --all-targets --workspace --no-default-features -- -D warnings
   before_cache_script:
     - rm -rf $HOME/.cargo/registry/index

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ You can also try to use the generated release binaries and manually install on y
 
 - [Latest stable release](https://github.com/ClementTsang/bottom/releases/latest), generated off of the release branch
 - [Latest nightly release](https://github.com/ClementTsang/bottom/releases/tag/nightly), generated daily off of the master branch at 00:00 UTC
+  - FreeBSD and ARM macOS binaries are generated via Cirrus CI, and for now, can be found [here](https://cirrus-ci.com/github/ClementTsang/bottom).
 
 #### Auto-completion
 


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds M1 macOS and FreeBSD binary builds via Cirrus CI. Note I need to still add some code to grab the generated binaries from Cirrus CI for releases here.

## Issue

_If applicable, what issue does this address?_

Closes: #843

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
