### PR TITLE
Change description of watt data when charging.

### DIFF
--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -153,8 +153,13 @@ impl Painter {
                         self.colours.high_battery_colour
                     }),
                 ]));
+                let state = match &battery_details.battery_duration {
+                    BatteryDuration::ToFull(_) => "Charging",
+                    BatteryDuration::ToEmpty(_) => "Consumption",
+                    _ => "Unknown",
+                };
                 battery_rows.push(
-                    Row::new(vec!["Consumption", &battery_details.watt_consumption])
+                    Row::new(vec![state, &battery_details.watt_consumption])
                         .style(self.colours.text_style),
                 );
 


### PR DESCRIPTION
## Description

When laptop is charging, change the widget text to be `Charging` instead of `Consumption`.

*Before*
![btm1](https://user-images.githubusercontent.com/5746693/232557591-bc7209c6-7ec3-481c-8cdb-c2ae73152ed2.png)

*After*
![btm2](https://user-images.githubusercontent.com/5746693/232557623-6dc0e9fd-bdf5-4dae-b646-c0a5a911c087.png)

## Issue

Improper description

Closes: #

## Testing

Visual testing via the screenshot.
Happy to add tests if there are references for data input into widgets, as I didn't see any.

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
