### PR TITLE
deps: bump sysinfo to 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.28.3"
+version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69e0d827cce279e61c2f3399eb789271a8f136d8245edef70f06e3c9601a670"
+checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
 dependencies = [
  "cfg-if",
  "core-foundation-sys 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a81bbc26c485910df47772df6bbcdb417036132caa9e51e29d2e39c4636d4e"
+checksum = "d3e847e2de7a137c8c2cede5095872dbb00f4f9bf34d061347e36b43322acd56"
 dependencies = [
  "cfg-if",
  "core-foundation-sys 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.26.9"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c18a6156d1f27a9592ee18c1a846ca8dd5c258b7179fc193ae87c74ebb666f5"
+checksum = "727220a596b4ca0af040a07091e49f5c105ec8f2592674339a5bf35be592f76e"
 dependencies = [
  "cfg-if",
  "core-foundation-sys 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e847e2de7a137c8c2cede5095872dbb00f4f9bf34d061347e36b43322acd56"
+checksum = "f69e0d827cce279e61c2f3399eb789271a8f136d8245edef70f06e3c9601a670"
 dependencies = [
  "cfg-if",
  "core-foundation-sys 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727220a596b4ca0af040a07091e49f5c105ec8f2592674339a5bf35be592f76e"
+checksum = "38a81bbc26c485910df47772df6bbcdb417036132caa9e51e29d2e39c4636d4e"
 dependencies = [
  "cfg-if",
  "core-foundation-sys 0.8.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ once_cell = "1.5.2"
 regex = "1.7.1"
 serde = { version = "1.0.152", features = ["derive"] }
 starship-battery = { version = "0.7.9", optional = true }
-sysinfo = "0.28.3"
+sysinfo = "0.28.4"
 thiserror = "1.0.38"
 time = { version = "0.3.20", features = ["formatting", "macros"] }
 toml_edit = { version = "0.19.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ once_cell = "1.5.2"
 regex = "1.7.1"
 serde = { version = "1.0.152", features = ["derive"] }
 starship-battery = { version = "0.7.9", optional = true }
-sysinfo = "0.28.1"
+sysinfo = "0.28.2"
 thiserror = "1.0.38"
 time = { version = "0.3.20", features = ["formatting", "macros"] }
 toml_edit = { version = "0.19.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ once_cell = "1.5.2"
 regex = "1.7.1"
 serde = { version = "1.0.152", features = ["derive"] }
 starship-battery = { version = "0.7.9", optional = true }
-sysinfo = "0.26.7"
+sysinfo = "0.28.0"
 thiserror = "1.0.38"
 time = { version = "0.3.20", features = ["formatting", "macros"] }
 toml_edit = { version = "0.19.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ once_cell = "1.5.2"
 regex = "1.7.1"
 serde = { version = "1.0.152", features = ["derive"] }
 starship-battery = { version = "0.7.9", optional = true }
-sysinfo = "0.28.2"
+sysinfo = "0.28.3"
 thiserror = "1.0.38"
 time = { version = "0.3.20", features = ["formatting", "macros"] }
 toml_edit = { version = "0.19.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ once_cell = "1.5.2"
 regex = "1.7.1"
 serde = { version = "1.0.152", features = ["derive"] }
 starship-battery = { version = "0.7.9", optional = true }
-sysinfo = "0.28.0"
+sysinfo = "0.28.1"
 thiserror = "1.0.38"
 time = { version = "0.3.20", features = ["formatting", "macros"] }
 toml_edit = { version = "0.19.4", features = ["serde"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,12 @@
 
 #![warn(rust_2018_idioms)]
 #![deny(clippy::missing_safety_doc)]
+// TODO: Deny unused imports.
 #[allow(unused_imports)]
+// Only used for builds not intended for release.
 #[cfg(feature = "log")]
 #[macro_use]
 extern crate log;
-
-// TODO: Deny unused imports.
 
 use std::{
     boxed::Box,


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Updates sysinfo to 0.28.4, which contains a bunch of nice improvements and fixes.

## Issue

_If applicable, what issue does this address?_

Might affect/close: #1050?

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [x] _Windows_
- [x] _macOS_
- [x] _Linux_
- [x] _FreeBSD (if possible)_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
