### PR TITLE
bug: fix dot marker setting not being considered

### DIFF
--- a/src/app/data_harvester/temperature/linux.rs
+++ b/src/app/data_harvester/temperature/linux.rs
@@ -64,7 +64,7 @@ fn get_from_hwmon(
         }
 
         let hwmon_name = file_path.join("name");
-        let hwmon_name = Some(fs::read_to_string(&hwmon_name)?);
+        let hwmon_name = Some(fs::read_to_string(hwmon_name)?);
 
         // Whether the temperature should *actually* be read during enumeration
         // Set to false if the device is in ACPI D3cold.

--- a/src/app/process_killer.rs
+++ b/src/app/process_killer.rs
@@ -39,7 +39,7 @@ impl Process {
 /// Kills a process, given a PID, for unix.
 #[cfg(target_family = "unix")]
 pub fn kill_process_given_pid(pid: Pid, signal: usize) -> crate::utils::error::Result<()> {
-    let output = unsafe { libc::kill(pid as i32, signal as i32) };
+    let output = unsafe { libc::kill(pid, signal as i32) };
     if output != 0 {
         // We had an error...
         let err_code = std::io::Error::last_os_error().raw_os_error();

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -412,8 +412,8 @@ impl Painter {
 
                 // This fixes #397, apparently if the height is 1, it can't render the CPU bars...
                 let cpu_height = {
-                    let c = (actual_cpu_data_len / 4) as u16
-                        + (if actual_cpu_data_len % 4 == 0 { 0 } else { 1 });
+                    let c =
+                        (actual_cpu_data_len / 4) as u16 + u16::from(actual_cpu_data_len % 4 != 0);
 
                     if c <= 1 {
                         1

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -98,7 +98,7 @@ impl Painter {
 
             let margined_draw_loc = Layout::default()
                 .constraints([Constraint::Percentage(100)])
-                .horizontal_margin(if is_on_widget || draw_border { 0 } else { 1 })
+                .horizontal_margin(u16::from(!(is_on_widget || draw_border)))
                 .direction(Direction::Horizontal)
                 .split(draw_loc)[0];
 

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -97,8 +97,7 @@ impl Painter {
                         let to_divide = REQUIRED_COLUMNS - itx;
                         let num_taken = min(
                             remaining_height,
-                            (row_counter / to_divide)
-                                + (if row_counter % to_divide == 0 { 0 } else { 1 }),
+                            (row_counter / to_divide) + usize::from(row_counter % to_divide != 0),
                         );
                         row_counter -= num_taken;
                         let chunk = (&mut gauge_info).take(num_taken);

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -272,7 +272,7 @@ impl Painter {
 
             let margined_draw_loc = Layout::default()
                 .constraints([Constraint::Percentage(100)])
-                .horizontal_margin(if is_on_widget || draw_border { 0 } else { 1 })
+                .horizontal_margin(u16::from(!(is_on_widget || draw_border)))
                 .direction(Direction::Horizontal)
                 .split(draw_loc)[0];
 

--- a/src/components/data_table/draw.rs
+++ b/src/components/data_table/draw.rs
@@ -147,7 +147,7 @@ where
         let draw_loc = draw_info.loc;
         let margined_draw_loc = Layout::default()
             .constraints([Constraint::Percentage(100)])
-            .horizontal_margin(if draw_horizontal { 0 } else { 1 })
+            .horizontal_margin(u16::from(!draw_horizontal))
             .direction(Direction::Horizontal)
             .split(draw_loc)[0];
 

--- a/src/components/time_graph.rs
+++ b/src/components/time_graph.rs
@@ -143,6 +143,7 @@ impl<'a> TimeGraph<'a> {
                 .block(block)
                 .x_axis(x_axis)
                 .y_axis(y_axis)
+                .marker(self.marker)
                 .legend_style(self.graph_style)
                 .hidden_legend_constraints(
                     self.legend_constraints

--- a/src/components/tui_widget/time_chart.rs
+++ b/src/components/tui_widget/time_chart.rs
@@ -363,7 +363,7 @@ impl<'a> TimeChart<'a> {
         for (i, label) in labels.iter().enumerate() {
             let dy = i as u16 * (graph_area.height - 1) / (labels_len - 1);
             if dy < graph_area.bottom() {
-                buf.set_span(x, graph_area.bottom() - 1 - dy, label, label_width as u16);
+                buf.set_span(x, graph_area.bottom() - 1 - dy, label, label_width);
             }
         }
     }

--- a/src/components/tui_widget/time_chart.rs
+++ b/src/components/tui_widget/time_chart.rs
@@ -426,6 +426,7 @@ impl<'a> Widget for TimeChart<'a> {
             .background_color(self.style.bg.unwrap_or(Color::Reset))
             .x_bounds(self.x_axis.bounds)
             .y_bounds(self.y_axis.bounds)
+            .marker(self.marker)
             .paint(|ctx| {
                 for dataset in &self.datasets {
                     let color = dataset.style.fg.unwrap_or(Color::Reset);

--- a/src/options.rs
+++ b/src/options.rs
@@ -236,11 +236,7 @@ pub fn build_app(
         hide_time: get_hide_time(matches, config),
         autohide_time,
         use_old_network_legend: get_use_old_network_legend(matches, config),
-        table_gap: if get_hide_table_gap(matches, config) {
-            0
-        } else {
-            1
-        },
+        table_gap: u16::from(!get_hide_table_gap(matches, config)),
         disable_click: get_disable_click(matches, config),
         enable_gpu_memory: get_enable_gpu_memory(matches, config),
         show_table_scroll_position: get_show_table_scroll_position(matches, config),


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Fixes marker settings being ignored by time graphs. Was caused by me forgetting to pass the argument into the builder. This also fixes a bevy of clippy warnings brought on by Rust 1.66.

## Issue

_If applicable, what issue does this address?_

Partly address: #933

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
