### PR TITLE
other: add a redraw event on resize

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -157,6 +157,9 @@ fn main() -> Result<()> {
         // TODO: Would be good to instead use a mix of is_terminated check + recv. Probably use a termination event instead.
         if let Ok(recv) = receiver.recv_timeout(Duration::from_millis(TICK_RATE_IN_MILLISECONDS)) {
             match recv {
+                BottomEvent::Resize => {
+                    try_drawing(&mut terminal, &mut app, &mut painter)?;
+                }
                 BottomEvent::KeyInput(event) => {
                     if handle_key_event_or_break(event, &mut app, &collection_thread_ctrl_sender) {
                         break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub type Pid = libc::pid_t;
 
 #[derive(Debug)]
 pub enum BottomEvent {
+    Resize,
     KeyInput(KeyEvent),
     MouseInput(MouseEvent),
     PasteEvent(String),
@@ -431,6 +432,14 @@ pub fn create_input_thread(
                     if let Ok(event) = read() {
                         // FIXME: Handle all other event cases.
                         match event {
+                            // TODO: Might want to debounce this in the future, or take into account the actual resize
+                            // values. Maybe we want to keep the current implementation in case the resize event might
+                            // not fire... not sure.
+                            Event::Resize(_, _) => {
+                                if sender.send(BottomEvent::Resize).is_err() {
+                                    break;
+                                }
+                            }
                             Event::Paste(paste) => {
                                 if sender.send(BottomEvent::PasteEvent(paste)).is_err() {
                                     break;


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

If we see a crossterm event saying we resized, we should redraw.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
