### PR TITLE
ci: run wf cache clear script twice with delays

### DIFF
--- a/.github/workflows/clear-workflow-cache.yml
+++ b/.github/workflows/clear-workflow-cache.yml
@@ -26,11 +26,19 @@ jobs:
         with:
           fetch-depth: 1
 
-      - run: |
+      # We run each script twice with a small delay in between to try and catch everything.
+      - name: Clear cache
+        run: |
           if [[ -n "${{ github.event.schedule }}" ]]; then
+            python ./scripts/clear_cache.py keep-master
+            sleep 5
             python ./scripts/clear_cache.py keep-master
           elif [[ -z "${{ github.event.inputs.id }}" ]]; then
             python ./scripts/clear_cache.py ${{ github.event.pull_request.number }}
+            sleep 5
+            python ./scripts/clear_cache.py ${{ github.event.pull_request.number }}
           else
+            python ./scripts/clear_cache.py ${{ github.event.inputs.id }}
+            sleep 5
             python ./scripts/clear_cache.py ${{ github.event.inputs.id }}
           fi

--- a/scripts/clear_cache.py
+++ b/scripts/clear_cache.py
@@ -4,9 +4,10 @@
 #
 # Expects a GitHub token in the environment variables as GITHUB_TOKEN.
 
-import os
 import json
+import os
 import sys
+import time
 from urllib.error import HTTPError, URLError
 
 from urllib.request import Request, urlopen
@@ -53,6 +54,7 @@ def main():
                         print("URLError with delete.")
                     else:
                         print("Successfully deleted cache ID {}!".format(id))
+                    time.sleep(0.3)
     elif args[1] == "keep-main" or args[1] == "keep-master":
         print("Clearing all but default branch cache.")
         with urlopen(cache_list_request(key)) as response:
@@ -70,6 +72,7 @@ def main():
                         print("URLError with delete.")
                     else:
                         print("Successfully deleted cache ID {}!".format(id))
+                    time.sleep(0.3)
     elif args[1] == "main" or args[1] == "master" or args[1] == "all":
         print("Clearing all caches.")
         with urlopen(cache_list_request(key)) as response:
@@ -86,6 +89,7 @@ def main():
                     print("URLError with delete.")
                 else:
                     print("Successfully deleted cache ID {}!".format(id))
+                time.sleep(0.3)
     else:
         print(f"Skipping, given argument {args[1]}.")
 

--- a/scripts/clear_cache.py
+++ b/scripts/clear_cache.py
@@ -54,7 +54,7 @@ def main():
                         print("URLError with delete.")
                     else:
                         print("Successfully deleted cache ID {}!".format(id))
-                    time.sleep(0.3)
+                    time.sleep(0.1)
     elif args[1] == "keep-main" or args[1] == "keep-master":
         print("Clearing all but default branch cache.")
         with urlopen(cache_list_request(key)) as response:
@@ -72,7 +72,7 @@ def main():
                         print("URLError with delete.")
                     else:
                         print("Successfully deleted cache ID {}!".format(id))
-                    time.sleep(0.3)
+                    time.sleep(0.1)
     elif args[1] == "main" or args[1] == "master" or args[1] == "all":
         print("Clearing all caches.")
         with urlopen(cache_list_request(key)) as response:
@@ -89,7 +89,7 @@ def main():
                     print("URLError with delete.")
                 else:
                     print("Successfully deleted cache ID {}!".format(id))
-                time.sleep(0.3)
+                time.sleep(0.1)
     else:
         print(f"Skipping, given argument {args[1]}.")
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Since there's occasionally stragglers, this runs the script 2x and adds some delays in between.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
