### PR TITLE
other: revert disk usage change for now

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1219,12 +1219,6 @@ impl App {
                     {
                         proc_widget_state.select_column(ProcWidget::PID_OR_COUNT);
                     }
-                } else if let Some(disk) = self
-                    .disk_state
-                    .get_mut_widget_state(self.current_widget.widget_id)
-                {
-                    disk.table.set_sort_index(5);
-                    disk.force_data_update();
                 }
             }
             'P' => {
@@ -1308,7 +1302,7 @@ impl App {
                     .disk_state
                     .get_mut_widget_state(self.current_widget.widget_id)
                 {
-                    disk.table.set_sort_index(6);
+                    disk.table.set_sort_index(5);
                     disk.force_data_update();
                 }
             }
@@ -1317,7 +1311,7 @@ impl App {
                     .disk_state
                     .get_mut_widget_state(self.current_widget.widget_id)
                 {
-                    disk.table.set_sort_index(7);
+                    disk.table.set_sort_index(6);
                     disk.force_data_update();
                 }
             }

--- a/src/widgets/disk_table.rs
+++ b/src/widgets/disk_table.rs
@@ -111,7 +111,7 @@ impl ColumnHeader for DiskWidgetColumn {
             DiskWidgetColumn::Mount => "Mount(m)",
             DiskWidgetColumn::Used => "Used(u)",
             DiskWidgetColumn::Free => "Free(n)",
-            DiskWidgetColumn::UsedPercent => "Used%(p)",
+            DiskWidgetColumn::UsedPercent => "Used(u)",
             DiskWidgetColumn::FreePercent => "Free%",
             DiskWidgetColumn::Total => "Total(t)",
             DiskWidgetColumn::IoRead => "R/s(r)",
@@ -213,10 +213,9 @@ impl DiskTableWidget {
         let columns = [
             SortColumn::soft(DiskWidgetColumn::Disk, Some(0.2)),
             SortColumn::soft(DiskWidgetColumn::Mount, Some(0.2)),
-            SortColumn::hard(DiskWidgetColumn::Used, 8).default_descending(),
+            SortColumn::hard(DiskWidgetColumn::UsedPercent, 9).default_descending(),
             SortColumn::hard(DiskWidgetColumn::Free, 8).default_descending(),
             SortColumn::hard(DiskWidgetColumn::Total, 9).default_descending(),
-            SortColumn::hard(DiskWidgetColumn::UsedPercent, 9).default_descending(),
             SortColumn::hard(DiskWidgetColumn::IoRead, 10).default_descending(),
             SortColumn::hard(DiskWidgetColumn::IoWrite, 11).default_descending(),
         ];


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This is a temp change, this commit will be reverted after 0.7.1 comes out. Effectively reverses #950 for now without reverting the sorting fixes.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
