### PR TITLE
other: move terminal check after the config check

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -39,9 +39,6 @@ fn main() -> Result<()> {
         utils::logging::init_logger(log::LevelFilter::Debug, std::ffi::OsStr::new("debug.log"))?;
     }
 
-    // Check if the current environment is in a terminal.
-    check_if_terminal();
-
     // Read from config file.
     let config_path = read_config(matches.get_one::<String>("config_location"))
         .context("Unable to access the given config file location.")?;
@@ -71,6 +68,9 @@ fn main() -> Result<()> {
 
     // Create painter and set colours.
     let mut painter = canvas::Painter::init(widget_layout, colours)?;
+
+    // Check if the current environment is in a terminal.
+    check_if_terminal();
 
     // Create termination mutex and cvar
     #[allow(clippy::mutex_atomic)]


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Move the terminal check to after the config check. This is just so if the config is invalid, that should warn first (e.g. in a test).

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
