### PR TITLE
bug: redirect stderr on FreeBSD to avoid drawing on UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "ctrlc",
  "dirs",
  "fern",
+ "filedescriptor",
  "futures",
  "futures-timer",
  "fxhash",
@@ -587,6 +588,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bdd7b0849075e79ee9a1836df22c717d1eba30451796fdc631b04565dd11e2a"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ winapi = "0.3.9"
 [target.'cfg(target_os = "freebsd")'.dependencies]
 serde_json = { version = "1.0.82" }
 sysctl = { version = "0.5.2", optional = true }
+filedescriptor = "0.8.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -251,14 +251,22 @@ impl DataCollector {
             if self.widgets_to_harvest.use_temp {
                 self.sys.refresh_components();
             }
-            if cfg!(target_os = "windows") && self.widgets_to_harvest.use_net {
-                self.sys.refresh_networks();
+
+            #[cfg(target_os = "windows")]
+            {
+                if self.widgets_to_harvest.use_net {
+                    self.sys.refresh_networks();
+                }
             }
-            if cfg!(target_os = "freebsd") && self.widgets_to_harvest.use_disk {
-                self.sys.refresh_disks();
-            }
-            if cfg!(target_os = "freebsd") && self.widgets_to_harvest.use_mem {
-                self.sys.refresh_memory();
+
+            #[cfg(target_os = "freebsd")]
+            {
+                if self.widgets_to_harvest.use_disk {
+                    self.sys.refresh_disks();
+                }
+                if self.widgets_to_harvest.use_mem {
+                    self.sys.refresh_memory();
+                }
             }
         }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -131,6 +131,16 @@ fn main() -> Result<()> {
     terminal.clear()?;
     terminal.hide_cursor()?;
 
+    #[cfg(target_os = "freebsd")]
+    let _stderr_fd = {
+        // A really ugly band-aid to suppress stderr warnings on FreeBSD due to sysinfo.
+        use filedescriptor::{FileDescriptor, StdioDescriptor};
+        use std::fs::OpenOptions;
+
+        let path = OpenOptions::new().write(true).open("/dev/null")?;
+        FileDescriptor::redirect_stdio(&path, StdioDescriptor::Stderr)?
+    };
+
     // Set panic hook
     panic::set_hook(Box::new(panic_hook));
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

A really ugly band-aid fix to stop stderr messages from being printed on only FreeBSD systems due to data gathering.

## Issue

_If applicable, what issue does this address?_

Closes: #798 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_
- [x] _FreeBSD_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
