### PR TITLE
bug: fix gruvbox cache colour being invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - Unreleased
+
+## Bug Fixes
+
+- [#1148](https://github.com/ClementTsang/bottom/pull/1148): Fix Gruvbox colour string being invalid when cache usage is enabled.
+
 ## [0.9.0] - 2023-05-10
 
 ## Bug Fixes

--- a/src/canvas/canvas_styling.rs
+++ b/src/canvas/canvas_styling.rs
@@ -392,9 +392,9 @@ impl CanvasColours {
 #[cfg(test)]
 mod test {
 
+    use super::{CanvasColours, ColourScheme};
+    use crate::Config;
     use tui::style::{Color, Style};
-
-    use super::CanvasColours;
 
     #[test]
     fn default_selected_colour_works() {
@@ -422,5 +422,16 @@ mod test {
             colours.currently_selected_text_style,
             Style::default().fg(Color::Red).bg(Color::Magenta),
         );
+    }
+
+    #[test]
+    fn test_built_in_colour_schemes() {
+        let config = Config::default();
+        CanvasColours::new(ColourScheme::Default, &config).unwrap();
+        CanvasColours::new(ColourScheme::DefaultLight, &config).unwrap();
+        CanvasColours::new(ColourScheme::Gruvbox, &config).unwrap();
+        CanvasColours::new(ColourScheme::GruvboxLight, &config).unwrap();
+        CanvasColours::new(ColourScheme::Nord, &config).unwrap();
+        CanvasColours::new(ColourScheme::NordLight, &config).unwrap();
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -152,7 +152,7 @@ pub static GRUVBOX_LIGHT_COLOUR_PALETTE: Lazy<ConfigColours> = Lazy::new(|| Conf
     ]),
     ram_color: Some("#427b58".into()),
     #[cfg(not(target_os = "windows"))]
-    cache_color: Some("d79921".into()),
+    cache_color: Some("#d79921".into()),
     swap_color: Some("#cc241d".into()),
     arc_color: Some("#689d6a".into()),
     gpu_core_colors: Some(vec![


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

The hex string was incorrectly defined (missing a `"#"`). This PR just fixes it and adds a test to check it in the future.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
