### PR TITLE
Fix is_list_ignored=false filters for network and temperature

### DIFF
--- a/src/app/data_harvester/network/heim.rs
+++ b/src/app/data_harvester/network/heim.rs
@@ -23,22 +23,17 @@ pub async fn get_network_data(
     while let Some(io) = io_data.next().await {
         if let Ok(io) = io {
             let to_keep = if let Some(filter) = filter {
-                if filter.is_list_ignored {
-                    let mut ret = true;
-                    for r in &filter.list {
-                        if r.is_match(io.interface()) {
-                            ret = false;
-                            break;
-                        }
+                let mut ret = filter.is_list_ignored;
+                for r in &filter.list {
+                    if r.is_match(io.interface()) {
+                        ret = !filter.is_list_ignored;
+                        break;
                     }
-                    ret
-                } else {
-                    true
                 }
+                ret
             } else {
                 true
             };
-
             if to_keep {
                 // TODO: Use bytes as the default instead, perhaps?
                 // Since you might have to do a double conversion (bytes -> bits -> bytes) in some cases;

--- a/src/app/data_harvester/temperature.rs
+++ b/src/app/data_harvester/temperature.rs
@@ -47,18 +47,14 @@ fn convert_celsius_to_fahrenheit(celsius: f32) -> f32 {
 
 fn is_temp_filtered(filter: &Option<Filter>, text: &str) -> bool {
     if let Some(filter) = filter {
-        if filter.is_list_ignored {
-            let mut ret = true;
-            for r in &filter.list {
-                if r.is_match(text) {
-                    ret = false;
-                    break;
-                }
+        let mut ret = filter.is_list_ignored;
+        for r in &filter.list {
+            if r.is_match(text) {
+                ret = !filter.is_list_ignored;
+                break;
             }
-            ret
-        } else {
-            true
         }
+        ret
     } else {
         true
     }


### PR DESCRIPTION
## Description

Use filter logic from network/sysinfo in temperature and network/heim harvesters. Previously is_list_ignored=false filter configs would silently accept every sensor and every interface.

## Testing

Network: with debug `eprintln!` of matched interface names
Temperature: by configuring the filter and checking that it now actually filters

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
