### PR TITLE
other: disable logging when building with default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,10 +66,13 @@ nvidia = ["nvml-wrapper"]
 zfs = []
 
 # The features we use by default.
-default = ["fern", "log", "battery", "gpu", "zfs"]
+default = ["deploy"]
 
 # The features we use on deploy. Logging is not included as that is primarily (for now) just for debugging locally.
 deploy = ["battery", "gpu", "zfs"]
+
+# Including logging for debugging purposes.
+logging = ["fern", "log"]
 
 [dependencies]
 anyhow = "1.0.71"
@@ -131,7 +134,9 @@ filedescriptor = "0.8.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.11"
-cargo-husky = { version = "1.5.0", default-features = false, features = ["user-hooks"] }
+cargo-husky = { version = "1.5.0", default-features = false, features = [
+    "user-hooks",
+] }
 predicates = "3.0.3"
 
 [build-dependencies]

--- a/docs/content/contribution/development/build_process.md
+++ b/docs/content/contribution/development/build_process.md
@@ -28,7 +28,7 @@ Binaries are built currently for various targets. Note that not all of these are
 - Enable cache.
 - Build a release build with:
 
-  - `--features deploy`, which disables unneeded dev features in bottom.
+  - `--features deploy`, which enables only crates needed for release builds.
   - `--locked` to lock the dependency versions.
   - The following env variables set:
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This makes it so that you need to opt-in to debug log logging when building by using `--features logging` (which makes more sense since only devs would be using it for now).

## Issue

_If applicable, what issue does this address?_

Related to: #1131

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

Tested by building and observing `fern` and `log` are not compiled by default. Enabling the feature does rope them in and debug logging works.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
