### PR TITLE
other: Speed up first draw and first data collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1016](https://github.com/ClementTsang/bottom/pull/1016): Add support for displaying process usernames on Windows.
 - [#1022](https://github.com/ClementTsang/bottom/pull/1022): Support three-character hex colour strings for styling.
 - [#1024](https://github.com/ClementTsang/bottom/pull/1024): Support FreeBSD temperature sensors based on `hw.temperature`.
-- [#1063](https://github.com/ClementTsang/bottom/pull/1063): Add buffer and cache memory tracking
+- [#1063](https://github.com/ClementTsang/bottom/pull/1063): Add buffer and cache memory tracking.
 
 ## Changes
 
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1075](https://github.com/ClementTsang/bottom/issues/1075): Update how drives are named in Windows.
 
 ## Other
+
+- [#1100](https://github.com/ClementTsang/bottom/pull/1100): Speed up first draw and first data collection.
 
 ## [0.8.0] - 2023-01-22
 

--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -195,21 +195,19 @@ impl DataCollector {
         self.update_data();
 
         // Sleep a few seconds to avoid potentially weird data...
-        {
-            let sleep_duration = {
-                cfg_if::cfg_if! {
-                    if #[cfg(target_os = "freebsd")] {
-                        // FreeBSD's system value is 1s, which is a bit too long for me so I'll accept the one-time
-                        // inaccuracy.
-                        std::time::Duration::from_millis(250)
-                    } else {
-                        sysinfo::System::MINIMUM_CPU_UPDATE_INTERVAL + Duration::from_millis(1)
-                    }
+        let sleep_duration = {
+            cfg_if::cfg_if! {
+                if #[cfg(target_os = "freebsd")] {
+                    // FreeBSD's min duration value is 1s, which is a bit too long for me so I'll accept the one-time
+                    // inaccuracy.
+                    std::time::Duration::from_millis(250)
+                } else {
+                    sysinfo::System::MINIMUM_CPU_UPDATE_INTERVAL + Duration::from_millis(1)
                 }
-            };
+            }
+        };
 
-            std::thread::sleep(sleep_duration);
-        }
+        std::thread::sleep(sleep_duration);
         self.data.cleanup();
     }
 

--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -194,7 +194,22 @@ impl DataCollector {
 
         self.update_data();
 
-        std::thread::sleep(std::time::Duration::from_millis(250));
+        // Sleep a few seconds to avoid potentially weird data...
+        {
+            let sleep_duration = {
+                cfg_if::cfg_if! {
+                    if #[cfg(target_os = "freebsd")] {
+                        // FreeBSD's system value is 1s, which is a bit too long for me so I'll accept the one-time
+                        // inaccuracy.
+                        std::time::Duration::from_millis(250)
+                    } else {
+                        sysinfo::System::MINIMUM_CPU_UPDATE_INTERVAL + Duration::from_millis(1)
+                    }
+                }
+            };
+
+            std::thread::sleep(sleep_duration);
+        }
         self.data.cleanup();
     }
 

--- a/src/app/layout_manager.rs
+++ b/src/app/layout_manager.rs
@@ -993,7 +993,7 @@ Supported widget names:
     }
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, Copy)]
 pub struct UsedWidgets {
     pub use_cpu: bool,
     pub use_mem: bool,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
     // let _profiler = dhat::Profiler::new_heap();
 
     let matches = clap::get_matches();
-    #[cfg(all(feature = "fern", debug_assertions))]
+    #[cfg(all(feature = "fern"))]
     {
         utils::logging::init_logger(log::LevelFilter::Debug, std::ffi::OsStr::new("debug.log"))?;
     }
@@ -126,7 +126,7 @@ fn main() -> Result<()> {
         app.used_widgets.clone(),
     );
 
-    // Set up up tui and crossterm
+    // Set up tui and crossterm
     let mut stdout_val = stdout();
     execute!(
         stdout_val,
@@ -161,6 +161,9 @@ fn main() -> Result<()> {
         ist_clone.store(true, Ordering::SeqCst);
     })?;
     let mut first_run = true;
+
+    // Draw once first to initialize the canvas, so it doesn't feel like it's frozen.
+    try_drawing(&mut terminal, &mut app, &mut painter)?;
 
     while !is_terminated.load(Ordering::SeqCst) {
         // TODO: Would be good to instead use a mix of is_terminated check + recv. Probably use a termination event instead.


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This PR has two main changes:

- Draw once ASAP after initialization to quickly produce a visual UI, even if devoid of data.
- Shorten data initialization sleep (for many cases) and load it earlier to load the first batch of data a bit faster.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [x] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
