### PR TITLE
ci: remove caching for release building

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -137,11 +137,6 @@ jobs:
           sh rustup.sh --default-toolchain stable -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-      - name: Enable Rust cache
-        uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1
-        with:
-          key: ${{ matrix.info.target }}
-
       - name: Build
         uses: ClementTsang/cargo-action@v0.0.3
         with:
@@ -201,12 +196,6 @@ jobs:
           name: release
           path: release
 
-      # If I add more shared cleanup stuff in the future, I should move to a separate script, perhaps.
-      - name: Delete automatically generated completion/manpage to not cache
-        shell: bash
-        run: |
-          rm -r ./target/tmp/bottom/
-
   build-msi:
     name: "Build MSI installer"
     runs-on: "windows-2019"
@@ -232,11 +221,6 @@ jobs:
         with:
           toolchain: stable
           target: x86_64-pc-windows-msvc
-
-      - name: Enable Rust cache
-        uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1
-        with:
-          key: x86_64-pc-windows-msvc-msi
 
       - name: Build MSI file
         shell: powershell
@@ -316,9 +300,6 @@ jobs:
           toolchain: stable
           target: ${{ matrix.info.target }}
 
-      - name: Enable Rust cache
-        uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1
-
       - name: Build
         uses: ClementTsang/cargo-action@v0.0.3
         with:
@@ -373,8 +354,3 @@ jobs:
           retention-days: 3
           name: release
           path: release
-
-      - name: Delete automatically generated completion/manpage to not cache
-        shell: bash
-        run: |
-          rm -r ./target/tmp/bottom/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   # Check if things should be skipped.
-  pre_job:
+  pre-job:
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -49,9 +49,9 @@ jobs:
 
   # Runs rustfmt + tests + clippy on the main supported platforms.
   supported:
-    needs: pre_job
+    needs: pre-job
     runs-on: ${{ matrix.info.os }}
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre-job.outputs.should_skip != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -121,10 +121,10 @@ jobs:
           RUST_BACKTRACE: full
 
   # Run cargo check on all other platforms
-  other_check:
-    needs: pre_job
+  other-check:
+    needs: pre-job
     runs-on: ${{ matrix.info.os }}
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre-job.outputs.should_skip != 'true' }}
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -239,7 +239,7 @@ jobs:
 
   completion:
     name: "CI Pass Check"
-    needs: [supported, other_check]
+    needs: [supported, other-check]
     runs-on: "ubuntu-latest"
     steps:
       - name: CI Passed

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'ClementTsang/bottom' }}
 
 jobs:
-  pre_job:
+  pre-job:
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -30,8 +30,8 @@ jobs:
           do_not_skip: '["workflow_dispatch", "push"]'
 
   coverage:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    needs: pre-job
+    if: ${{ needs.pre-job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,6 +18,8 @@ env:
   CARGO_PROFILE_DEV_DEBUG: 0
 
 jobs:
+  # TODO: Add a pre-job check to skip if no change; may want to add something to check if there is a new rust version/week limit of skips?
+
   initialize-job:
     name: initialize-job
     runs-on: ubuntu-latest

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'ClementTsang/bottom' }}
 
 jobs:
-  pre_job:
+  pre-job:
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -24,8 +24,8 @@ jobs:
 
   test-build-documentation:
     name: Test building docs
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    needs: pre-job
+    if: ${{ needs.pre-job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Seems a bit redundant to take up cache space with release builds, especially since it usually just runs once a day (nightly) or occasionally (stable releases).

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

CI should pass, [nightly build](https://github.com/ClementTsang/bottom/actions/runs/3392307949) should pass.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
