### PR TITLE
change: show process in tree if any ancestor or descendent matches

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,8 @@ pub fn handle_key_event_or_break(
                 KeyCode::Char('c') | KeyCode::Char('C') => app.toggle_ignore_case(),
                 KeyCode::Char('w') | KeyCode::Char('W') => app.toggle_search_whole_word(),
                 KeyCode::Char('r') | KeyCode::Char('R') => app.toggle_search_regex(),
+                // KeyCode::Char('b') | KeyCode::Char('B') => todo!(),
+                // KeyCode::Char('f') | KeyCode::Char('F') => todo!(),
                 KeyCode::Char('h') => app.on_left_key(),
                 KeyCode::Char('l') => app.on_right_key(),
                 _ => {}


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

In tree mode, we already show an entry if any descendant matches. We now show as well if any ancestor matches.

Comparison having searched `"lightdm"`, with the current behaviour on the left and the new behaviour on the right:

![image](https://user-images.githubusercontent.com/34804052/220014456-eeed7231-d4b8-4000-8808-909ed61fd0dd.png)

Searching `"radeon"` (no change):

![image](https://user-images.githubusercontent.com/34804052/220014536-e0e48d3d-cb01-4776-ae83-593f34a59031.png)


Comparison searching for `"code"`, current on the left and new on the right:

![image](https://user-images.githubusercontent.com/34804052/220014131-62c23bfe-3c5d-46a2-9c63-a3b2453da313.png)


## Issue

_If applicable, what issue does this address?_

Closes: #668 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
