### PR TITLE
other: don't draw on non-updating events

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -162,14 +162,17 @@ fn main() -> Result<()> {
                         break;
                     }
                     update_data(&mut app);
+                    try_drawing(&mut terminal, &mut app, &mut painter)?;
                 }
                 BottomEvent::MouseInput(event) => {
                     handle_mouse_event(event, &mut app);
                     update_data(&mut app);
+                    try_drawing(&mut terminal, &mut app, &mut painter)?;
                 }
                 BottomEvent::PasteEvent(paste) => {
                     app.handle_paste(paste);
                     update_data(&mut app);
+                    try_drawing(&mut terminal, &mut app, &mut painter)?;
                 }
                 BottomEvent::Update(data) => {
                     app.data_collection.eat_data(data);
@@ -278,6 +281,7 @@ fn main() -> Result<()> {
                         }
 
                         update_data(&mut app);
+                        try_drawing(&mut terminal, &mut app, &mut painter)?;
                     }
                 }
                 BottomEvent::Clean => {
@@ -286,9 +290,6 @@ fn main() -> Result<()> {
                 }
             }
         }
-
-        // TODO: [OPT] Should not draw if no change (ie: scroll max)
-        try_drawing(&mut terminal, &mut app, &mut painter)?;
     }
 
     // I think doing it in this order is safe...


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

The frozen case or cleaning cases don't really need to force a screen redraw.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
