### PR TITLE
bug: fix CPU 'all' label missing on small sizes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Bug Fixes
 
 - [#952](https://github.com/ClementTsang/bottom/pull/952): Partially fix battery text getting cut off in small windows.
+- [#953](https://github.com/ClementTsang/bottom/pull/953): Fix CPU widget's 'all' label being missing on small sizes.
 
 ## Changes
 

--- a/src/components/data_table/draw.rs
+++ b/src/components/data_table/draw.rs
@@ -221,11 +221,7 @@ where
                                 .iter()
                                 .zip(&self.state.calculated_widths)
                                 .filter_map(|(column, &width)| {
-                                    if width > 0 {
-                                        data_row.to_cell(column.inner(), width)
-                                    } else {
-                                        None
-                                    }
+                                    data_row.to_cell(column.inner(), width)
                                 }),
                         );
 

--- a/src/widgets/cpu_graph.rs
+++ b/src/widgets/cpu_graph.rs
@@ -77,7 +77,7 @@ impl CpuWidgetTableData {
 
 impl DataToCell<CpuWidgetColumn> for CpuWidgetTableData {
     fn to_cell<'a>(&'a self, column: &CpuWidgetColumn, calculated_width: u16) -> Option<Text<'a>> {
-        const CPU_HIDE_BREAKPOINT: u16 = 5;
+        const CPU_TRUNCATE_BREAKPOINT: u16 = 5;
 
         // This is a bit of a hack, but apparently we can avoid having to do any fancy checks
         // of showing the "All" on a specific column if the other is hidden by just always
@@ -88,22 +88,22 @@ impl DataToCell<CpuWidgetColumn> for CpuWidgetTableData {
         // it is too small.
         match &self {
             CpuWidgetTableData::All => match column {
-                CpuWidgetColumn::CPU => Some(truncate_to_text("All", calculated_width)),
+                CpuWidgetColumn::CPU => Some("All".into()),
                 CpuWidgetColumn::Use => None,
             },
             CpuWidgetTableData::Entry {
                 data_type,
                 last_entry,
-            } => match column {
-                CpuWidgetColumn::CPU => {
-                    if calculated_width == 0 {
-                        None
-                    } else {
-                        match data_type {
+            } => {
+                if calculated_width == 0 {
+                    None
+                } else {
+                    match column {
+                        CpuWidgetColumn::CPU => match data_type {
                             CpuDataType::Avg => Some(truncate_to_text("AVG", calculated_width)),
                             CpuDataType::Cpu(index) => {
                                 let index_str = index.to_string();
-                                let text = if calculated_width < CPU_HIDE_BREAKPOINT {
+                                let text = if calculated_width < CPU_TRUNCATE_BREAKPOINT {
                                     truncate_to_text(&index_str, calculated_width)
                                 } else {
                                     truncate_to_text(
@@ -114,14 +114,14 @@ impl DataToCell<CpuWidgetColumn> for CpuWidgetTableData {
 
                                 Some(text)
                             }
-                        }
+                        },
+                        CpuWidgetColumn::Use => Some(truncate_to_text(
+                            &format!("{:.0}%", last_entry.round()),
+                            calculated_width,
+                        )),
                     }
                 }
-                CpuWidgetColumn::Use => Some(truncate_to_text(
-                    &format!("{:.0}%", last_entry.round()),
-                    calculated_width,
-                )),
-            },
+            }
         }
     }
 

--- a/src/widgets/disk_table.rs
+++ b/src/widgets/disk_table.rs
@@ -123,6 +123,10 @@ impl ColumnHeader for DiskWidgetColumn {
 
 impl DataToCell<DiskWidgetColumn> for DiskWidgetData {
     fn to_cell<'a>(&'a self, column: &DiskWidgetColumn, calculated_width: u16) -> Option<Text<'a>> {
+        if calculated_width == 0 {
+            return None;
+        }
+
         let text = match column {
             DiskWidgetColumn::Disk => truncate_to_text(&self.name, calculated_width),
             DiskWidgetColumn::Mount => truncate_to_text(&self.mount_point, calculated_width),

--- a/src/widgets/process_table/proc_widget_data.rs
+++ b/src/widgets/process_table/proc_widget_data.rs
@@ -221,6 +221,10 @@ impl ProcWidgetData {
 
 impl DataToCell<ProcColumn> for ProcWidgetData {
     fn to_cell<'a>(&'a self, column: &ProcColumn, calculated_width: u16) -> Option<Text<'a>> {
+        if calculated_width == 0 {
+            return None;
+        }
+
         // TODO: Optimize the string allocations here...
         // TODO: Also maybe just pull in the to_string call but add a variable for the differences.
         Some(truncate_to_text(

--- a/src/widgets/process_table/sort_table.rs
+++ b/src/widgets/process_table/sort_table.rs
@@ -17,6 +17,10 @@ impl ColumnHeader for SortTableColumn {
 
 impl DataToCell<SortTableColumn> for &'static str {
     fn to_cell<'a>(&'a self, _column: &SortTableColumn, calculated_width: u16) -> Option<Text<'a>> {
+        if calculated_width == 0 {
+            return None;
+        }
+
         Some(truncate_to_text(self, calculated_width))
     }
 
@@ -30,6 +34,10 @@ impl DataToCell<SortTableColumn> for &'static str {
 
 impl DataToCell<SortTableColumn> for Cow<'static, str> {
     fn to_cell<'a>(&'a self, _column: &SortTableColumn, calculated_width: u16) -> Option<Text<'a>> {
+        if calculated_width == 0 {
+            return None;
+        }
+
         Some(truncate_to_text(self, calculated_width))
     }
 

--- a/src/widgets/temperature_table.rs
+++ b/src/widgets/temperature_table.rs
@@ -49,6 +49,10 @@ impl TempWidgetData {
 
 impl DataToCell<TempWidgetColumn> for TempWidgetData {
     fn to_cell<'a>(&'a self, column: &TempWidgetColumn, calculated_width: u16) -> Option<Text<'a>> {
+        if calculated_width == 0 {
+            return None;
+        }
+
         Some(match column {
             TempWidgetColumn::Sensor => truncate_to_text(&self.sensor, calculated_width),
             TempWidgetColumn::Temp => truncate_to_text(&self.temperature(), calculated_width),


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Fixes the "All" label being missing on small windows. This was a regression due to #918. We work around it by moving the width skip check into the implementors.

Before vs after:

![image](https://user-images.githubusercontent.com/34804052/210494926-01e20807-3b2f-47fd-a35b-1982f9bec563.png)


## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
