### PR TITLE
ci: update the upload artifact action to v3.1.2

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -196,7 +196,7 @@ jobs:
           mv manpage.tar.gz release/
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           retention-days: 3
           name: release
@@ -242,7 +242,7 @@ jobs:
           mv bottom_x86_64_installer.msi release/
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           retention-days: 3
           name: release
@@ -274,7 +274,7 @@ jobs:
           python ./scripts/cirrus/build.py "$BRANCH" "release/" "${{ inputs.caller }}"
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           retention-days: 3
           name: release
@@ -375,7 +375,7 @@ jobs:
           mv ${{ steps.verify.outputs.DEB_FILE }} release/
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           retention-days: 3
           name: release

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -41,7 +41,7 @@ jobs:
         run: echo "${{ env.VERSION }}" > release-version
 
       - name: Upload release-version as artifact
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           retention-days: 3
           name: release-version
@@ -97,7 +97,7 @@ jobs:
           mv choco.zip release/
 
       - name: Save release as artifact
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           retention-days: 3
           name: release


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Update the `upload-artifact` action hash to point from v3.1.1 to v3.1.2.

Changelog can be found [here](https://github.com/actions/upload-artifact/releases/tag/v3.1.2).

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

Tested using the [nightly workflow](https://github.com/ClementTsang/bottom/actions/runs/4372151573), seems to work fine for my use cases.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
