### PR TITLE
other: add random seed to fxhash hasher to avoid quadratic behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "once_cell",
  "predicates",
  "procfs",
+ "rand",
  "regex",
  "serde",
  "serde_json",
@@ -1243,6 +1244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "predicates"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,6 +1308,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ kstring = { version = "2.0.0", features = ["arc"] }
 log = { version = "0.4.16", optional = true }
 nvml-wrapper = { version = "0.7.0", optional = true }
 once_cell = "1.5.2"
+rand = "0.8.5"
 regex = "1.5.5"
 serde = { version = "1.0.136", features = ["derive"] }
 starship-battery = { version = "0.7.9", optional = true }
@@ -115,21 +116,9 @@ clap_mangen = "0.1.6"
 [package.metadata.deb]
 section = "utility"
 assets = [
-    [
-        "target/release/btm",
-        "usr/bin/",
-        "755",
-    ],
-    [
-        "LICENSE",
-        "usr/share/doc/btm/",
-        "644",
-    ],
-    [
-        "manpage/btm.1.gz",
-        "usr/share/man/man1/btm.1.gz",
-        "644",
-    ],
+    ["target/release/btm", "usr/bin/", "755"],
+    ["LICENSE", "usr/share/doc/btm/", "644"],
+    ["manpage/btm.1.gz", "usr/share/man/man1/btm.1.gz", "644"],
     [
         "completion/btm.bash",
         "usr/share/bash-completion/completions/btm",
@@ -140,11 +129,7 @@ assets = [
         "usr/share/fish/vendor_completions.d/btm.fish",
         "644",
     ],
-    [
-        "completion/_btm",
-        "usr/share/zsh/vendor-completions/",
-        "644",
-    ],
+    ["completion/_btm", "usr/share/zsh/vendor-completions/", "644"],
 ]
 extended-description = """\
 A customizable cross-platform graphical process/system monitor for the terminal. Supports Linux, macOS, and Windows.

--- a/src/app/data_farmer.rs
+++ b/src/app/data_farmer.rs
@@ -15,7 +15,6 @@
 
 use once_cell::sync::Lazy;
 
-use fxhash::FxHashMap;
 use itertools::Itertools;
 
 use std::{time::Instant, vec::Vec};
@@ -25,7 +24,10 @@ use crate::data_harvester::batteries;
 
 use crate::{
     data_harvester::{cpu, disks, memory, network, processes::ProcessHarvest, temperature, Data},
-    utils::gen_util::{get_decimal_bytes, GIGA_LIMIT},
+    utils::{
+        gen_util::{get_decimal_bytes, GIGA_LIMIT},
+        rfxhash::RfxHashMap,
+    },
     Pid,
 };
 use regex::Regex;
@@ -50,10 +52,10 @@ pub struct TimedData {
 #[derive(Clone, Debug, Default)]
 pub struct ProcessData {
     /// A PID to process data map.
-    pub process_harvest: FxHashMap<Pid, ProcessHarvest>,
+    pub process_harvest: RfxHashMap<Pid, ProcessHarvest>,
 
     /// A mapping between a process PID to any children process PIDs.
-    pub process_parent_mapping: FxHashMap<Pid, Vec<Pid>>,
+    pub process_parent_mapping: RfxHashMap<Pid, Vec<Pid>>,
 
     /// PIDs corresponding to processes that have no parents.
     pub orphan_pids: Vec<Pid>,

--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -3,7 +3,7 @@
 use std::time::Instant;
 
 #[cfg(target_os = "linux")]
-use fxhash::FxHashMap;
+use crate::utils::rfxhash::RfxHashMap;
 
 #[cfg(not(target_os = "linux"))]
 use sysinfo::{System, SystemExt};
@@ -105,7 +105,7 @@ pub struct DataCollector {
     previous_cpu_times: Vec<(cpu::PastCpuWork, cpu::PastCpuTotal)>,
     previous_average_cpu_time: Option<(cpu::PastCpuWork, cpu::PastCpuTotal)>,
     #[cfg(target_os = "linux")]
-    pid_mapping: FxHashMap<crate::Pid, processes::PrevProcDetails>,
+    pid_mapping: RfxHashMap<crate::Pid, processes::PrevProcDetails>,
     #[cfg(target_os = "linux")]
     prev_idle: f64,
     #[cfg(target_os = "linux")]
@@ -137,7 +137,7 @@ impl DataCollector {
             previous_cpu_times: vec![],
             previous_average_cpu_time: None,
             #[cfg(target_os = "linux")]
-            pid_mapping: FxHashMap::default(),
+            pid_mapping: RfxHashMap::default(),
             #[cfg(target_os = "linux")]
             prev_idle: 0_f64,
             #[cfg(target_os = "linux")]

--- a/src/app/data_harvester/processes/linux.rs
+++ b/src/app/data_harvester/processes/linux.rs
@@ -4,6 +4,7 @@ use std::collections::hash_map::Entry;
 
 use crate::components::tui_widget::time_chart::Point;
 use crate::utils::error::{self, BottomError};
+use crate::utils::rfxhash::{RfxHashMap, RfxHashSet};
 use crate::Pid;
 
 use super::{ProcessHarvest, UserTable};
@@ -11,8 +12,6 @@ use super::{ProcessHarvest, UserTable};
 use sysinfo::ProcessStatus;
 
 use procfs::process::{Process, Stat};
-
-use fxhash::{FxHashMap, FxHashSet};
 
 /// Maximum character length of a /proc/<PID>/stat process name.
 /// If it's equal or greater, then we instead refer to the command for the name.
@@ -229,13 +228,13 @@ fn read_proc(
 
 pub fn get_process_data(
     prev_idle: &mut f64, prev_non_idle: &mut f64,
-    pid_mapping: &mut FxHashMap<Pid, PrevProcDetails>, use_current_cpu_total: bool,
+    pid_mapping: &mut RfxHashMap<Pid, PrevProcDetails>, use_current_cpu_total: bool,
     time_difference_in_secs: u64, mem_total_kb: u64, user_table: &mut UserTable,
 ) -> crate::utils::error::Result<Vec<ProcessHarvest>> {
     // TODO: [PROC THREADS] Add threads
 
     if let Ok((cpu_usage, cpu_fraction)) = cpu_usage_calculation(prev_idle, prev_non_idle) {
-        let mut pids_to_clear: FxHashSet<Pid> = pid_mapping.keys().cloned().collect();
+        let mut pids_to_clear: RfxHashSet<Pid> = pid_mapping.keys().cloned().collect();
 
         let process_vector: Vec<ProcessHarvest> = std::fs::read_dir("/proc")?
             .filter_map(|dir| {

--- a/src/app/data_harvester/processes/unix.rs
+++ b/src/app/data_harvester/processes/unix.rs
@@ -1,12 +1,10 @@
 //! Unix-specific parts of process collection.
 
-use fxhash::FxHashMap;
-
-use crate::utils::error;
+use crate::utils::{error, rfxhash::RfxHashMap};
 
 #[derive(Debug, Default)]
 pub struct UserTable {
-    pub uid_user_mapping: FxHashMap<libc::uid_t, String>,
+    pub uid_user_mapping: RfxHashMap<libc::uid_t, String>,
 }
 
 impl UserTable {

--- a/src/app/widgets/process_table.rs
+++ b/src/app/widgets/process_table.rs
@@ -12,10 +12,10 @@ use crate::{
         Column, ColumnHeader, ColumnWidthBounds, DataTable, DataTableColumn, DataTableProps,
         DataTableStyling, SortColumn, SortDataTable, SortDataTableProps, SortOrder,
     },
+    utils::rfxhash::{RfxHashMap, RfxHashSet},
     Pid,
 };
 
-use fxhash::{FxHashMap, FxHashSet};
 use itertools::Itertools;
 
 pub mod proc_widget_column;
@@ -62,14 +62,14 @@ impl ProcessSearchState {
 
 #[derive(Clone, Debug)]
 pub enum ProcWidgetMode {
-    Tree { collapsed_pids: FxHashSet<Pid> },
+    Tree { collapsed_pids: RfxHashSet<Pid> },
     Grouped,
     Normal,
 }
 
 type ProcessTable = SortDataTable<ProcWidgetData, ProcColumn>;
 type SortTable = DataTable<Cow<'static, str>, SortTableColumn>;
-type StringPidMap = FxHashMap<String, Vec<Pid>>;
+type StringPidMap = RfxHashMap<String, Vec<Pid>>;
 
 pub struct ProcWidget {
     pub mode: ProcWidgetMode,
@@ -222,7 +222,7 @@ impl ProcWidget {
             show_memory_as_values,
         );
 
-        let id_pid_map = FxHashMap::default();
+        let id_pid_map = RfxHashMap::default();
 
         ProcWidget {
             proc_search: process_search_state,
@@ -275,7 +275,7 @@ impl ProcWidget {
     }
 
     fn get_tree_data(
-        &self, collapsed_pids: &FxHashSet<Pid>, data_collection: &DataCollection,
+        &self, collapsed_pids: &RfxHashSet<Pid>, data_collection: &DataCollection,
     ) -> Vec<ProcWidgetData> {
         const BRANCH_END: char = '└';
         const BRANCH_VERTICAL: char = '│';
@@ -306,13 +306,13 @@ impl ProcWidget {
                         .unwrap_or(true),
                 )
             })
-            .collect::<FxHashMap<_, _>>();
+            .collect::<RfxHashMap<_, _>>();
 
         let filtered_tree = {
-            let mut filtered_tree = FxHashMap::default();
+            let mut filtered_tree = RfxHashMap::default();
 
             // We do a simple BFS traversal to build our filtered parent-to-tree mappings.
-            let mut visited_pids = FxHashMap::default();
+            let mut visited_pids = RfxHashMap::default();
             let mut stack = orphan_pids
                 .iter()
                 .filter_map(|process| process_harvest.get(process))
@@ -484,7 +484,7 @@ impl ProcWidget {
     }
 
     fn get_normal_data(
-        &mut self, process_harvest: &FxHashMap<Pid, ProcessHarvest>,
+        &mut self, process_harvest: &RfxHashMap<Pid, ProcessHarvest>,
     ) -> Vec<ProcWidgetData> {
         let search_query = self.get_query();
         let is_using_command = self.is_using_command();
@@ -497,9 +497,9 @@ impl ProcWidget {
                 .unwrap_or(true)
         });
 
-        let mut id_pid_map: FxHashMap<String, Vec<Pid>> = FxHashMap::default();
+        let mut id_pid_map: RfxHashMap<String, Vec<Pid>> = RfxHashMap::default();
         let mut filtered_data: Vec<ProcWidgetData> = if let ProcWidgetMode::Grouped = self.mode {
-            let mut id_process_mapping: FxHashMap<String, ProcessHarvest> = FxHashMap::default();
+            let mut id_process_mapping: RfxHashMap<String, ProcessHarvest> = RfxHashMap::default();
             for process in filtered_iter {
                 let id = if is_using_command {
                     &process.command

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,6 @@ use options::*;
 use utils::error;
 
 pub mod app;
-pub mod utils {
-    pub mod error;
-    pub mod gen_util;
-    pub mod logging;
-}
 pub mod canvas;
 pub mod clap;
 pub mod components;
@@ -56,6 +51,7 @@ pub mod constants;
 pub mod data_conversion;
 pub mod options;
 pub mod units;
+pub mod utils;
 
 #[cfg(target_family = "windows")]
 pub type Pid = usize;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
 pub mod error;
 pub mod gen_util;
 pub mod logging;
+pub mod rfxhash;

--- a/src/utils/rfxhash.rs
+++ b/src/utils/rfxhash.rs
@@ -1,0 +1,43 @@
+//! fxhash but with a random start state. See the following links for the rationale on why this is needed:
+//! - https://morestina.net/blog/1843/the-stable-hashmap-trap (changes are based on the provided workaround)
+//! - https://accidentallyquadratic.tumblr.com/post/153545455987/rust-hash-iteration-reinsertion
+//! - https://github.com/cbreeden/fxhash/issues/15
+
+use std::{
+    cell::Cell,
+    collections::{HashMap, HashSet},
+    hash::{BuildHasher, Hasher},
+};
+
+use fxhash::FxHasher;
+use rand::Rng;
+
+pub type RfxHashMap<K, V> = HashMap<K, V, FxRandomState>;
+pub type RfxHashSet<V> = HashSet<V, FxRandomState>;
+
+#[derive(Copy, Clone, Debug)]
+pub struct FxRandomState(usize);
+
+impl BuildHasher for FxRandomState {
+    type Hasher = FxHasher;
+
+    fn build_hasher(&self) -> FxHasher {
+        let mut hasher = FxHasher::default();
+        hasher.write_usize(self.0);
+        hasher
+    }
+}
+
+impl Default for FxRandomState {
+    fn default() -> Self {
+        thread_local! {
+            static SEED: Cell<usize> = Cell::new(rand::thread_rng().gen())
+        }
+        let seed = SEED.with(|seed| {
+            let n = seed.get();
+            seed.set(n.wrapping_add(1));
+            n
+        });
+        FxRandomState(seed)
+    }
+}


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Seems like fxhash can, in some cases (when iterating and reinserting), give nearly quadratic behaviour. That's not really good. Thankfully, it seems like an easy bandaid fix is to just add a random seed to the hasher.

Rationale:
- https://morestina.net/blog/1843/the-stable-hashmap-trap
- https://accidentallyquadratic.tumblr.com/post/153545455987/rust-hash-iteration-reinsertion

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
