### PR TITLE
deps: switch back to crossterm 0.26.1 with fix to double keypress

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ use constants::*;
 use crossterm::{
     event::{
         poll, read, DisableBracketedPaste, DisableMouseCapture, Event, KeyCode, KeyEvent,
-        KeyModifiers, MouseEvent, MouseEventKind,
+        KeyEventKind, KeyModifiers, MouseEvent, MouseEventKind,
     },
     execute,
     style::Print,
@@ -444,7 +444,9 @@ pub fn create_input_thread(
                                     break;
                                 }
                             }
-                            Event::Key(key) => {
+                            Event::Key(key) if key.kind == KeyEventKind::Press => {
+                                // For now, we only care about keydown events. This may change in the future.
+
                                 if sender.send(BottomEvent::KeyInput(key)).is_err() {
                                     break;
                                 }


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Explicitly ignore anything but `Press` key events from crossterm.

## Issue

_If applicable, what issue does this address?_

Related to #1065 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [x] _Windows_
- [x] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
