### PR TITLE
ci: run build on unsupported platforms instead of check, bump cross

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -150,7 +150,7 @@ jobs:
           command: build
           args: --release --verbose --locked --target=${{ matrix.info.target }} --features deploy
           use-cross: ${{ matrix.info.cross }}
-          cross-version: 0.2.4
+          cross-version: 0.2.5
 
       - name: Move automatically generated completion/manpage
         shell: bash
@@ -336,7 +336,7 @@ jobs:
           command: build
           args: --release --locked --verbose --features deploy --target ${{ matrix.info.target }}
           use-cross: ${{ matrix.info.cross }}
-          cross-version: 0.2.4
+          cross-version: 0.2.5
 
       - name: Move automatically generated completion/manpage
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           command: test
           args: --no-run --locked ${{ matrix.features }} --target=${{ matrix.info.target }}
           use-cross: ${{ matrix.info.cross }}
-          cross-version: 0.2.4
+          cross-version: 0.2.5
         env:
           RUST_BACKTRACE: full
 
@@ -121,7 +121,7 @@ jobs:
           command: test
           args: --no-fail-fast ${{ matrix.features }} --target=${{ matrix.info.target }} -- --nocapture --quiet
           use-cross: ${{ matrix.info.cross }}
-          cross-version: 0.2.4
+          cross-version: 0.2.5
         env:
           RUST_BACKTRACE: full
 
@@ -131,17 +131,18 @@ jobs:
           command: clippy
           args: ${{ matrix.features }} --all-targets --workspace --target=${{ matrix.info.target }} -- -D warnings
           use-cross: ${{ matrix.info.cross }}
-          cross-version: 0.2.4
+          cross-version: 0.2.5
         env:
           RUST_BACKTRACE: full
 
-  # Run cargo check on all other platforms
+  # Check running cargo build on all other platforms.
+  # TODO: Maybe some of these should be allowed to fail.
   other-check:
     needs: pre-job
     runs-on: ${{ matrix.info.os }}
     if: ${{ needs.pre-job.outputs.should_skip != 'true' }}
     continue-on-error: true
-    timeout-minutes: 18
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -178,7 +179,7 @@ jobs:
               rust: stable,
             }
 
-          # Beta; should be allowed to fail.
+          # Beta
           - {
               os: "ubuntu-latest",
               target: "x86_64-unknown-linux-gnu",
@@ -246,13 +247,13 @@ jobs:
         with:
           key: ${{ matrix.info.target }}
 
-      - name: Check
+      - name: Try building
         uses: ClementTsang/cargo-action@v0.0.3
         with:
-          command: check
+          command: build
           args: --all-targets --verbose --target=${{ matrix.info.target }} --locked
           use-cross: ${{ matrix.info.cross }}
-          cross-version: 0.2.4
+          cross-version: 0.2.5
 
   completion:
     name: "CI Pass Check"


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Runs a build instead of just a check, and bumps cross to 0.2.5 on CI actions.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
