### PR TITLE
ci: switch delete-tag-and-release to personal fork to avoid node16 warning

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,7 +59,7 @@ jobs:
           du -h -d 0 ./release/*
 
       - name: Delete tag and release
-        uses: dev-drprasad/delete-tag-and-release@085c6969f18bad0de1b9f3fe6692a3cd01f64fe5 # 0.2.0
+        uses: ClementTsang/delete-tag-and-release@d379c0b0792c89690fd9fabd7bb4b8c620ef5aad # v0.3.0
         if: github.event.inputs.isMock != 'mock'
         with:
           delete_release: true


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This resolves [this](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) GitHub Actions deprecation warning by switching over to a personal fork of the action.

For more context, see #846.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Non-mock nightly should work. Workflow: https://github.com/ClementTsang/bottom/actions/runs/3443381845/jobs/5744852253

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
