### PR TITLE
ci: update upload-artifact to 3.1.1 to remove set-output warnings

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -190,7 +190,7 @@ jobs:
           mv manpage.tar.gz release/
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           retention-days: 3
           name: release
@@ -236,7 +236,7 @@ jobs:
           mv bottom_x86_64_installer.msi release/
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           retention-days: 3
           name: release
@@ -262,7 +262,7 @@ jobs:
           python ./scripts/cirrus/build.py "${{ github.ref_name }}" "release/" "${{ inputs.caller }}"
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           retention-days: 3
           name: release
@@ -349,7 +349,7 @@ jobs:
           mv bottom_${{ matrix.info.target }}.deb release/
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           retention-days: 3
           name: release

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -41,7 +41,7 @@ jobs:
         run: echo "${{ env.VERSION }}" > release-version
 
       - name: Upload release-version as artifact
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           retention-days: 3
           name: release-version
@@ -97,7 +97,7 @@ jobs:
           mv choco.zip release/
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           retention-days: 3
           name: release


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This resolves [this](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) GitHub Actions deprecation warning.

For more context, see #846.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

All affected workflows *should* pass, though it might be hard to test deployment without some extra work. We'll mainly just test nightly instead, which should be fine as there are no breaking changes. The previous warning should be gone.

The run can be found here: https://github.com/ClementTsang/bottom/actions/runs/3443313490

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
