### PR TITLE
feature: search paste support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#841](https://github.com/ClementTsang/bottom/pull/841): Add page up/page down support for the help screen.
 - [#868](https://github.com/ClementTsang/bottom/pull/868): Make temperature widget sortable.
 - [#870](https://github.com/ClementTsang/bottom/pull/870): Make disk widget sortable.
+- [#881](https://github.com/ClementTsang/bottom/pull/881): Add pasting to the search bar.
 
 ## [0.6.8] - 2022-02-01
 

--- a/docs/content/usage/widgets/process.md
+++ b/docs/content/usage/widgets/process.md
@@ -102,7 +102,7 @@ Lastly, we can refine our search even further based on the other columns, like P
     <img src="../../../assets/screenshots/process/search/cpu.webp" alt="A picture of searching for a process with a search condition that uses the CPU keyword."/>
 </figure>
 
-You can also paste search queries (e.g. ++shift+insert++, ++ctrl+shift+v++), though this may not work in Windows.
+You can also paste search queries (e.g. ++shift+insert++, ++ctrl+shift+v++), though this may not work in some Windows terminals.
 
 #### Keywords
 

--- a/docs/content/usage/widgets/process.md
+++ b/docs/content/usage/widgets/process.md
@@ -102,6 +102,8 @@ Lastly, we can refine our search even further based on the other columns, like P
     <img src="../../../assets/screenshots/process/search/cpu.webp" alt="A picture of searching for a process with a search condition that uses the CPU keyword."/>
 </figure>
 
+You can also paste search queries (e.g. ++shift+insert++, ++ctrl+shift+v++).
+
 #### Keywords
 
 Note all keywords are case-insensitive. To search for a process/command that collides with a keyword, surround the term with quotes (e.x. `"cpu"`).

--- a/docs/content/usage/widgets/process.md
+++ b/docs/content/usage/widgets/process.md
@@ -102,7 +102,7 @@ Lastly, we can refine our search even further based on the other columns, like P
     <img src="../../../assets/screenshots/process/search/cpu.webp" alt="A picture of searching for a process with a search condition that uses the CPU keyword."/>
 </figure>
 
-You can also paste search queries (e.g. ++shift+insert++, ++ctrl+shift+v++).
+You can also paste search queries (e.g. ++shift+insert++, ++ctrl+shift+v++), though this may not work in Windows.
 
 #### Keywords
 

--- a/docs/content/usage/widgets/process.md
+++ b/docs/content/usage/widgets/process.md
@@ -102,7 +102,7 @@ Lastly, we can refine our search even further based on the other columns, like P
     <img src="../../../assets/screenshots/process/search/cpu.webp" alt="A picture of searching for a process with a search condition that uses the CPU keyword."/>
 </figure>
 
-You can also paste search queries (e.g. ++shift+insert++, ++ctrl+shift+v++), though this may not work in some Windows terminals.
+You can also paste search queries (e.g. ++shift+insert++, ++ctrl+shift+v++).
 
 #### Keywords
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2766,8 +2766,6 @@ impl App {
                 proc_widget_state.update_query();
                 proc_widget_state.proc_search.search_state.cursor_direction =
                     CursorDirection::Right;
-
-                return;
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2718,7 +2718,8 @@ impl App {
 
     /// A quick and dirty way to handle paste events.
     pub fn handle_paste(&mut self, paste: String) {
-        // Partially copy-pasted from the single-char variant; should probably optimize this process in the future.
+        // Partially copy-pasted from the single-char variant; should probably clean up this process in the future.
+        // In particular, encapsulate this entire logic and add some tests to make it less potentially error-prone.
         let is_in_search_widget = self.is_in_search_widget();
         if let Some(proc_widget_state) = self
             .proc_state

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ use std::{
     time::Instant,
 };
 
+use concat_string::concat_string;
 use unicode_segmentation::GraphemeCursor;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -35,7 +36,7 @@ pub mod widgets;
 
 use frozen_state::FrozenState;
 
-const MAX_SEARCH_LENGTH: usize = 200;
+const MAX_SEARCH_LENGTH: usize = 200; // FIXME: Remove this limit, it's unnecessary.
 
 #[derive(Debug, Clone)]
 pub enum AxisScaling {
@@ -2712,6 +2713,62 @@ impl App {
             }
         } else {
             1 + self.app_config_fields.table_gap
+        }
+    }
+
+    /// A quick and dirty way to handle paste events.
+    pub fn handle_paste(&mut self, paste: String) {
+        // Partially copy-pasted from the single-char variant; should probably optimize this process in the future.
+        let is_in_search_widget = self.is_in_search_widget();
+        if let Some(proc_widget_state) = self
+            .proc_state
+            .widget_states
+            .get_mut(&(self.current_widget.widget_id - 1))
+        {
+            let curr_width = UnicodeWidthStr::width(
+                proc_widget_state
+                    .proc_search
+                    .search_state
+                    .current_search_query
+                    .as_str(),
+            );
+            let paste_width = UnicodeWidthStr::width(paste.as_str());
+
+            if is_in_search_widget
+                && proc_widget_state.is_search_enabled()
+                && curr_width + paste_width <= MAX_SEARCH_LENGTH
+            {
+                let left_bound = proc_widget_state.get_search_cursor_position();
+                let new_left_bound = (left_bound + paste_width).saturating_sub(1);
+                let curr_query = &mut proc_widget_state
+                    .proc_search
+                    .search_state
+                    .current_search_query;
+                let (left, right) = curr_query.split_at(left_bound);
+                *curr_query = concat_string!(left, paste, right);
+
+                proc_widget_state.proc_search.search_state.grapheme_cursor = GraphemeCursor::new(
+                    new_left_bound,
+                    proc_widget_state
+                        .proc_search
+                        .search_state
+                        .current_search_query
+                        .len(),
+                    true,
+                );
+                proc_widget_state.search_walk_forward(new_left_bound);
+
+                proc_widget_state
+                    .proc_search
+                    .search_state
+                    .char_cursor_position += paste_width;
+
+                proc_widget_state.update_query();
+                proc_widget_state.proc_search.search_state.cursor_direction =
+                    CursorDirection::Right;
+
+                return;
+            }
         }
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -26,7 +26,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use crossterm::{
-    event::EnableMouseCapture,
+    event::{EnableBracketedPaste, EnableMouseCapture},
     execute,
     terminal::{enable_raw_mode, EnterAlternateScreen},
 };
@@ -120,7 +120,12 @@ fn main() -> Result<()> {
 
     // Set up up tui and crossterm
     let mut stdout_val = stdout();
-    execute!(stdout_val, EnterAlternateScreen, EnableMouseCapture)?;
+    execute!(
+        stdout_val,
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        EnableBracketedPaste
+    )?;
     enable_raw_mode()?;
 
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout_val))?;
@@ -149,6 +154,10 @@ fn main() -> Result<()> {
                 }
                 BottomEvent::MouseInput(event) => {
                     handle_mouse_event(event, &mut app);
+                    update_data(&mut app);
+                }
+                BottomEvent::PasteEvent(paste) => {
+                    app.handle_paste(paste);
                     update_data(&mut app);
                 }
                 BottomEvent::Update(data) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@ use std::{
 
 use crossterm::{
     event::{
-        poll, read, DisableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent,
-        MouseEventKind,
+        poll, read, DisableBracketedPaste, DisableMouseCapture, Event, KeyCode, KeyEvent,
+        KeyModifiers, MouseEvent, MouseEventKind,
     },
     execute,
     style::Print,
@@ -71,6 +71,7 @@ pub type Pid = libc::pid_t;
 pub enum BottomEvent<I, J> {
     KeyInput(I),
     MouseInput(J),
+    PasteEvent(String),
     Update(Box<data_harvester::Data>),
     Clean,
 }
@@ -273,6 +274,7 @@ pub fn cleanup_terminal(
     disable_raw_mode()?;
     execute!(
         terminal.backend_mut(),
+        DisableBracketedPaste,
         DisableMouseCapture,
         LeaveAlternateScreen
     )?;
@@ -311,7 +313,13 @@ pub fn panic_hook(panic_info: &PanicInfo<'_>) {
     let stacktrace: String = format!("{:?}", backtrace::Backtrace::new());
 
     disable_raw_mode().unwrap();
-    execute!(stdout, DisableMouseCapture, LeaveAlternateScreen).unwrap();
+    execute!(
+        stdout,
+        DisableBracketedPaste,
+        DisableMouseCapture,
+        LeaveAlternateScreen
+    )
+    .unwrap();
 
     // Print stack trace.  Must be done after!
     execute!(
@@ -425,6 +433,11 @@ pub fn create_input_thread(
                     if let Ok(event) = read() {
                         // FIXME: Handle all other event cases.
                         match event {
+                            Event::Paste(paste) => {
+                                if sender.send(BottomEvent::PasteEvent(paste)).is_err() {
+                                    break;
+                                }
+                            }
                             Event::Key(key) => {
                                 if Instant::now().duration_since(keyboard_timer).as_millis() >= 20 {
                                     if sender.send(BottomEvent::KeyInput(key)).is_err() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,7 +418,6 @@ pub fn create_input_thread(
 ) -> JoinHandle<()> {
     thread::spawn(move || {
         let mut mouse_timer = Instant::now();
-        let mut keyboard_timer = Instant::now();
 
         loop {
             if let Ok(is_terminated) = termination_ctrl_lock.try_lock() {
@@ -439,11 +438,8 @@ pub fn create_input_thread(
                                 }
                             }
                             Event::Key(key) => {
-                                if Instant::now().duration_since(keyboard_timer).as_millis() >= 20 {
-                                    if sender.send(BottomEvent::KeyInput(key)).is_err() {
-                                        break;
-                                    }
-                                    keyboard_timer = Instant::now();
+                                if sender.send(BottomEvent::KeyInput(key)).is_err() {
+                                    break;
                                 }
                             }
                             Event::Mouse(mouse) => {


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Adds paste support to the process search bar.

Unix support is primarily implemented using paste events. Windows falls back to keyboard inputs; to support this, I removed the key event throttler since it doesn't really seem to be necessary anymore.

This also fixes a potential issue of the grapheme cursor increment occasionally failing if it doesn't have enough context - luckily, the unicode library has a fix for that.

## Issue

_If applicable, what issue does this address?_

Closes: #880 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [x] _Windows_
- [x] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
