### PR TITLE
ci: add build hash to nightly builds for version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,6 +76,7 @@ build_task:
     BTM_GENERATE: true
     COMPLETION_DIR: "target/tmp/bottom/completion/"
     MANPAGE_DIR: "target/tmp/bottom/manpage/"
+    # -PLACEHOLDER FOR CI-
   matrix:
     - name: "FreeBSD 13 Build"
       alias: "freebsd_13_1_build"
@@ -104,6 +105,7 @@ build_task:
     - . $HOME/.cargo/env
     - cargo build --release --verbose --locked --features deploy
     - mv ./target/release/btm ./
+    - ./btm -V
     - mv "$COMPLETION_DIR" completion
     - mv "$MANPAGE_DIR" manpage
     - tar -czvf bottom_$NAME.tar.gz btm completion

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -73,7 +73,7 @@ body:
       label: What version of `bottom` are you running?
       description: >
         Please provide which version of `bottom` you're running, which you can find with `btm -V`. If you are using
-        a nightly/non-release version, please specify that and any related details (e.g. the commit hash/which nightly build).
+        a nightly/non-release version, please also specify that.
       placeholder: 0.7.0
 
   - type: input

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -152,6 +152,7 @@ jobs:
         uses: ClementTsang/cargo-action@v0.0.3
         env:
           BTM_GENERATE: true
+          BTM_BUILD_RELEASE_CALLER: ${{ inputs.caller }}
         with:
           command: build
           args: --release --verbose --locked --target=${{ matrix.info.target }} --features deploy

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ More details on configuration can be found [in the documentation](https://clemen
 ## Troubleshooting
 
 If some things aren't working, give the [Troubleshooting page](https://clementtsang.github.io/bottom/nightly/troubleshooting) a look. If things still aren't
-working, then consider asking a [question by opening a question](https://github.com/ClementTsang/bottom/discussions) or filing a [bug report](https://github.com/ClementTsang/bottom/issues/new/choose).
+working, then consider opening [a question](https://github.com/ClementTsang/bottom/discussions) or filing a [bug report](https://github.com/ClementTsang/bottom/issues/new/choose).
 
 ## Contribution
 

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
 use std::{
-    env, fs,
-    io::Result,
+    env, fs, io,
     path::{Path, PathBuf},
 };
 
@@ -8,7 +7,7 @@ use clap_complete::{generate_to, shells::Shell};
 
 include!("src/clap.rs");
 
-fn create_dir(dir: &Path) -> Result<()> {
+fn create_dir(dir: &Path) -> io::Result<()> {
     let res = fs::create_dir_all(dir);
     match &res {
         Ok(()) => {}
@@ -23,12 +22,14 @@ fn create_dir(dir: &Path) -> Result<()> {
     res
 }
 
-fn main() -> Result<()> {
-    const COMPLETION_DIR: &str = "./target/tmp/bottom/completion/";
-    const MANPAGE_DIR: &str = "./target/tmp/bottom/manpage/";
+fn btm_generate() -> io::Result<()> {
+    const ENV_KEY: &str = "BTM_GENERATE";
 
-    match env::var_os("BTM_GENERATE") {
+    match env::var_os(ENV_KEY) {
         Some(var) if !var.is_empty() => {
+            const COMPLETION_DIR: &str = "./target/tmp/bottom/completion/";
+            const MANPAGE_DIR: &str = "./target/tmp/bottom/manpage/";
+
             let completion_out_dir = PathBuf::from(COMPLETION_DIR);
             let manpage_out_dir = PathBuf::from(MANPAGE_DIR);
 
@@ -53,7 +54,34 @@ fn main() -> Result<()> {
         _ => {}
     }
 
-    println!("cargo:rerun-if-env-changed=BTM_GENERATE");
+    println!("cargo:rerun-if-env-changed={ENV_KEY}");
+
+    Ok(())
+}
+
+fn nightly_version() {
+    const ENV_KEY: &str = "BTM_BUILD_RELEASE_CALLER";
+
+    match env::var_os(ENV_KEY) {
+        Some(var) if !var.is_empty() && var == "nightly" => {
+            if let Ok(output) = std::process::Command::new("git")
+                .args(["rev-parse", "--short", "HEAD"])
+                .output()
+            {
+                let version = env!("CARGO_PKG_VERSION");
+                let git_hash = String::from_utf8(output.stdout).unwrap();
+                println!("cargo:rustc-env=NIGHTLY_VERSION={version}-nightly-{git_hash}");
+            }
+        }
+        _ => {}
+    }
+
+    println!("cargo:rerun-if-env-changed={ENV_KEY}");
+}
+
+fn main() -> Result<()> {
+    btm_generate()?;
+    nightly_version();
 
     Ok(())
 }

--- a/scripts/cirrus/build.py
+++ b/scripts/cirrus/build.py
@@ -28,17 +28,24 @@ DL_URL_TEMPLATE = "https://api.cirrus-ci.com/v1/artifact/build/%s/%s/binaries/%s
 def make_query_request(key: str, branch: str, build_type: str):
     print("Creating query request.")
     mutation_id = "Cirrus CI Build {}-{}-{}".format(build_type, branch, int(time()))
+
+    # Dumb but if it works...
+    config_override = (
+        Path(".cirrus.yml").read_text().replace("# -PLACEHOLDER FOR CI-", 'BTM_BUILD_RELEASE_CALLER: "nightly"')
+    )
     query = """
         mutation CreateCirrusCIBuild (
             $repo: ID!,
             $branch: String!,
-            $mutation_id: String!
+            $mutation_id: String!,
+            $config_override: String,
         ) {
             createBuild(
                 input: {
                     repositoryId: $repo,
                     branch: $branch,
                     clientMutationId: $mutation_id,
+                    configOverride: $config_override
                 }
             ) {
                 build {
@@ -52,6 +59,7 @@ def make_query_request(key: str, branch: str, build_type: str):
         "repo": "6646638922956800",
         "branch": branch,
         "mutation_id": mutation_id,
+        "config_override": dedent(config_override),
     }
     data = {"query": dedent(query), "variables": params}
     data = json.dumps(data).encode()

--- a/src/clap.rs
+++ b/src/clap.rs
@@ -368,9 +368,14 @@ use CPU (3) as the default instead.
         .help("The timespan of data kept.")
         .long_help("How much data is stored at once in terms of time. Takes in human-readable time spans (e.g. 10m, 1h), with a minimum of 1 minute. Note higher values will take up more memory. Defaults to 10 minutes.");
 
+    const VERSION: &str = match option_env!("NIGHTLY_VERSION") {
+        Some(nightly_version) => nightly_version,
+        None => crate_version!(),
+    };
+
     #[allow(unused_mut)]
     let mut app = Command::new(crate_name!())
-        .version(crate_version!())
+        .version(VERSION)
         .author(crate_authors!())
         .about(crate_description!())
         .override_usage(USAGE)


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This adds the build hash to the `btm -V` output for nightly builds, making it easier to troubleshoot when someone might have obtained a nightly build, and what commit it corresponds to.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

Manually run nightly build workflows:

- [Nightly test one](https://github.com/ClementTsang/bottom/actions/runs/3821914007), should show the hash.
- [Nightly test two](https://github.com/ClementTsang/bottom/actions/runs/3821940098) with hashing disabled via a typo to simulate a non-nightly build. This will fail because I'm lazy and want to check the versions in CI, but that causes issues for cross build targets.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
