### PR TITLE
other: ignore uninlined_format_args clippy lint for now

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,8 +13,7 @@ fn create_dir(dir: &Path) -> io::Result<()> {
         Ok(()) => {}
         Err(err) => {
             eprintln!(
-            "Failed to create a directory at location {:?}, encountered error {:?}.  Aborting...",
-            dir, err
+            "Failed to create a directory at location {dir:?}, encountered error {err:?}.  Aborting...",
         );
         }
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![allow(clippy::uninlined_format_args)]
 #[allow(unused_imports)]
 #[cfg(feature = "log")]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //! bottom, refer to [here](https://clementtsang.github.io/bottom/stable/).
 
 #![warn(rust_2018_idioms)]
+#![allow(clippy::uninlined_format_args)]
 #[allow(unused_imports)]
 #[cfg(feature = "log")]
 #[macro_use]


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Appease clippy's new lints from 1.67. And by appease, I mean ignore the `uninlined-format-args` lint for now.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
