### PR TITLE
Add support for displaying process usernames on Windows

### DIFF
--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -182,6 +182,10 @@ impl DataCollector {
                 self.sys.refresh_networks_list();
             }
 
+            if cfg!(target_os = "windows") && self.widgets_to_harvest.use_proc {
+                self.sys.refresh_users_list();
+            }
+
             if self.widgets_to_harvest.use_proc || self.widgets_to_harvest.use_cpu {
                 self.sys.refresh_cpu();
             }

--- a/src/app/data_harvester/processes.rs
+++ b/src/app/data_harvester/processes.rs
@@ -72,8 +72,7 @@ pub struct ProcessHarvest {
     #[cfg(target_family = "unix")]
     pub uid: Option<libc::uid_t>,
 
-    /// This is the process' user. This is only used on Unix platforms.
-    #[cfg(target_family = "unix")]
+    /// This is the process' user.
     pub user: std::borrow::Cow<'static, str>,
     // TODO: Additional fields
     // pub rss_kb: u64,

--- a/src/app/data_harvester/processes/windows.rs
+++ b/src/app/data_harvester/processes/windows.rs
@@ -1,6 +1,6 @@
 //! Process data collection for Windows.  Uses sysinfo.
 
-use sysinfo::{CpuExt, PidExt, ProcessExt, System, SystemExt};
+use sysinfo::{CpuExt, PidExt, ProcessExt, System, SystemExt, UserExt};
 
 use super::ProcessHarvest;
 
@@ -75,6 +75,10 @@ pub fn get_process_data(
             total_read_bytes: disk_usage.total_read_bytes,
             total_write_bytes: disk_usage.total_written_bytes,
             process_state,
+            user: process_val
+                .user_id()
+                .and_then(|uid| sys.get_user_by_id(uid))
+                .map_or_else(|| "N/A".into(), |user| user.name().to_owned().into()),
         });
     }
 

--- a/src/app/query.rs
+++ b/src/app/query.rs
@@ -670,16 +670,7 @@ impl Prefix {
                     }),
                     PrefixType::Pid => r.is_match(process.pid.to_string().as_str()),
                     PrefixType::State => r.is_match(process.process_state.0.as_str()),
-                    PrefixType::User => {
-                        #[cfg(target_family = "unix")]
-                        {
-                            r.is_match(process.user.as_ref())
-                        }
-                        #[cfg(not(target_family = "unix"))]
-                        {
-                            false
-                        }
-                    }
+                    PrefixType::User => r.is_match(process.user.as_ref()),
                     _ => true,
                 }
             } else {

--- a/src/widgets/process_table.rs
+++ b/src/widgets/process_table.rs
@@ -101,12 +101,8 @@ impl ProcWidgetState {
     pub const WPS: usize = 5;
     pub const T_READ: usize = 6;
     pub const T_WRITE: usize = 7;
-    #[cfg(target_family = "unix")]
     pub const USER: usize = 8;
-    #[cfg(target_family = "unix")]
     pub const STATE: usize = 9;
-    #[cfg(not(target_family = "unix"))]
-    pub const STATE: usize = 8;
 
     fn new_sort_table(config: &AppConfigFields, colours: &CanvasColours) -> SortTable {
         const COLUMNS: [Column<SortTableColumn>; 1] = [Column::hard(SortTableColumn, 7)];
@@ -162,7 +158,6 @@ impl ProcWidgetState {
                 wps,
                 tr,
                 tw,
-                #[cfg(target_family = "unix")]
                 SortColumn::soft(User, Some(0.05)),
                 state,
             ]
@@ -677,7 +672,6 @@ impl ProcWidgetState {
                         *col = ProcColumn::Count;
                         sort_col.default_order = SortOrder::Descending;
 
-                        #[cfg(target_family = "unix")]
                         self.hide_column(Self::USER);
                         self.hide_column(Self::STATE);
                         self.mode = ProcWidgetMode::Grouped;
@@ -686,7 +680,6 @@ impl ProcWidgetState {
                         *col = ProcColumn::Pid;
                         sort_col.default_order = SortOrder::Ascending;
 
-                        #[cfg(target_family = "unix")]
                         self.show_column(Self::USER);
                         self.show_column(Self::STATE);
                         self.mode = ProcWidgetMode::Normal;
@@ -821,6 +814,8 @@ mod test {
             process_char: '?',
             #[cfg(target_family = "unix")]
             user: "root".to_string(),
+            #[cfg(not(target_family = "unix"))]
+            user: "N/A".to_string(),
             num_similar: 0,
             disabled: false,
         };

--- a/src/widgets/process_table/proc_widget_column.rs
+++ b/src/widgets/process_table/proc_widget_column.rs
@@ -109,13 +109,10 @@ impl SortsRow for ProcColumn {
                 }
             }
             ProcColumn::User => {
-                #[cfg(target_family = "unix")]
-                {
-                    if descending {
-                        data.sort_by_cached_key(|pd| Reverse(pd.user.to_lowercase()));
-                    } else {
-                        data.sort_by_cached_key(|pd| pd.user.to_lowercase());
-                    }
+                if descending {
+                    data.sort_by_cached_key(|pd| Reverse(pd.user.to_lowercase()));
+                } else {
+                    data.sort_by_cached_key(|pd| pd.user.to_lowercase());
                 }
             }
         }

--- a/src/widgets/process_table/proc_widget_data.rs
+++ b/src/widgets/process_table/proc_widget_data.rs
@@ -120,7 +120,6 @@ pub struct ProcWidgetData {
     pub total_write: u64,
     pub process_state: String,
     pub process_char: char,
-    #[cfg(target_family = "unix")]
     pub user: String,
     pub num_similar: u64,
     pub disabled: bool,
@@ -155,7 +154,6 @@ impl ProcWidgetData {
             total_write: process.total_write_bytes,
             process_state: process.process_state.0.clone(),
             process_char: process.process_state.1,
-            #[cfg(target_family = "unix")]
             user: process.user.to_string(),
             num_similar: 1,
             disabled: false,
@@ -205,16 +203,7 @@ impl ProcWidgetData {
             ProcColumn::TotalRead => dec_bytes_string(self.total_read),
             ProcColumn::TotalWrite => dec_bytes_string(self.total_write),
             ProcColumn::State => self.process_char.to_string(),
-            ProcColumn::User => {
-                #[cfg(target_family = "unix")]
-                {
-                    self.user.clone()
-                }
-                #[cfg(not(target_family = "unix"))]
-                {
-                    "".to_string()
-                }
-            }
+            ProcColumn::User => self.user.clone(),
         }
     }
 }
@@ -247,16 +236,7 @@ impl DataToCell<ProcColumn> for ProcWidgetData {
                         self.process_state.clone()
                     }
                 }
-                ProcColumn::User => {
-                    #[cfg(target_family = "unix")]
-                    {
-                        self.user.clone()
-                    }
-                    #[cfg(not(target_family = "unix"))]
-                    {
-                        "".to_string()
-                    }
-                }
+                ProcColumn::User => self.user.clone(),
             },
             calculated_width,
         ))


### PR DESCRIPTION
## Description

This adds the "User" column to the process table on Windows. Usernames are extracted using the `sysinfo` library.

The main reason for adding this is that it allows filtering of the processes that belong to the current user.

## Testing

Tested by visual inspection:

- The name of the user running the application is correctly displayed.
- When running un-elevated, the usernames of other processes are shown as "N/A".
- When running elevated, the usernames for _some_ of the other processes are displayed. This appears to be a limitation of how `sysinfo` gathers usernames.

![image](https://user-images.githubusercontent.com/1389811/217928621-0e8fc5bf-db29-4448-a228-2dc1606786bb.png)

Tested on:

- [x] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
