### PR TITLE
refactor: use internal committed memory calculation for Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,8 +119,9 @@ mach2 = "0.4.1"
 [target.'cfg(target_os = "windows")'.dependencies]
 heim = { version = "0.1.0-rc.1", features = ["disk"] }
 windows = { version = "0.44.0", features = [
-    "Win32_System_Threading",
     "Win32_Foundation",
+    "Win32_System_ProcessStatus",
+    "Win32_System_Threading",
 ] }
 
 [target.'cfg(target_os = "freebsd")'.dependencies]

--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -397,7 +397,10 @@ impl DataCollector {
     fn update_memory_usage(&mut self) {
         if self.widgets_to_harvest.use_mem {
             self.data.memory = memory::get_ram_usage(&self.sys);
-            self.data.swap = memory::get_swap_usage(&self.sys);
+            self.data.swap = memory::get_swap_usage(
+                #[cfg(not(target_os = "windows"))]
+                &self.sys,
+            );
 
             #[cfg(feature = "zfs")]
             {

--- a/src/app/data_harvester/memory.rs
+++ b/src/app/data_harvester/memory.rs
@@ -1,7 +1,17 @@
 //! Memory data collection.
 
 pub mod sysinfo;
-pub(crate) use self::sysinfo::{get_ram_usage, get_swap_usage};
+pub(crate) use self::sysinfo::get_ram_usage;
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "windows")] {
+        pub mod windows;
+        pub(crate) use self::windows::get_swap_usage;
+    } else {
+        pub(crate) use self::sysinfo::get_swap_usage;
+
+    }
+}
 
 #[cfg(feature = "gpu")]
 pub mod gpu;

--- a/src/app/data_harvester/memory/sysinfo.rs
+++ b/src/app/data_harvester/memory/sysinfo.rs
@@ -21,6 +21,7 @@ pub(crate) fn get_ram_usage(sys: &System) -> Option<MemHarvest> {
 }
 
 /// Returns SWAP usage.
+#[cfg(not(target_os = "windows"))]
 pub(crate) fn get_swap_usage(sys: &System) -> Option<MemHarvest> {
     let mem_used_in_kib = sys.used_swap() / 1024;
     let mem_total_in_kib = sys.total_swap() / 1024;

--- a/src/app/data_harvester/memory/windows.rs
+++ b/src/app/data_harvester/memory/windows.rs
@@ -5,14 +5,19 @@ use windows::Win32::System::ProcessStatus::{K32GetPerformanceInfo, PERFORMANCE_I
 use crate::data_harvester::memory::MemHarvest;
 
 // TODO: Note this actually calculates the total *committed* usage. Rename and change label for accuracy!
+/// Get the committed memory usage.
+///
+/// Code based on [sysinfo's](https://github.com/GuillaumeGomez/sysinfo/blob/6f8178495adcf3ca4696a9ec548586cf6a621bc8/src/windows/system.rs#L169).
 pub(crate) fn get_swap_usage() -> Option<MemHarvest> {
+    // SAFETY: The safety invariant is that we only touch what's in `perf_info` if it succeeds, and that
+    // the bindings are "safe" to use with how we call them.
     unsafe {
         let mut perf_info: PERFORMANCE_INFORMATION = zeroed();
         if K32GetPerformanceInfo(&mut perf_info, size_of::<PERFORMANCE_INFORMATION>() as u32)
             == TRUE
         {
+            // Saturating sub by perf_info.PhysicalTotal for what sysinfo does.
             let swap_total = perf_info.PageSize.saturating_mul(perf_info.CommitLimit) as u64;
-
             let swap_used = perf_info.PageSize.saturating_mul(perf_info.CommitTotal) as u64;
 
             Some(MemHarvest {

--- a/src/app/data_harvester/memory/windows.rs
+++ b/src/app/data_harvester/memory/windows.rs
@@ -1,0 +1,27 @@
+use std::mem::{size_of, zeroed};
+use windows::Win32::Foundation::TRUE;
+use windows::Win32::System::ProcessStatus::{K32GetPerformanceInfo, PERFORMANCE_INFORMATION};
+
+use crate::data_harvester::memory::MemHarvest;
+
+// TODO: Note this actually calculates the total *committed* usage. Rename and change label for accuracy!
+pub(crate) fn get_swap_usage() -> Option<MemHarvest> {
+    unsafe {
+        let mut perf_info: PERFORMANCE_INFORMATION = zeroed();
+        if K32GetPerformanceInfo(&mut perf_info, size_of::<PERFORMANCE_INFORMATION>() as u32)
+            == TRUE
+        {
+            let swap_total = perf_info.PageSize.saturating_mul(perf_info.CommitLimit) as u64;
+
+            let swap_used = perf_info.PageSize.saturating_mul(perf_info.CommitTotal) as u64;
+
+            Some(MemHarvest {
+                total_kib: swap_total / 1024,
+                used_kib: swap_used / 1024,
+                use_percent: Some(swap_used as f64 / swap_total as f64 * 100.0),
+            })
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Basically, we're going back to displaying the total `committed` usage, as we were when using heim.

I'm considering further breaking this down (and clarifying this isn't technically swap on Windows) in later PRs. See #1052 for more details/further work later.

## Issue

_If applicable, what issue does this address?_

Closes: #1043

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [x] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
