### PR TITLE
deps: remove const_format dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,6 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "concat-string",
- "const_format",
  "core-foundation",
  "crossterm",
  "ctrlc",
@@ -291,26 +290,6 @@ name = "concat-string"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7439becb5fafc780b6f4de382b1a7a3e70234afe783854a4702ee8adbb838609"
-
-[[package]]
-name = "const_format"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
 
 [[package]]
 name = "core-foundation"
@@ -1392,12 +1371,6 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "uom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,12 +131,8 @@ filedescriptor = "0.8.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.10"
+cargo-husky = { version = "1.5.0", default-features = false, features = ["user-hooks"] }
 predicates = "3.0.2"
-
-[dev-dependencies.cargo-husky]
-version = "1.5.0"
-default-features = false
-features = ["user-hooks"]
 
 [build-dependencies]
 clap = { version = "4.2.4", features = ["default", "cargo", "wrap_help"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,6 @@ backtrace = "0.3.67"
 cfg-if = "1.0.0"
 clap = { version = "4.2.4", features = ["default", "cargo", "wrap_help"] }
 concat-string = "1.0.1"
-const_format = "0.2.30"
 crossterm = "0.26.1"
 ctrlc = { version = "3.2.5", features = ["termination"] }
 # dhat = "0.3.2"

--- a/src/widgets/process_table.rs
+++ b/src/widgets/process_table.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, collections::BTreeMap};
 
-use const_format::formatcp;
 use hashbrown::{HashMap, HashSet};
 use itertools::Itertools;
 
@@ -274,9 +273,9 @@ impl ProcWidgetState {
         &self, collapsed_pids: &HashSet<Pid>, data_collection: &DataCollection,
     ) -> Vec<ProcWidgetData> {
         const BRANCH_END: char = '└';
-        const BRANCH_VERTICAL: char = '│';
         const BRANCH_SPLIT: char = '├';
         const BRANCH_HORIZONTAL: char = '─';
+        const SPACED_BRANCH_VERTICAL: &str = "│  ";
 
         let search_query = self.get_query();
         let is_using_command = self.is_using_command();
@@ -487,7 +486,7 @@ impl ProcWidgetState {
                         prefixes.push(if is_last {
                             "   "
                         } else {
-                            formatcp!("{}  ", BRANCH_VERTICAL)
+                            SPACED_BRANCH_VERTICAL
                         });
                     }
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

I was importing it for just one use case, but I could just define the const string manually and not pull it in at all.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
