### PR TITLE
feature: basic sortable temp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#794](https://github.com/ClementTsang/bottom/pull/794): Add GPU memory support for NVIDIA GPUs.
 - [#806](https://github.com/ClementTsang/bottom/pull/806): Update sysinfo to support M1 macOS temperature sensors.
 - [#841](https://github.com/ClementTsang/bottom/pull/841): Add page up/page down support for the help screen.
+- [#868](https://github.com/ClementTsang/bottom/pull/868): Make temperature widget sortable.
 
 ## [0.6.8] - 2022-02-01
 

--- a/docs/content/usage/widgets/temperature.md
+++ b/docs/content/usage/widgets/temperature.md
@@ -14,12 +14,14 @@ The temperature widget provides the sensor name as well as its current temperatu
 
 Note that key bindings are generally case-sensitive.
 
-| Binding            | Action                               |
-| ------------------ | ------------------------------------ |
-| ++up++ , ++k++     | Move up within a widget              |
-| ++down++ , ++j++   | Move down within a widget            |
-| ++g+g++ , ++home++ | Jump to the first entry in the table |
-| ++G++ , ++end++    | Jump to the last entry in the table  |
+| Binding            | Action                                                    |
+| ------------------ | --------------------------------------------------------- |
+| ++up++ , ++k++     | Move up within a widget                                   |
+| ++down++ , ++j++   | Move down within a widget                                 |
+| ++g+g++ , ++home++ | Jump to the first entry in the table                      |
+| ++G++ , ++end++    | Jump to the last entry in the table                       |
+| ++t++              | Sort by temperature, press again to reverse sorting order |
+| ++s++              | Sort by sensor name, press again to reverse sorting order |
 
 ## Mouse bindings
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2562,19 +2562,28 @@ impl App {
                             // We might have clicked on a header!  Check if we only exceeded the table + border offset, and
                             // it's implied we exceeded the gap offset.
                             if clicked_entry == border_offset {
-                                if let BottomWidgetType::Proc = &self.current_widget.widget_type {
-                                    if let Some(proc_widget_state) = self
-                                        .proc_state
-                                        .get_mut_widget_state(self.current_widget.widget_id)
-                                    {
-                                        if proc_widget_state
-                                            .table
-                                            .try_select_location(x, y)
-                                            .is_some()
+                                match &self.current_widget.widget_type {
+                                    BottomWidgetType::Proc => {
+                                        if let Some(state) = self
+                                            .proc_state
+                                            .get_mut_widget_state(self.current_widget.widget_id)
                                         {
-                                            proc_widget_state.force_data_update();
+                                            if state.table.try_select_location(x, y).is_some() {
+                                                state.force_data_update();
+                                            }
                                         }
                                     }
+                                    BottomWidgetType::Temp => {
+                                        if let Some(state) = self
+                                            .temp_state
+                                            .get_mut_widget_state(self.current_widget.widget_id)
+                                        {
+                                            if state.table.try_select_location(x, y).is_some() {
+                                                state.force_data_update();
+                                            }
+                                        }
+                                    }
+                                    _ => (),
                                 }
                             }
                         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1206,6 +1206,7 @@ impl App {
         }
     }
 
+    // FIXME: Refactor this system...
     fn handle_char(&mut self, caught_char: char) {
         match caught_char {
             '/' => {
@@ -1310,12 +1311,34 @@ impl App {
             'L' | 'D' => self.move_widget_selection(&WidgetDirection::Right),
             'K' | 'W' => self.move_widget_selection(&WidgetDirection::Up),
             'J' | 'S' => self.move_widget_selection(&WidgetDirection::Down),
-            't' => self.toggle_tree_mode(),
+            't' => {
+                if let BottomWidgetType::Proc = self.current_widget.widget_type {
+                    self.toggle_tree_mode()
+                } else if let Some(temp) = self
+                    .temp_state
+                    .get_mut_widget_state(self.current_widget.widget_id)
+                {
+                    temp.table.set_sort_index(1);
+                    temp.force_data_update();
+                    self.is_force_redraw = true;
+                }
+            }
             '+' => self.on_plus(),
             '-' => self.on_minus(),
             '=' => self.reset_zoom(),
             'e' => self.toggle_expand_widget(),
-            's' => self.toggle_sort_menu(),
+            's' => {
+                if let BottomWidgetType::Proc = self.current_widget.widget_type {
+                    self.toggle_sort_menu()
+                } else if let Some(temp) = self
+                    .temp_state
+                    .get_mut_widget_state(self.current_widget.widget_id)
+                {
+                    temp.table.set_sort_index(0);
+                    temp.force_data_update();
+                    self.is_force_redraw = true;
+                }
+            }
             'I' => self.invert_sort(),
             '%' => self.toggle_percentages(),
             _ => {}

--- a/src/app/widgets/process_table.rs
+++ b/src/app/widgets/process_table.rs
@@ -262,7 +262,7 @@ impl ProcWidget {
 
     /// This function *only* updates the displayed process data. If there is a need to update the actual *stored* data,
     /// call it before this function.
-    pub fn update_displayed_process_data(&mut self, data_collection: &DataCollection) {
+    pub fn ingest_data(&mut self, data_collection: &DataCollection) {
         let data = match &self.mode {
             ProcWidgetMode::Grouped | ProcWidgetMode::Normal => {
                 self.get_normal_data(&data_collection.process_data.process_harvest)

--- a/src/app/widgets/temperature_table.rs
+++ b/src/app/widgets/temperature_table.rs
@@ -8,10 +8,10 @@ use crate::{
     app::{data_harvester::temperature::TemperatureType, AppConfigFields},
     canvas::canvas_colours::CanvasColours,
     components::data_table::{
-        Column, ColumnHeader, DataTable, DataTableColumn, DataTableProps, DataTableStyling,
-        DataToCell,
+        ColumnHeader, DataTableColumn, DataTableProps, DataTableStyling, DataToCell, SortColumn,
+        SortDataTable, SortDataTableProps, SortOrder, SortsRow,
     },
-    utils::gen_util::truncate_text,
+    utils::gen_util::{sort_partial_fn, truncate_text},
 };
 
 #[derive(Clone)]
@@ -72,34 +72,67 @@ impl DataToCell<TempWidgetColumn> for TempWidgetData {
     }
 }
 
+impl SortsRow for TempWidgetColumn {
+    type DataType = TempWidgetData;
+
+    fn sort_data(&self, data: &mut [Self::DataType], descending: bool) {
+        match self {
+            TempWidgetColumn::Sensor => {
+                data.sort_by(|a, b| sort_partial_fn(descending)(&a.sensor, &b.sensor));
+            }
+            TempWidgetColumn::Temp => {
+                data.sort_by(|a, b| {
+                    sort_partial_fn(descending)(a.temperature_value, b.temperature_value)
+                });
+            }
+        }
+    }
+}
+
 pub struct TempWidgetState {
-    pub table: DataTable<TempWidgetData, TempWidgetColumn>,
+    pub table: SortDataTable<TempWidgetData, TempWidgetColumn>,
+    pub force_update_data: bool,
 }
 
 impl TempWidgetState {
     pub fn new(config: &AppConfigFields, colours: &CanvasColours) -> Self {
-        const COLUMNS: [Column<TempWidgetColumn>; 2] = [
-            Column::soft(TempWidgetColumn::Sensor, Some(0.8)),
-            Column::soft(TempWidgetColumn::Temp, None),
+        let columns = [
+            SortColumn::soft(TempWidgetColumn::Sensor, Some(0.8)),
+            SortColumn::soft(TempWidgetColumn::Temp, None).default_descending(),
         ];
 
-        let props = DataTableProps {
-            title: Some(" Temperatures ".into()),
-            table_gap: config.table_gap,
-            left_to_right: false,
-            is_basic: config.use_basic_mode,
-            show_table_scroll_position: config.show_table_scroll_position,
-            show_current_entry_when_unfocused: false,
+        let props = SortDataTableProps {
+            inner: DataTableProps {
+                title: Some(" Temperatures ".into()),
+                table_gap: config.table_gap,
+                left_to_right: false,
+                is_basic: config.use_basic_mode,
+                show_table_scroll_position: config.show_table_scroll_position,
+                show_current_entry_when_unfocused: false,
+            },
+            sort_index: 0,
+            order: SortOrder::Ascending,
         };
 
         let styling = DataTableStyling::from_colours(colours);
 
         Self {
-            table: DataTable::new(COLUMNS, props, styling),
+            table: SortDataTable::new_sortable(columns, props, styling),
+            force_update_data: false,
         }
     }
 
+    /// Forces an update of the data stored.
+    #[inline]
+    pub fn force_data_update(&mut self) {
+        self.force_update_data = true;
+    }
+
     pub fn ingest_data(&mut self, data: &[TempWidgetData]) {
-        self.table.set_data(data.to_vec());
+        let mut data = data.to_vec();
+        if let Some(column) = self.table.columns.get(self.table.sort_index()) {
+            column.sort_by(&mut data, self.table.order());
+        }
+        self.table.set_data(data);
     }
 }

--- a/src/app/widgets/temperature_table.rs
+++ b/src/app/widgets/temperature_table.rs
@@ -29,8 +29,8 @@ pub enum TempWidgetColumn {
 impl ColumnHeader for TempWidgetColumn {
     fn text(&self) -> Cow<'static, str> {
         match self {
-            TempWidgetColumn::Sensor => "Sensor".into(),
-            TempWidgetColumn::Temp => "Temp".into(),
+            TempWidgetColumn::Sensor => "Sensor(s)".into(),
+            TempWidgetColumn::Temp => "Temp(t)".into(),
         }
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -196,7 +196,11 @@ fn main() -> Result<()> {
                             app.converted_data.ingest_temp_data(
                                 &app.data_collection,
                                 app.app_config_fields.temperature_type,
-                            )
+                            );
+
+                            for temp in app.temp_state.widget_states.values_mut() {
+                                temp.force_data_update();
+                            }
                         }
 
                         // Memory

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,7 @@ pub fn update_data(app: &mut App) {
 
     for proc in app.proc_state.widget_states.values_mut() {
         if proc.force_update_data {
-            proc.update_displayed_process_data(data_source);
+            proc.ingest_data(data_source);
             proc.force_update_data = false;
         }
     }
@@ -353,7 +353,10 @@ pub fn update_data(app: &mut App) {
     {
         let data = &app.converted_data.temp_data;
         for temp in app.temp_state.widget_states.values_mut() {
-            temp.ingest_data(data);
+            if temp.force_update_data {
+                temp.ingest_data(data);
+                temp.force_update_data = false;
+            }
         }
     }
     {


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Add sorting + shortcuts to the temp widget.

![image](https://user-images.githubusercontent.com/34804052/200145154-afc8041b-0878-48cb-ada8-48c11db613ab.png)
![image](https://user-images.githubusercontent.com/34804052/200145166-4b9e37ae-7402-4380-b3e3-9e2bfb2700da.png)

I don't really want to break the current behaviour, so the default sort is still ascending + by temp sensor name.

Nice to haves later:
- Currently doesn't have a sort table added, maybe needed?
- I want to do some refactoring
- Maybe an option for setting default order/index (e.g. temp)

## Issue

_If applicable, what issue does this address?_

Closes: #429 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
