### PR TITLE
other: promote macOS aarch64 to official support

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -77,7 +77,7 @@ jobs:
               cross: true,
             }
 
-          # macOS (x64)
+          # macOS (x64), M1 is built via CirrusCI.
           - { os: "macos-12", target: "x86_64-apple-darwin", cross: false }
 
           # Windows (x64, x86)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
           do_not_skip: '["workflow_dispatch", "push"]'
 
   # Runs rustfmt + tests + clippy on the main supported platforms.
+  #
+  # Note that m1 macOS is tested via CirrusCI.
   supported:
     needs: pre-job
     runs-on: ${{ matrix.info.os }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'ClementTsang/bottom' }}
 
+# TODO: Maybe add this for more than just Linux.
 jobs:
   pre-job:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changes
 
+- [#1025](https://github.com/ClementTsang/bottom/pull/1025): Officially support M1 macOS.
+
 ## Other
 
 ## [0.8.0] - 2023-01-22

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can find more details in [the documentation](https://clementtsang.github.io/
 
 bottom _officially_ supports the following operating systems and corresponding architectures:
 
-- macOS (`x86_64`)
+- macOS (`x86_64`, `aarch64`)
 - Linux (`x86_64`, `i686`, `aarch64`)
 - Windows (`x86_64`, `i686`)
 
@@ -117,13 +117,12 @@ bottom may work on a number of platforms that aren't officially supported. Note 
 - Might not be properly tested by maintainers prior to a stable release.
 - May only receive limited support, such as missing features or bugs that may not be fixed.
 
-Note that some unsupported platforms may eventually be officially supported (e.g., FreeBSD, M1 macOS devices).
+Note that some unsupported platforms may eventually be officially supported (e.g., FreeBSD).
 
 A non-comprehensive list of some currently unofficially supported platforms that may compile/work include:
 
-- FreeBSD on `x86_64`
-- Linux on `armv6`, `armv7`, `powerpc64le`, `riscv64gc`
-- macOS on `aarch64`
+- FreeBSD (`x86_64`)
+- Linux (`armv6`, `armv7`, `powerpc64le`, `riscv64gc`)
 
 For more details on unsupported platforms and known problems, check out [the documentation](https://clementtsang.github.io/bottom/nightly/support/unofficial/).
 

--- a/docs/content/support/official.md
+++ b/docs/content/support/official.md
@@ -2,7 +2,7 @@
 
 bottom _officially_ supports the following operating systems and corresponding architectures:
 
-- macOS (`x86_64`)
+- macOS (`x86_64`, `aarch64`)
 - Linux (`x86_64`, `i686`, `aarch64`)
 - Windows (`x86_64`, `i686`)
 

--- a/docs/content/support/unofficial.md
+++ b/docs/content/support/unofficial.md
@@ -1,15 +1,15 @@
 # Unofficial support
 
-Systems and architectures that aren't officially supported may still work, but there are no guarantees on how much will work. For example, it might only compile, or it might run with bugs/broken features.
-Furthermore, while it will depend on the problem at the end of the day, _issues on unsupported platforms are likely to go unfixed_.
+Systems and architectures that aren't officially supported may still work, but there are no guarantees on how much will
+work. For example, it might only compile, or it might run with bugs/broken features. Furthermore, while it will depend
+on the problem at the end of the day, _issues on unsupported platforms are likely to go unfixed_.
 
 Unofficially supported platforms known to compile/work:
 
+- FreeBSD
 - Linux on ARMv7 and ARMv6 (tested to compile in [CI](https://github.com/ClementTsang/bottom/blob/master/.github/workflows/ci.yml))
-- macOS on AArch64 (tested to compile in [CI](https://github.com/ClementTsang/bottom/blob/master/.github/workflows/ci.yml))
 - Linux on PowerPC 64 LE (tested to compile in [CI](https://github.com/ClementTsang/bottom/blob/master/.github/workflows/ci.yml))
 - Linux on an RISC-V (tested to compile in [CI](https://github.com/ClementTsang/bottom/blob/master/.github/workflows/ci.yml), tested to run on an [Allwinner D1 Nezha](https://github.com/ClementTsang/bottom/issues/564))
-- FreeBSD
 
 ## Known problems
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Since I have a macOS M1 laptop to test on now, I think it's a good time to bump it to being officially supported, especially since it's going to be the main macOS platform for the foreseeable feature.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
