### PR TITLE
feat: :wrench: Update ArchLinux install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ cargo install bottom
 There is an [official package](https://archlinux.org/packages/community/x86_64/bottom/) that can be installed with `pacman`:
 
 ```bash
-sudo pacman -Syu bottom
+sudo pacman -S bottom
 ```
 
 ### Debian/Ubuntu


### PR DESCRIPTION
## Description

It is removing `-yu`, because it updates the system before downloading the package. ArchLinux is updated constantly and can crash the system, so it's better just to install the package.