### PR TITLE
other: skip battery duration draw if unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changes
 
+- [#974](https://github.com/ClementTsang/bottom/pull/974): Hide battery duration section if the value is unknown. Also update shortened text.
+
 ## Other
 
 ## [0.7.1] - 2023-01-06

--- a/src/app.rs
+++ b/src/app.rs
@@ -1183,7 +1183,7 @@ impl App {
             'k' => self.on_up_key(),
             'j' => self.on_down_key(),
             'f' => {
-                self.frozen_state.toggle(&self.data_collection); // TODO: Unthawing should force a full data refresh and redraw immediately.
+                self.frozen_state.toggle(&self.data_collection); // TODO: Thawing should force a full data refresh and redraw immediately.
             }
             'c' => {
                 if let BottomWidgetType::Proc = self.current_widget.widget_type {

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -168,7 +168,7 @@ impl Painter {
                                 battery_rows.push(Row::new(vec!["Time to empty", &s]).style(style));
                             } else {
                                 s = short_time(*secs);
-                                battery_rows.push(Row::new(vec!["Empty", &s]).style(style));
+                                battery_rows.push(Row::new(vec!["To empty", &s]).style(style));
                             }
                         }
                         BatteryDuration::ToFull(secs) => {
@@ -177,7 +177,7 @@ impl Painter {
                                 battery_rows.push(Row::new(vec!["Time to full", &s]).style(style));
                             } else {
                                 s = short_time(*secs);
-                                battery_rows.push(Row::new(vec!["Full", &s]).style(style));
+                                battery_rows.push(Row::new(vec!["To full", &s]).style(style));
                             }
                         }
                         BatteryDuration::Unknown => {}

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -142,56 +142,52 @@ impl Painter {
                     format!("{}h {}m {}s", time.whole_hours(), num_minutes, num_seconds,)
                 }
 
-                let s: String; // Brought out due to lifetimes.
-                let time_text = {
+                let mut battery_rows = Vec::with_capacity(4);
+                battery_rows.push(Row::new(vec![
+                    Cell::from("Charge %").style(self.colours.text_style),
+                    Cell::from(bars).style(if charge_percentage < 10.0 {
+                        self.colours.low_battery_colour
+                    } else if charge_percentage < 50.0 {
+                        self.colours.medium_battery_colour
+                    } else {
+                        self.colours.high_battery_colour
+                    }),
+                ]));
+                battery_rows.push(
+                    Row::new(vec!["Consumption", &battery_details.watt_consumption])
+                        .style(self.colours.text_style),
+                );
+
+                let s: String; // Keep string in scope.
+                {
                     let style = self.colours.text_style;
                     match &battery_details.battery_duration {
                         BatteryDuration::ToEmpty(secs) => {
                             if half_width > 25 {
                                 s = long_time(*secs);
-                                Row::new(vec!["Time to empty", &s]).style(style)
+                                battery_rows.push(Row::new(vec!["Time to empty", &s]).style(style));
                             } else {
                                 s = short_time(*secs);
-                                Row::new(vec!["Empty", &s]).style(style)
+                                battery_rows.push(Row::new(vec!["Empty", &s]).style(style));
                             }
                         }
                         BatteryDuration::ToFull(secs) => {
                             if half_width > 25 {
                                 s = long_time(*secs);
-                                Row::new(vec!["Time to full", &s]).style(style)
+                                battery_rows.push(Row::new(vec!["Time to full", &s]).style(style));
                             } else {
                                 s = short_time(*secs);
-                                Row::new(vec!["Full", &s]).style(style)
+                                battery_rows.push(Row::new(vec!["Full", &s]).style(style));
                             }
                         }
-                        BatteryDuration::Unknown => {
-                            // TODO: Potentially just don't draw this?
-                            if half_width > 20 {
-                                Row::new(vec!["Time to full/empty", "N/A"]).style(style)
-                            } else {
-                                Row::new(vec!["Empty/full", "N/A"]).style(style)
-                            }
-                        }
+                        BatteryDuration::Unknown => {}
                     }
-                };
+                }
 
-                let battery_rows = vec![
-                    Row::new(vec![
-                        Cell::from("Charge %").style(self.colours.text_style),
-                        Cell::from(bars).style(if charge_percentage < 10.0 {
-                            self.colours.low_battery_colour
-                        } else if charge_percentage < 50.0 {
-                            self.colours.medium_battery_colour
-                        } else {
-                            self.colours.high_battery_colour
-                        }),
-                    ]),
-                    Row::new(vec!["Consumption", &battery_details.watt_consumption])
-                        .style(self.colours.text_style),
-                    time_text,
+                battery_rows.push(
                     Row::new(vec!["Health %", &battery_details.health])
                         .style(self.colours.text_style),
-                ];
+                );
 
                 // Draw
                 f.render_widget(


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Skips drawing the battery duration row if the duration is unknown.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
