### PR TITLE
bug: fix side borders in basic mode

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,5 @@
 use once_cell::sync::Lazy;
+use tui::widgets::Borders;
 
 use crate::options::ConfigColours;
 
@@ -21,7 +22,7 @@ pub const TABLE_GAP_HEIGHT_LIMIT: u16 = 7;
 pub const TIME_LABEL_HEIGHT_LIMIT: u16 = 7;
 
 // Side borders
-pub const SIDE_BORDERS: tui::widgets::Borders = tui::widgets::Borders::from_bits_truncate(20);
+pub const SIDE_BORDERS: Borders = Borders::LEFT.union(Borders::RIGHT);
 pub static DEFAULT_TEXT_STYLE: Lazy<tui::style::Style> =
     Lazy::new(|| tui::style::Style::default().fg(tui::style::Color::Gray));
 pub static DEFAULT_HEADER_STYLE: Lazy<tui::style::Style> =
@@ -736,6 +737,16 @@ mod test {
             HELP_CONTENTS_TEXT.len(),
             HELP_TEXT.len(),
             "the two should be equal, or this test should be updated"
+        )
+    }
+
+    /// This test exists because previously, [`SIDE_BORDERS`] was set incorrectly after I moved from
+    /// tui-rs to ratatui.
+    #[test]
+    fn assert_side_border_bits_match() {
+        assert_eq!(
+            SIDE_BORDERS,
+            Borders::ALL.difference(Borders::TOP.union(Borders::BOTTOM))
         )
     }
 }


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Seems like I broke this when migrating from tui-rs to ratatui. This just uses explicit enum variants to set my side borders and a test to try and make sure this doesn't happen again.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
