### PR TITLE
deps: bump once_cell and related dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ deny.toml
 
 # mkdocs
 site/
+
+# dhat heap profiling
+dhat-heap.json

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ site/
 
 # dhat heap profiling
 dhat-heap.json
+dhat/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,13 +40,14 @@ checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.4"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+checksum = "ec0b2340f55d9661d76793b2bfc2eb0e62689bd79d067a95707ea762afd5e9dd"
 dependencies = [
+ "anstyle",
  "bstr",
  "doc-comment",
- "predicates 2.1.5",
+ "predicates",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -121,7 +122,7 @@ dependencies = [
  "mach2",
  "nvml-wrapper",
  "once_cell",
- "predicates 3.0.2",
+ "predicates",
  "procfs",
  "regex",
  "serde",
@@ -141,13 +142,14 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
 dependencies = [
- "lazy_static",
  "memchr",
+ "once_cell",
  "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -839,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "os_str_bytes"
@@ -874,17 +876,6 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
-dependencies = [
- "difflib",
- "itertools",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c575290b64d24745b6c57a12a31465f0a66f3a4799686a6921526a33b0797965"
@@ -900,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
 
 [[package]]
 name = "predicates-tree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ lto = true
 opt-level = 3
 codegen-units = 1
 
-[profile.flamegraph]
+[profile.profiling]
 inherits = "release"
 debug = true
 strip = false
@@ -80,6 +80,7 @@ concat-string = "1.0.1"
 const_format = "0.2.30"
 crossterm = "0.26.1"
 ctrlc = { version = "3.2.5", features = ["termination"] }
+# dhat = "0.3.2"
 dirs = "5.0.0"
 fern = { version = "0.6.2", optional = true }
 fxhash = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ itertools = "0.10.5"
 kstring = { version = "2.0.0", features = ["arc"] }
 log = { version = "0.4.17", optional = true }
 nvml-wrapper = { version = "0.9.0", optional = true }
-once_cell = "1.5.2"
+once_cell = "1.17.1"
 regex = "1.7.3"
 serde = { version = "1.0.159", features = ["derive"] }
 starship-battery = { version = "0.7.9", optional = true }
@@ -130,7 +130,7 @@ sysctl = { version = "0.5.4" }
 filedescriptor = "0.8.2"
 
 [dev-dependencies]
-assert_cmd = "2.0.4" # cannot update this due to once_cell
+assert_cmd = "2.0.10"
 predicates = "3.0.2"
 
 [dev-dependencies.cargo-husky]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -34,7 +34,12 @@ use crossterm::{
 };
 use tui::{backend::CrosstermBackend, Terminal};
 
+// #[global_allocator]
+// static ALLOC: dhat::Alloc = dhat::Alloc;
+
 fn main() -> Result<()> {
+    // let _profiler = dhat::Profiler::new_heap();
+
     let matches = clap::get_matches();
     #[cfg(all(feature = "fern", debug_assertions))]
     {


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Now that we've removed heim, I can bump up other dependencies that relied on newer versions of once_cell.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
