### PR TITLE
other: explicitly style dd text colours

### DIFF
--- a/src/canvas/dialogs/dd_dialog.rs
+++ b/src/canvas/dialogs/dd_dialog.rs
@@ -70,10 +70,10 @@ impl Painter {
             let (yes_button, no_button) = match app_state.delete_dialog_state.selected_signal {
                 KillSignal::Kill(_) => (
                     Span::styled("Yes", self.colours.currently_selected_text_style),
-                    Span::raw("No"),
+                    Span::styled("No", self.colours.text_style),
                 ),
                 KillSignal::Cancel => (
-                    Span::raw("Yes"),
+                    Span::styled("Yes", self.colours.text_style),
                     Span::styled("No", self.colours.currently_selected_text_style),
                 ),
             };
@@ -323,9 +323,9 @@ impl Painter {
                 let mut buttons = signal_text
                     [scroll_offset + 1..min((layout.len()) + scroll_offset, signal_text.len())]
                     .iter()
-                    .map(|text| Span::raw(*text))
+                    .map(|text| Span::styled(*text, self.colours.text_style))
                     .collect::<Vec<Span<'_>>>();
-                buttons.insert(0, Span::raw(signal_text[0]));
+                buttons.insert(0, Span::styled(signal_text[0], self.colours.text_style));
                 buttons[selected - scroll_offset] = Span::styled(
                     signal_text[selected],
                     self.colours.currently_selected_text_style,


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This just explicitly styles the text "buttons" used for dd.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
