### PR TITLE
ci: reduce CI timeout to 18 minutes

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,6 +7,7 @@ on:
     - cron: "0 0 * * 1"
 jobs:
   audit:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,7 +7,7 @@ on:
     - cron: "0 0 * * 1"
 jobs:
   audit:
-    timeout-minutes: 15
+    timeout-minutes: 18
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     needs: pre-job
     runs-on: ${{ matrix.info.os }}
     if: ${{ needs.pre-job.outputs.should_skip != 'true' }}
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -136,7 +136,7 @@ jobs:
     runs-on: ${{ matrix.info.os }}
     if: ${{ needs.pre-job.outputs.should_skip != 'true' }}
     continue-on-error: true
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     needs: pre-job
     runs-on: ${{ matrix.info.os }}
     if: ${{ needs.pre-job.outputs.should_skip != 'true' }}
-    timeout-minutes: 15
+    timeout-minutes: 18
     strategy:
       fail-fast: false
       matrix:
@@ -136,7 +136,7 @@ jobs:
     runs-on: ${{ matrix.info.os }}
     if: ${{ needs.pre-job.outputs.should_skip != 'true' }}
     continue-on-error: true
-    timeout-minutes: 15
+    timeout-minutes: 18
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,7 @@ jobs:
   coverage:
     needs: pre-job
     if: ${{ needs.pre-job.outputs.should_skip != 'true' }}
-    timeout-minutes: 15
+    timeout-minutes: 18
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,6 +34,7 @@ jobs:
   coverage:
     needs: pre-job
     if: ${{ needs.pre-job.outputs.should_skip != 'true' }}
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Reduce the CI to 18 minutes since the current 30 minutes is unnecessarily long. Also add timeouts in some workflows.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
