### PR TITLE
bug: fix reading temperature from disabled devices

### DIFF
--- a/src/app/data_harvester/temperature/linux.rs
+++ b/src/app/data_harvester/temperature/linux.rs
@@ -161,11 +161,16 @@ fn get_from_hwmon(
 
             if is_temp_filtered(filter, &name) {
                 let temp = if should_read_temp {
-                    let temp = fs::read_to_string(temp)?;
-                    let temp = temp.trim_end().parse::<f32>().map_err(|e| {
-                        crate::utils::error::BottomError::ConversionError(e.to_string())
-                    })?;
-                    temp / 1_000.0
+                    if let Ok(temp) = fs::read_to_string(temp) {
+                        let temp = temp.trim_end().parse::<f32>().map_err(|e| {
+                            crate::utils::error::BottomError::ConversionError(e.to_string())
+                        })?;
+                        temp / 1_000.0
+                    } else {
+                        // For some devices (e.g. iwlwifi), this file becomes empty when the device
+                        // is disabled. In this case we skip the device.
+                        continue;
+                    }
                 } else {
                     0.0
                 };


### PR DESCRIPTION
## Description

On Linux, when an `iwlwifi` (Intel Wi-Fi) device is disabled, its `temp1_input` file becomes empty and causes `fs::read_to_string` to return an error. This PR fixes the issue by ignoring the error and skipping the file.

## Issue

Did not open one since I quickly worked out the fix.

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
