### PR TITLE
feature: split usage into usage percentage and value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - ???
+
+## Bug Fixes
+
+## Changes
+
+## Features
+
+- [#950](https://github.com/ClementTsang/bottom/pull/950): Split usage into usage percentage and value.
+
 ## [0.7.0] - 2022-12-31
 
 ## Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "bottom"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bottom"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Clement Tsang <cjhtsang@uwaterloo.ca>"]
 edition = "2018"
 repository = "https://github.com/ClementTsang/bottom"

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ cargo install bottom
 
 ### Arch Linux
 
-There is an official package that can be installed with `pacman`:
+There is an [official package](https://archlinux.org/packages/community/x86_64/bottom/) that can be installed with `pacman`:
 
 ```bash
 sudo pacman -Syu bottom

--- a/src/app.rs
+++ b/src/app.rs
@@ -1219,6 +1219,12 @@ impl App {
                     {
                         proc_widget_state.select_column(ProcWidget::PID_OR_COUNT);
                     }
+                } else if let Some(disk) = self
+                    .disk_state
+                    .get_mut_widget_state(self.current_widget.widget_id)
+                {
+                    disk.table.set_sort_index(5);
+                    disk.force_data_update();
                 }
             }
             'P' => {
@@ -1302,7 +1308,7 @@ impl App {
                     .disk_state
                     .get_mut_widget_state(self.current_widget.widget_id)
                 {
-                    disk.table.set_sort_index(5);
+                    disk.table.set_sort_index(6);
                     disk.force_data_update();
                 }
             }
@@ -1311,7 +1317,7 @@ impl App {
                     .disk_state
                     .get_mut_widget_state(self.current_widget.widget_id)
                 {
-                    disk.table.set_sort_index(6);
+                    disk.table.set_sort_index(7);
                     disk.force_data_update();
                 }
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -381,15 +381,7 @@ impl App {
                     proc_widget_state.toggle_mem_percentage();
                 }
             }
-            BottomWidgetType::Disk => {
-                if let Some(disk_widget_state) = self
-                    .disk_state
-                    .widget_states
-                    .get_mut(&self.current_widget.widget_id)
-                {
-                    disk_widget_state.toggle_percentage();
-                }
-            }
+
             _ => {}
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -379,7 +379,15 @@ impl App {
                     .get_mut(&self.current_widget.widget_id)
                 {
                     proc_widget_state.toggle_mem_percentage();
-                    proc_widget_state.force_data_update();
+                }
+            }
+            BottomWidgetType::Disk => {
+                if let Some(disk_widget_state) = self
+                    .disk_state
+                    .widget_states
+                    .get_mut(&self.current_widget.widget_id)
+                {
+                    disk_widget_state.toggle_percentage();
                 }
             }
             _ => {}

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -90,12 +90,18 @@ impl ConvertedData {
             .iter()
             .zip(&data.io_labels)
             .for_each(|(disk, (io_read, io_write))| {
+                let summed_total_bytes = match (disk.used_space, disk.free_space) {
+                    (Some(used), Some(free)) => Some(used + free),
+                    _ => None,
+                };
+
                 self.disk_data.push(DiskWidgetData {
                     name: KString::from_ref(&disk.name),
                     mount_point: KString::from_ref(&disk.mount_point),
                     free_bytes: disk.free_space,
                     used_bytes: disk.used_space,
                     total_bytes: disk.total_space,
+                    summed_total_bytes,
                     io_read: io_read.into(),
                     io_write: io_write.into(),
                 });

--- a/src/widgets/disk_table.rs
+++ b/src/widgets/disk_table.rs
@@ -105,7 +105,7 @@ impl ColumnHeader for DiskWidgetColumn {
             DiskWidgetColumn::Mount => "Mount(m)",
             DiskWidgetColumn::Used => "Used(u)",
             DiskWidgetColumn::Free => "Free(n)",
-            DiskWidgetColumn::UsedPercent => "Used%(u)",
+            DiskWidgetColumn::UsedPercent => "Used%",
             DiskWidgetColumn::FreePercent => "Free%(n)",
             DiskWidgetColumn::Total => "Total(t)",
             DiskWidgetColumn::IoRead => "R/s(r)",
@@ -199,6 +199,7 @@ impl DiskTableWidget {
             SortColumn::hard(DiskWidgetColumn::Used, 8).default_descending(),
             SortColumn::hard(DiskWidgetColumn::Free, 8).default_descending(),
             SortColumn::hard(DiskWidgetColumn::Total, 9).default_descending(),
+            SortColumn::hard(DiskWidgetColumn::UsedPercent, 6).default_descending(),
             SortColumn::hard(DiskWidgetColumn::IoRead, 10).default_descending(),
             SortColumn::hard(DiskWidgetColumn::IoWrite, 11).default_descending(),
         ];
@@ -237,35 +238,5 @@ impl DiskTableWidget {
             column.sort_by(&mut data, self.table.order());
         }
         self.table.set_data(data);
-    }
-
-    pub fn toggle_percentage(&mut self) {
-        if let Some(col) = self.table.columns.get_mut(2) {
-            let col = col.inner_mut();
-            match col {
-                DiskWidgetColumn::Used => {
-                    *col = DiskWidgetColumn::UsedPercent;
-                }
-                DiskWidgetColumn::UsedPercent => {
-                    *col = DiskWidgetColumn::Used;
-                }
-                _ => unreachable!(),
-            }
-        }
-
-        if let Some(col) = self.table.columns.get_mut(3) {
-            let col = col.inner_mut();
-            match col {
-                DiskWidgetColumn::Free => {
-                    *col = DiskWidgetColumn::FreePercent;
-                }
-                DiskWidgetColumn::FreePercent => {
-                    *col = DiskWidgetColumn::Free;
-                }
-                _ => unreachable!(),
-            }
-        }
-
-        self.force_data_update();
     }
 }

--- a/src/widgets/disk_table.rs
+++ b/src/widgets/disk_table.rs
@@ -112,7 +112,7 @@ impl ColumnHeader for DiskWidgetColumn {
             DiskWidgetColumn::Used => "Used(u)",
             DiskWidgetColumn::Free => "Free(n)",
             DiskWidgetColumn::UsedPercent => "Used%(p)",
-            DiskWidgetColumn::FreePercent => "Free%(n)",
+            DiskWidgetColumn::FreePercent => "Free%",
             DiskWidgetColumn::Total => "Total(t)",
             DiskWidgetColumn::IoRead => "R/s(r)",
             DiskWidgetColumn::IoWrite => "W/s(w)",
@@ -162,7 +162,6 @@ impl DataToCell<DiskWidgetColumn> for DiskWidgetData {
 pub struct DiskTableWidget {
     pub table: SortDataTable<DiskWidgetData, DiskWidgetColumn>,
     pub force_update_data: bool,
-    pub using_percentage: bool,
 }
 
 impl SortsRow for DiskWidgetColumn {
@@ -236,7 +235,6 @@ impl DiskTableWidget {
         Self {
             table: SortDataTable::new_sortable(columns, props, styling),
             force_update_data: false,
-            using_percentage: false,
         }
     }
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Denotes both usage and usage percentage. This also redoes the calculation for percentage to be based on the sum of avail + used, rather than on total, as otherwise we get potentially confusing percentages.

![image](https://user-images.githubusercontent.com/34804052/210166191-880e4484-70d1-45d4-8d66-760882f1582b.png)


## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
