### PR TITLE
ci: add freebsd 12 as a build/check target

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,6 +47,9 @@ test_task:
     - name: "FreeBSD 13 Test"
       freebsd_instance:
         image_family: freebsd-13-1
+    - name: "FreeBSD 12 Test"
+      freebsd_instance:
+        image_family: freebsd-12-3
     - name: "macOS M1 Test"
       macos_instance:
         image: ghcr.io/cirruslabs/macos-monterey-base:latest

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -75,9 +75,15 @@ build_task:
     MANPAGE_DIR: "target/tmp/bottom/manpage/"
   matrix:
     - name: "FreeBSD 13 Build"
-      alias: "freebsd_build"
+      alias: "freebsd_13_1_build"
       freebsd_instance:
         image_family: freebsd-13-1
+      env:
+        TARGET: "x86_64-unknown-freebsd"
+    - name: "FreeBSD 12 Build"
+      alias: "freebsd_12_3_build"
+      freebsd_instance:
+        image_family: freebsd-12-3
       env:
         TARGET: "x86_64-unknown-freebsd"
     - name: "macOS M1 Build"

--- a/scripts/cirrus/build.py
+++ b/scripts/cirrus/build.py
@@ -18,7 +18,8 @@ from urllib.request import Request, urlopen, urlretrieve
 
 URL = "https://api.cirrus-ci.com/graphql"
 TASKS = [
-    ("freebsd_build", "bottom_x86_64-unknown-freebsd.tar.gz"),
+    ("freebsd_12_3_build", "bottom_x86_64-unknown-freebsd-12-3.tar.gz"),
+    ("freebsd_13_1_build", "bottom_x86_64-unknown-freebsd-13-1.tar.gz"),
     ("macos_build", "bottom_aarch64-apple-darwin.tar.gz"),
 ]
 DL_URL_TEMPLATE = "https://api.cirrus-ci.com/v1/artifact/build/%s/%s/binaries/%s"


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This adds FreeBSD 12-3 as a Cirrus target for builds and checks.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

- CI workflow should succeed
- Nightly workflow should succeed: https://github.com/ClementTsang/bottom/actions/runs/3605977724


## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
