### PR TITLE
other: keep running even if logger fails to initialize

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -47,7 +47,11 @@ fn main() -> Result<()> {
     let matches = clap::get_matches();
     #[cfg(all(feature = "fern"))]
     {
-        utils::logging::init_logger(log::LevelFilter::Debug, std::ffi::OsStr::new("debug.log"))?;
+        if let Err(err) =
+            utils::logging::init_logger(log::LevelFilter::Debug, std::ffi::OsStr::new("debug.log"))
+        {
+            println!("Issue initializing logger: {err}");
+        }
     }
 
     // Read from config file.


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This just makes it so that even if the logger is enabled, if it fails to initialize (e.g. read-only directory), bottom will still continue to start up, and just print a warning that the logger encountered an issue.

## Issue

_If applicable, what issue does this address?_

Closes: #1131

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
