### PR TITLE
other: support hw.temperature-based temps on FreeBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1016](https://github.com/ClementTsang/bottom/pull/1016): Add support for displaying process usernames on Windows.
 - [#1022](https://github.com/ClementTsang/bottom/pull/1022): Support three-character hex colour strings for styling.
+- [#1024](https://github.com/ClementTsang/bottom/pull/1024): Support FreeBSD temperature sensors based on `hw.temperature`.
 
 ## Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "enum-as-inner"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +797,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heim"
@@ -1644,12 +1662,13 @@ dependencies = [
 
 [[package]]
 name = "sysctl"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99d037b2bef227ab8963f4b0acc33ecbb1f9a2e7365add7789372b387ec19e1"
+checksum = "ed66d6a2ccbd656659289bc90767895b7abbdec897a0fc6031aca3ed1cb51d3e"
 dependencies = [
  "bitflags",
  "byteorder",
+ "enum-as-inner",
  "libc",
  "thiserror",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,13 +63,12 @@ strip = false
 battery = ["starship-battery"]
 gpu = ["nvidia"]
 nvidia = ["nvml-wrapper"]
-zfs = ["sysctl"]
 
 # The features we use by default.
-default = ["fern", "log", "battery", "gpu", "zfs"]
+default = ["fern", "log", "battery", "gpu"]
 
 # The features we use on deploy. Logging is not included as that is primarily (for now) just for debugging locally.
-deploy = ["battery", "gpu", "zfs"]
+deploy = ["battery", "gpu"]
 
 [dependencies]
 anyhow = "1.0.57"
@@ -134,7 +133,7 @@ winapi = "0.3.9"
 
 [target.'cfg(target_os = "freebsd")'.dependencies]
 serde_json = { version = "1.0.82" }
-sysctl = { version = "0.5.4", optional = true }
+sysctl = { version = "0.5.4" }
 filedescriptor = "0.8.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,13 @@ unicode-width = "0.1.10"
 libc = "0.2.124"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-heim = { version = "0.1.0-rc.1", features = ["cpu", "disk", "memory", "net", "sensors"] }
+heim = { version = "0.1.0-rc.1", features = [
+    "cpu",
+    "disk",
+    "memory",
+    "net",
+    "sensors",
+] }
 procfs = { version = "0.14.2", default-features = false }
 smol = "1.2.5"
 
@@ -119,13 +125,16 @@ mach2 = "0.4.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 heim = { version = "0.1.0-rc.1", features = ["cpu", "disk", "memory"] }
-windows = { version = "0.44.0", features = ["Win32_System_Threading", "Win32_Foundation"] }
+windows = { version = "0.44.0", features = [
+    "Win32_System_Threading",
+    "Win32_Foundation",
+] }
 
 winapi = "0.3.9"
 
 [target.'cfg(target_os = "freebsd")'.dependencies]
 serde_json = { version = "1.0.82" }
-sysctl = { version = "0.5.2", optional = true }
+sysctl = { version = "0.5.4", optional = true }
 filedescriptor = "0.8.2"
 
 [dev-dependencies]

--- a/src/app/data_harvester/temperature/sysinfo.rs
+++ b/src/app/data_harvester/temperature/sysinfo.rs
@@ -38,5 +38,30 @@ pub fn get_temperature_data(
         super::nvidia::add_nvidia_data(&mut temperature_vec, temp_type, filter)?;
     }
 
+    // For RockPro64 boards on FreeBSD, they apparently use "hw.temperature" for sensors.
+    #[cfg(target_os = "freebsd")]
+    {
+        use sysctl::Sysctl;
+
+        const KEY: &str = "hw.temperature";
+        if let Ok(root) = sysctl::Ctl::new(KEY) {
+            for ctl in sysctl::CtlIter::below(root).flatten() {
+                if let (Ok(name), Ok(temp)) = (ctl.name(), ctl.value()) {
+                    if let Some(temp) = temp.as_temperature() {
+                        temperature_vec.push(TempHarvest {
+                            name,
+                            temperature: match temp_type {
+                                TemperatureType::Celsius => temp.celsius(),
+                                TemperatureType::Kelvin => temp.kelvin(),
+                                TemperatureType::Fahrenheit => temp.fahrenheit(),
+                            },
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // TODO: Should we instead use a hashmap -> vec to skip dupes?
     Ok(Some(temperature_vec))
 }


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Add simple support for FreeBSD-based systems that may get temperatures using sysctl and `hw.temperature`.

## Issue

_If applicable, what issue does this address?_

Closes: #797

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_
- [x] _FreeBSD_

I tested whether the code works for *some* sysctl - I tried it with `dev.cpu` on my FreeBSD box, and it works. I did **not** test it for `hw.temperature`, as that does nothing for my x86-64-based FreeBSD machine.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
