### PR TITLE
ci: add Cirrus build alias for easier build artifact URLs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,9 +26,8 @@ cache_template: &CACHE_TEMPLATE
 cleanup_template: &CLEANUP_TEMPLATE
   before_cache_script:
     - rm -rf $HOME/.cargo/registry/index
+    - rm -rf $HOME/.cargo/registry/src
     - rm -f ./target/.rustc_info.json
-    - find ./target/debug -maxdepth 1 -type f -delete || true # Delete stray files if they exist
-    - find ./target/release -maxdepth 1 -type f -delete || true # Delete stray files
 
 env:
   CARGO_INCREMENTAL: 0
@@ -61,18 +60,20 @@ test_task:
   <<: *CLEANUP_TEMPLATE
 
 build_task:
-  only_if: $CIRRUS_RELEASE != "" || $CIRRUS_CRON == "nightly"
+  only_if: $CIRRUS_RELEASE != "" || $CIRRUS_CRON == "nightly" || $CIRRUS_API_CREATED == true || $CIRRUS_BRANCH == "master"
   env:
     BTM_GENERATE: true
     COMPLETION_DIR: "target/tmp/bottom/completion/"
     MANPAGE_DIR: "target/tmp/bottom/manpage/"
   matrix:
     - name: "FreeBSD 13 Build"
+      alias: "freebsd_build"
       freebsd_instance:
         image_family: freebsd-13-1
       env:
         TARGET: "x86_64-unknown-freebsd"
     - name: "macOS M1 Build"
+      alias: "macos_build"
       macos_instance:
         image: ghcr.io/cirruslabs/macos-monterey-base:latest
       env:

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ sudo eopkg it bottom
 ```
 
 ### Void
+
 ```bash
 sudo xbps-install bottom
 ```
@@ -283,7 +284,8 @@ You can also try to use the generated release binaries and manually install on y
 
 - [Latest stable release](https://github.com/ClementTsang/bottom/releases/latest), generated off of the release branch
 - [Latest nightly release](https://github.com/ClementTsang/bottom/releases/tag/nightly), generated daily off of the master branch at 00:00 UTC
-  - FreeBSD and ARM macOS binaries are generated via Cirrus CI, and for now, can be found [here](https://cirrus-ci.com/github/ClementTsang/bottom).
+  - FreeBSD builds can be found [here](https://api.cirrus-ci.com/v1/artifact/github/ClementTsang/bottom/freebsd_build/binaries.zip)
+  - macOS ARM builds can be found [here](https://api.cirrus-ci.com/v1/artifact/github/ClementTsang/bottom/macos_build/binaries.zip)
 
 #### Auto-completion
 


### PR DESCRIPTION
## Description

_A description of the change and what it does. If relevant (such as any change that modifies the UI), **please provide screenshots** of the change:_

Adds a build alias for Cirrus to make it easier to reference build artifact URLs. 

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
