### PR TITLE
Adding default expanded option to commandline and config (closes #822)

### DIFF
--- a/sample_configs/default_config.toml
+++ b/sample_configs/default_config.toml
@@ -43,6 +43,8 @@
 # Override layout default widget
 #default_widget_type = "proc"
 #default_widget_count = 1
+# Expand selected widget upon starting the app
+#expanded_on_startup = true
 # Use basic mode
 #basic = false
 # Use the old network legend style

--- a/src/app.rs
+++ b/src/app.rs
@@ -123,7 +123,7 @@ pub struct App {
     #[builder(default, setter(skip))]
     pub help_dialog_state: AppHelpDialogState,
 
-    #[builder(default = false, setter(skip))]
+    #[builder(default = false)]
     pub is_expanded: bool,
 
     #[builder(default = false, setter(skip))]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -48,7 +48,7 @@ fn main() -> Result<()> {
         .context("Unable to properly parse or create the config file.")?;
 
     // Get widget layout separately
-    let (widget_layout, default_widget_id, default_widget_type_option, expanded_on_startup) =
+    let (widget_layout, default_widget_id, default_widget_type_option) =
         get_widget_layout(&matches, &config)
             .context("Found an issue while trying to build the widget layout.")?;
 
@@ -65,7 +65,6 @@ fn main() -> Result<()> {
         &widget_layout,
         default_widget_id,
         &default_widget_type_option,
-        expanded_on_startup,
         &colours,
     )?;
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -48,7 +48,7 @@ fn main() -> Result<()> {
         .context("Unable to properly parse or create the config file.")?;
 
     // Get widget layout separately
-    let (widget_layout, default_widget_id, default_widget_type_option) =
+    let (widget_layout, default_widget_id, default_widget_type_option, expanded_on_startup) =
         get_widget_layout(&matches, &config)
             .context("Found an issue while trying to build the widget layout.")?;
 
@@ -65,6 +65,7 @@ fn main() -> Result<()> {
         &widget_layout,
         default_widget_id,
         &default_widget_type_option,
+        expanded_on_startup,
         &colours,
     )?;
 

--- a/src/clap.rs
+++ b/src/clap.rs
@@ -319,7 +319,8 @@ use CPU (3) as the default instead.
     let expanded_on_startup = Arg::new("expanded_on_startup")
         .long("expanded")
         .short('e')
-        .help("Expanded selected widget upon starting the app. Same as pressing \"e\" inside the app. Use with \"default_widget_type\" and \"default_widget_count\" to select desired expanded widget.");
+        .help("Expand selected widget upon starting the app.")
+        .long_help("Expand selected widget upon starting the app. Same as pressing \"e\" inside the app. Use with \"default_widget_type\" and \"default_widget_count\" to select desired expanded widget.");
 
     let rate = Arg::new("rate")
         .short('r')

--- a/src/clap.rs
+++ b/src/clap.rs
@@ -316,6 +316,11 @@ use CPU (3) as the default instead.
         .help("Sets the default widget type, use --help for info.")
         .long_help(DEFAULT_WIDGET_TYPE_STR);
 
+    let expanded_on_startup = Arg::new("expanded_on_startup")
+        .long("expanded")
+        .short('e')
+        .help("Expanded selected widget upon starting the app. Same as pressing \"e\" inside the app. Use with \"default_widget_type\" and \"default_widget_count\" to select desired expanded widget.");
+
     let rate = Arg::new("rate")
         .short('r')
         .long("rate")
@@ -407,7 +412,8 @@ use CPU (3) as the default instead.
         .arg(unnormalized_cpu)
         .arg(use_old_network_legend)
         .arg(whole_word)
-        .arg(retention);
+        .arg(retention)
+        .arg(expanded_on_startup);
 
     #[cfg(feature = "battery")]
     {

--- a/src/clap.rs
+++ b/src/clap.rs
@@ -320,7 +320,7 @@ use CPU (3) as the default instead.
         .long("expanded")
         .short('e')
         .help("Expand selected widget upon starting the app.")
-        .long_help("Expand selected widget upon starting the app. Same as pressing \"e\" inside the app. Use with \"default_widget_type\" and \"default_widget_count\" to select desired expanded widget.");
+        .long_help("Expand selected widget upon starting the app. Same as pressing \"e\" inside the app. Use with \"default_widget_type\" and \"default_widget_count\" to select desired expanded widget. This flag has no effect in basic mode (--basic)");
 
     let rate = Arg::new("rate")
         .short('r')

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -518,6 +518,7 @@ pub const CONFIG_TEXT: &str = r##"# This is a default config file for bottom.  A
 # Override layout default widget
 #default_widget_type = "proc"
 #default_widget_count = 1
+#expanded_on_startup = false
 # Use basic mode
 #basic = false
 # Use the old network legend style

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -518,7 +518,8 @@ pub const CONFIG_TEXT: &str = r##"# This is a default config file for bottom.  A
 # Override layout default widget
 #default_widget_type = "proc"
 #default_widget_count = 1
-#expanded_on_startup = false
+# Expand selected widget upon starting the app
+#expanded_on_startup = true
 # Use basic mode
 #basic = false
 # Use the old network legend style

--- a/src/options.rs
+++ b/src/options.rs
@@ -173,7 +173,7 @@ pub struct IgnoreList {
 pub fn build_app(
     matches: &ArgMatches, config: &mut Config, widget_layout: &BottomLayout,
     default_widget_id: u64, default_widget_type_option: &Option<BottomWidgetType>,
-    expanded_upon_startup: bool, colours: &CanvasColours,
+    colours: &CanvasColours,
 ) -> Result<App> {
     use BottomWidgetType::*;
 
@@ -407,6 +407,8 @@ pub fn build_app(
     let net_filter =
         get_ignore_list(&config.net_filter).context("Update 'net_filter' in your config file")?;
 
+    let expanded_upon_startup = get_expanded_on_startup(matches, config);
+
     Ok(App::builder()
         .app_config_fields(app_config_fields)
         .cpu_state(CpuState::init(cpu_state_map))
@@ -432,7 +434,7 @@ pub fn build_app(
 
 pub fn get_widget_layout(
     matches: &ArgMatches, config: &Config,
-) -> error::Result<(BottomLayout, u64, Option<BottomWidgetType>, bool)> {
+) -> error::Result<(BottomLayout, u64, Option<BottomWidgetType>)> {
     let left_legend = get_use_left_legend(matches, config);
     let (default_widget_type, mut default_widget_count) =
         get_default_widget_and_count(matches, config)?;
@@ -492,14 +494,7 @@ pub fn get_widget_layout(
         }
     };
 
-    let expanded_upon_startup = get_expanded_on_startup(matches, config);
-
-    Ok((
-        bottom_layout,
-        default_widget_id,
-        default_widget_type,
-        expanded_upon_startup,
-    ))
+    Ok((bottom_layout, default_widget_id, default_widget_type))
 }
 
 fn get_update_rate_in_milliseconds(matches: &ArgMatches, config: &Config) -> error::Result<u64> {

--- a/src/options.rs
+++ b/src/options.rs
@@ -422,7 +422,7 @@ pub fn build_app(
         .current_widget(widget_map.get(&initial_widget_id).unwrap().clone()) // TODO: [UNWRAP] - many of the unwraps are fine (like this one) but do a once-over and/or switch to expect?
         .widget_map(widget_map)
         .used_widgets(used_widgets)
-        .is_expanded(expanded_upon_startup)
+        .is_expanded(expanded_upon_startup && !use_basic_mode)
         .filters(DataFilters {
             disk_filter,
             mount_filter,


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Addresses #822: Adding option to expand widgets on startup. Also adding the corresponding option to config file.

## Issue

_If applicable, what issue does this address?_

Closes: #822 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

testing by `debug_assert()` from `clap`.

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [x] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
