### PR TITLE
ci: update GitHub CI to remove deprecated/unmaintained actions and commands

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,7 +17,7 @@ task:
     - env:
         FEATURES: "--no-default-features"
   setup_script:
-    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y
     - . $HOME/.cargo/env
     - rustc --version
@@ -54,7 +54,7 @@ task:
     - env:
         FEATURES: "--no-default-features"
   setup_script:
-    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y
     - source $HOME/.cargo/env
     - rustc --version

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,7 +16,7 @@ jobs:
         uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@88e7c2e1da2693cf72d58fce9416206818e61dea # https://github.com/dtolnay/rust-toolchain/commit/88e7c2e1da2693cf72d58fce9416206818e61dea
+        uses: dtolnay/rust-toolchain@ba37adf8f94a7d9affce79bd3baff1b9e3189c33 # https://github.com/dtolnay/rust-toolchain/commit/ba37adf8f94a7d9affce79bd3baff1b9e3189c33
         with:
           toolchain: stable
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable Rust cache
-        uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # 1.4.0
+        uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@88e7c2e1da2693cf72d58fce9416206818e61dea # https://github.com/dtolnay/rust-toolchain/commit/88e7c2e1da2693cf72d58fce9416206818e61dea

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,6 +24,6 @@ jobs:
         run: |
           cargo install cargo-audit --locked
 
-      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # 1.2.0
+      - uses: rustsec/audit-check@bb800784d9c5b0afa352b75dae201bf2e438960a # https://github.com/rustsec/audit-check/commit/bb800784d9c5b0afa352b75dae201bf2e438960a
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -66,7 +66,7 @@ jobs:
             }
 
           # macOS (x64)
-          - { os: "macOS-latest", target: "x86_64-apple-darwin", cross: false }
+          - { os: "macos-12", target: "x86_64-apple-darwin", cross: false }
 
           # Windows (x64, x86)
           - {
@@ -109,7 +109,7 @@ jobs:
             }
 
           # macOS ARM
-          - { os: "macOS-latest", target: "aarch64-apple-darwin", cross: true }
+          - { os: "macos-12", target: "aarch64-apple-darwin", cross: true }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Set up Rust toolchain
         if: matrix.info.container == ''
-        uses: dtolnay/rust-toolchain@88e7c2e1da2693cf72d58fce9416206818e61dea # https://github.com/dtolnay/rust-toolchain/commit/88e7c2e1da2693cf72d58fce9416206818e61dea
+        uses: dtolnay/rust-toolchain@ba37adf8f94a7d9affce79bd3baff1b9e3189c33 # https://github.com/dtolnay/rust-toolchain/commit/ba37adf8f94a7d9affce79bd3baff1b9e3189c33
         with:
           toolchain: stable
           target: ${{ matrix.info.target }}
@@ -222,7 +222,7 @@ jobs:
           args: install -y wixtoolset
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@88e7c2e1da2693cf72d58fce9416206818e61dea # https://github.com/dtolnay/rust-toolchain/commit/88e7c2e1da2693cf72d58fce9416206818e61dea
+        uses: dtolnay/rust-toolchain@ba37adf8f94a7d9affce79bd3baff1b9e3189c33 # https://github.com/dtolnay/rust-toolchain/commit/ba37adf8f94a7d9affce79bd3baff1b9e3189c33
         with:
           toolchain: stable
           target: x86_64-pc-windows-msvc
@@ -279,7 +279,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@88e7c2e1da2693cf72d58fce9416206818e61dea # https://github.com/dtolnay/rust-toolchain/commit/88e7c2e1da2693cf72d58fce9416206818e61dea
+        uses: dtolnay/rust-toolchain@ba37adf8f94a7d9affce79bd3baff1b9e3189c33 # https://github.com/dtolnay/rust-toolchain/commit/ba37adf8f94a7d9affce79bd3baff1b9e3189c33
         with:
           toolchain: stable
           target: ${{ matrix.info.target }}

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -132,7 +132,7 @@ jobs:
           target: ${{ matrix.info.target }}
 
       - name: Enable Rust cache
-        uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # 1.4.0
+        uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1
         with:
           key: ${{ matrix.info.target }}
 
@@ -228,7 +228,7 @@ jobs:
           target: x86_64-pc-windows-msvc
 
       - name: Enable Rust cache
-        uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # 1.4.0
+        uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1
         with:
           key: x86_64-pc-windows-msvc-msi
 
@@ -285,7 +285,7 @@ jobs:
           target: ${{ matrix.info.target }}
 
       - name: Enable Rust cache
-        uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # 1.4.0
+        uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1
 
       - name: Build
         uses: ClementTsang/cargo-action@v0.0.2

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -107,9 +107,6 @@ jobs:
               target: "riscv64gc-unknown-linux-gnu",
               cross: true,
             }
-
-          # macOS ARM
-          - { os: "macos-12", target: "aarch64-apple-darwin", cross: true }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -137,7 +137,7 @@ jobs:
           key: ${{ matrix.info.target }}
 
       - name: Build
-        uses: ClementTsang/cargo-action@v0.0.2
+        uses: ClementTsang/cargo-action@v0.0.3
         with:
           command: build
           args: --release --verbose --locked --target=${{ matrix.info.target }} --features deploy
@@ -288,7 +288,7 @@ jobs:
         uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1
 
       - name: Build
-        uses: ClementTsang/cargo-action@v0.0.2
+        uses: ClementTsang/cargo-action@v0.0.3
         with:
           command: build
           args: --release --locked --verbose --features deploy --target ${{ matrix.info.target }}

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -125,11 +125,11 @@ jobs:
 
       - name: Set up Rust toolchain (non-GitHub container)
         if: matrix.info.container != ''
-        uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746 # https://github.com/actions-rs/toolchain/commit/88dc2356392166efad76775c878094f4e83ff746
-        with:
-          profile: minimal
-          toolchain: stable
-          target: ${{ matrix.info.target }}
+        shell: bash
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup.sh
+          sh rustup.sh --default-toolchain stable -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Enable Rust cache
         uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -189,7 +189,7 @@ jobs:
           mv manpage.tar.gz release/
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           retention-days: 3
           name: release
@@ -246,7 +246,7 @@ jobs:
           mv bottom_x86_64_installer.msi release/
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           retention-days: 3
           name: release
@@ -336,7 +336,7 @@ jobs:
           mv bottom_${{ matrix.info.target }}.deb release/
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           retention-days: 3
           name: release

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -217,7 +217,7 @@ jobs:
         run: Install-WindowsFeature Net-Framework-Core
 
       - name: Install wixtoolset
-        uses: crazy-max/ghaction-chocolatey@87d06bbbd2cfb1835f1820042d356aef4875fb5f # 1.6.0
+        uses: crazy-max/ghaction-chocolatey@90deb87d9fbf0bb2f022b91e3bf11b4441cddda5 # 2.1.0
         with:
           args: install -y wixtoolset
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,14 +204,6 @@ jobs:
               rust: stable,
             }
 
-          # macOS ARM
-          - {
-              os: "macos-12",
-              target: "aarch64-apple-darwin",
-              cross: true,
-              rust: stable,
-            }
-
     steps:
       - name: Check if this action should be skipped
         id: skip_check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Check if this action should be skipped
         id: skip_check
-        uses: fkirc/skip-duplicate-actions@38c3738dcac87b41e2b7038775457756c793566e # https://github.com/fkirc/skip-duplicate-actions/commit/38c3738dcac87b41e2b7038775457756c793566e
+        uses: fkirc/skip-duplicate-actions@f11521568414503656a5af807dc3018c012552c4 # v5.2.0
         with:
           concurrent_skipping: "same_content_newer"
           skip_after_successful_duplicate: "true"
@@ -215,7 +215,7 @@ jobs:
     steps:
       - name: Check if this action should be skipped
         id: skip_check
-        uses: fkirc/skip-duplicate-actions@38c3738dcac87b41e2b7038775457756c793566e # https://github.com/fkirc/skip-duplicate-actions/commit/38c3738dcac87b41e2b7038775457756c793566e
+        uses: fkirc/skip-duplicate-actions@f11521568414503656a5af807dc3018c012552c4 # v5.2.0
         with:
           concurrent_skipping: "same_content_newer"
           skip_after_successful_duplicate: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Set up Rust toolchain
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        uses: dtolnay/rust-toolchain@88e7c2e1da2693cf72d58fce9416206818e61dea # https://github.com/dtolnay/rust-toolchain/commit/88e7c2e1da2693cf72d58fce9416206818e61dea
+        uses: dtolnay/rust-toolchain@ba37adf8f94a7d9affce79bd3baff1b9e3189c33 # https://github.com/dtolnay/rust-toolchain/commit/ba37adf8f94a7d9affce79bd3baff1b9e3189c33
         with:
           toolchain: stable
           components: rustfmt, clippy
@@ -228,7 +228,7 @@ jobs:
 
       - name: Set up Rust toolchain
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        uses: dtolnay/rust-toolchain@88e7c2e1da2693cf72d58fce9416206818e61dea # https://github.com/dtolnay/rust-toolchain/commit/88e7c2e1da2693cf72d58fce9416206818e61dea
+        uses: dtolnay/rust-toolchain@ba37adf8f94a7d9affce79bd3baff1b9e3189c33 # https://github.com/dtolnay/rust-toolchain/commit/ba37adf8f94a7d9affce79bd3baff1b9e3189c33
         with:
           toolchain: ${{ matrix.info.rust }}
           target: ${{ matrix.info.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
               target: "aarch64-unknown-linux-gnu",
               cross: true,
             }
-          - { os: "macOS-latest", target: "x86_64-apple-darwin", cross: false }
+          - { os: "macos-12", target: "x86_64-apple-darwin", cross: false }
           - {
               os: "windows-2019",
               target: "x86_64-pc-windows-msvc",
@@ -160,7 +160,7 @@ jobs:
               rust: beta,
             }
           - {
-              os: "macOS-latest",
+              os: "macos-12",
               target: "x86_64-apple-darwin",
               cross: false,
               rust: beta,
@@ -206,7 +206,7 @@ jobs:
 
           # macOS ARM
           - {
-              os: "macOS-latest",
+              os: "macos-12",
               target: "aarch64-apple-darwin",
               cross: true,
               rust: stable,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Enable Rust cache
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # 1.4.0
+        uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1
 
       - name: Check cargo fmt
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
@@ -234,7 +234,7 @@ jobs:
           target: ${{ matrix.info.target }}
 
       - name: Enable Rust cache
-        uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # 1.4.0
+        uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           key: ${{ matrix.info.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Build tests
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        uses: ClementTsang/cargo-action@v0.0.2
+        uses: ClementTsang/cargo-action@v0.0.3
         with:
           command: test
           args: --no-run --locked ${{ matrix.features }} --target=${{ matrix.info.target }}
@@ -92,7 +92,7 @@ jobs:
 
       - name: Run tests
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        uses: ClementTsang/cargo-action@v0.0.2
+        uses: ClementTsang/cargo-action@v0.0.3
         with:
           command: test
           args: --no-fail-fast ${{ matrix.features }} --target=${{ matrix.info.target }} -- --nocapture --quiet
@@ -103,7 +103,7 @@ jobs:
 
       - name: Run clippy
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        uses: ClementTsang/cargo-action@v0.0.2
+        uses: ClementTsang/cargo-action@v0.0.3
         with:
           command: clippy
           args: ${{ matrix.features }} --all-targets --workspace --target=${{ matrix.info.target }} -- -D warnings
@@ -241,7 +241,7 @@ jobs:
 
       - name: Check
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        uses: ClementTsang/cargo-action@v0.0.2
+        uses: ClementTsang/cargo-action@v0.0.3
         with:
           command: check
           args: --all-targets --verbose --target=${{ matrix.info.target }} --locked

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,7 @@ jobs:
           toolchain: stable
 
       - name: Enable Rust cache
-        uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # 1.4.0
+        uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1
 
       - name: Install cargo-llvm-cov
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@38c3738dcac87b41e2b7038775457756c793566e # https://github.com/fkirc/skip-duplicate-actions/commit/38c3738dcac87b41e2b7038775457756c793566e
+        uses: fkirc/skip-duplicate-actions@f11521568414503656a5af807dc3018c012552c4 # v5.2.0
         with:
           concurrent_skipping: "same_content_newer"
           skip_after_successful_duplicate: "false"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@88e7c2e1da2693cf72d58fce9416206818e61dea # https://github.com/dtolnay/rust-toolchain/commit/88e7c2e1da2693cf72d58fce9416206818e61dea
+        uses: dtolnay/rust-toolchain@ba37adf8f94a7d9affce79bd3baff1b9e3189c33 # https://github.com/dtolnay/rust-toolchain/commit/ba37adf8f94a7d9affce79bd3baff1b9e3189c33
         with:
           toolchain: stable
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -41,7 +41,7 @@ jobs:
         run: echo "${{ env.VERSION }}" > release-version
 
       - name: Upload release-version as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           retention-days: 3
           name: release-version
@@ -94,7 +94,7 @@ jobs:
           mv choco.zip release/
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           retention-days: 3
           name: release

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -10,7 +10,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@38c3738dcac87b41e2b7038775457756c793566e # https://github.com/fkirc/skip-duplicate-actions/commit/38c3738dcac87b41e2b7038775457756c793566e
+        uses: fkirc/skip-duplicate-actions@f11521568414503656a5af807dc3018c012552c4 # v5.2.0
         with:
           skip_after_successful_duplicate: "true"
           paths: '["docs/**", ".github/workflows/docs.yml"]'


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

See [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) (deprecated `set-output`) and [here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) (Node 12 is deprecated) - this was causing a bunch of warnings/spam in CI/workflows.

The updated CI changes are as follows:

- Use `macos-12` rather than `macos-latest` (which pointed to 11, and was warning that it was going to move to 12)
- Use `Swatinem/rust-cache` pinned to `22c9328bcba27aa81a32b1bef27c7e3c78052531` (version 2.0.1)
- Use `dtolnay/rust-toolchain` pinned to `ba37adf8f94a7d9affce79bd3baff1b9e3189c33`
- Use `crazy-max/ghaction-chocolatey` pinned to `90deb87d9fbf0bb2f022b91e3bf11b4441cddda5` (version 2.1.0)
- Use `fkirc/skip-duplicate-actions` pinned to `f11521568414503656a5af807dc3018c012552c4` (version 5.2.0)
- Use `ClementTsang/cargo-action` version 0.0.3
- Use `actions/upload-artifact` pinned to `3cea5372237819ed00197afe530f5a7ea3e805c8` (version 3.1.0)
- Use `rustsec/audit-check` pinned to `bb800784d9c5b0afa352b75dae201bf2e438960a` over `action-rs/audit-check`, which is unmaintained.
- Remove `actions-rs/toolchain`, which I was still using in some niche cases where it worked better, as it is unmaintained and will likely break at some point unless someone takes ownership or it gets forked. I've already stopped using it for 99% of my workflows at this point, so this is probably for the better.

Note some actions are out of my control and have not yet updated - I'll update those later:

- `rustsec/audit-check` is on a deprecated version of Node.
- `upload-artifact` uses `set-output` (https://github.com/actions/upload-artifact/issues/351)
- `action-gh-release` uses `set-output` (https://github.com/softprops/action-gh-release/issues/268)

This also removes the GitHub workflow for macOS ARM since that is now handled by Cirrus CI.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

All affected workflows should be tested. This is primarily:

- CI pipelines (required to pass PR anyways)
- [Audit](https://github.com/ClementTsang/bottom/actions/runs/3288214685/jobs/5418281886) (note it will fail as there is a current issue that will be addressed)
- [Nightly](https://github.com/ClementTsang/bottom/actions/runs/3288655777)

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [x] _If relevant, new tests were added (don't worry too much about coverage)_
