### PR TITLE
refactor: use macros for initializing canvas styles

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -30,7 +30,7 @@ use crossterm::{
 use tui::{backend::CrosstermBackend, Terminal};
 
 use bottom::{
-    canvas::{self, canvas_styling::CanvasColours},
+    canvas::{self, canvas_styling::CanvasStyling},
     constants::*,
     data_conversion::*,
     options::*,
@@ -68,7 +68,7 @@ fn main() -> Result<()> {
     // FIXME: Should move this into build app or config
     let colours = {
         let colour_scheme = get_color_scheme(&matches, &config)?;
-        CanvasColours::new(colour_scheme, &config)?
+        CanvasStyling::new(colour_scheme, &config)?
     };
 
     // Create an "app" struct, which will control most of the program and store settings/state

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -66,7 +66,7 @@ fn main() -> Result<()> {
             .context("Found an issue while trying to build the widget layout.")?;
 
     // FIXME: Should move this into build app or config
-    let colours = {
+    let styling = {
         let colour_scheme = get_color_scheme(&matches, &config)?;
         CanvasStyling::new(colour_scheme, &config)?
     };
@@ -78,11 +78,11 @@ fn main() -> Result<()> {
         &widget_layout,
         default_widget_id,
         &default_widget_type_option,
-        &colours,
+        &styling,
     )?;
 
     // Create painter and set colours.
-    let mut painter = canvas::Painter::init(widget_layout, colours)?;
+    let mut painter = canvas::Painter::init(widget_layout, styling)?;
 
     // Check if the current environment is in a terminal.
     check_if_terminal();

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -82,7 +82,7 @@ enum LayoutConstraint {
 }
 
 impl Painter {
-    pub fn init(widget_layout: BottomLayout, colours: CanvasStyling) -> anyhow::Result<Self> {
+    pub fn init(widget_layout: BottomLayout, styling: CanvasStyling) -> anyhow::Result<Self> {
         // Now for modularity; we have to also initialize the base layouts!
         // We want to do this ONCE and reuse; after this we can just construct
         // based on the console size.
@@ -153,7 +153,7 @@ impl Painter {
         });
 
         let mut painter = Painter {
-            colours,
+            colours: styling,
             height: 0,
             width: 0,
             styled_help_text: Vec::default(),

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -59,7 +59,7 @@ impl FromStr for ColourScheme {
 
 /// Handles the canvas' state.
 pub struct Painter {
-    pub colours: CanvasColours,
+    pub colours: CanvasStyling,
     height: u16,
     width: u16,
     styled_help_text: Vec<Spans<'static>>,
@@ -82,7 +82,7 @@ enum LayoutConstraint {
 }
 
 impl Painter {
-    pub fn init(widget_layout: BottomLayout, colours: CanvasColours) -> anyhow::Result<Self> {
+    pub fn init(widget_layout: BottomLayout, colours: CanvasStyling) -> anyhow::Result<Self> {
         // Now for modularity; we have to also initialize the base layouts!
         // We want to do this ONCE and reuse; after this we can just construct
         // based on the console size.

--- a/src/canvas/canvas_styling.rs
+++ b/src/canvas/canvas_styling.rs
@@ -101,9 +101,9 @@ macro_rules! try_set_colour {
     ($styling:expr, $field:ident, $colours:expr, $colour_field:ident) => {
         if let Some(colour_str) = &$colours.$colour_field {
             $styling.$field = str_to_fg(colour_str).context(concat!(
-                "update ",
+                "update '",
                 stringify!($colour_field),
-                " in your config file"
+                "' in your config file"
             ))?;
         }
     };
@@ -117,9 +117,9 @@ macro_rules! try_set_colour_list {
                 .map(|s| str_to_fg(s))
                 .collect::<error::Result<Vec<Style>>>()
                 .context(concat!(
-                    "update ",
+                    "update '",
                     stringify!($colour_field),
-                    " in your config file"
+                    "' in your config file"
                 ))?;
         }
     };

--- a/src/canvas/canvas_styling.rs
+++ b/src/canvas/canvas_styling.rs
@@ -157,11 +157,12 @@ impl CanvasStyling {
     }
 
     pub fn set_colours_from_palette(&mut self, colours: &ConfigColours) -> anyhow::Result<()> {
+        // CPU
         try_set_colour!(self.avg_colour_style, colours, avg_cpu_color);
-        try_set_colour!(self.all_colour_style, colours, all_cpu_color);
         try_set_colour!(self.all_colour_style, colours, all_cpu_color);
         try_set_colour_list!(self.cpu_colour_styles, colours, cpu_core_colors);
 
+        // Memory
         #[cfg(not(target_os = "windows"))]
         try_set_colour!(self.cache_style, colours, cache_color);
 
@@ -174,36 +175,40 @@ impl CanvasStyling {
         try_set_colour!(self.ram_style, colours, ram_color);
         try_set_colour!(self.swap_style, colours, swap_color);
 
+        // Network
         try_set_colour!(self.rx_style, colours, rx_color);
         try_set_colour!(self.tx_style, colours, tx_color);
         try_set_colour!(self.total_rx_style, colours, rx_total_color);
         try_set_colour!(self.total_tx_style, colours, tx_total_color);
 
+        // Battery
         try_set_colour!(self.high_battery_colour, colours, high_battery_color);
         try_set_colour!(self.medium_battery_colour, colours, medium_battery_color);
         try_set_colour!(self.low_battery_colour, colours, low_battery_color);
 
-        try_set_colour!(self.table_header_style, colours, table_header_color);
-
+        // Widget text and graphs
         try_set_colour!(self.widget_title_style, colours, widget_title_color);
         try_set_colour!(self.graph_style, colours, graph_color);
-        try_set_colour!(self.border_style, colours, border_color);
         try_set_colour!(self.text_style, colours, text_color);
         try_set_colour!(self.disabled_text_style, colours, disabled_text_color);
+        try_set_colour!(self.border_style, colours, border_color);
         try_set_colour!(
             self.highlighted_border_style,
             colours,
             highlighted_border_color
         );
 
+        // Tables
+        try_set_colour!(self.table_header_style, colours, table_header_color);
+
         if let Some(scroll_entry_text_color) = &colours.selected_text_color {
             self.set_scroll_entry_text_color(scroll_entry_text_color)
-                .context("Update 'selected_text_color' in your config file..")?;
+                .context("update 'selected_text_color' in your config file")?;
         }
 
         if let Some(scroll_entry_bg_color) = &colours.selected_bg_color {
             self.set_scroll_entry_bg_color(scroll_entry_bg_color)
-                .context("Update 'selected_bg_color' in your config file..")?;
+                .context("update 'selected_bg_color' in your config file")?;
         }
 
         Ok(())
@@ -214,6 +219,7 @@ impl CanvasStyling {
         self.currently_selected_text_style = Style::default()
             .fg(self.currently_selected_text_colour)
             .bg(self.currently_selected_bg_colour);
+
         Ok(())
     }
 
@@ -222,13 +228,13 @@ impl CanvasStyling {
         self.currently_selected_text_style = Style::default()
             .fg(self.currently_selected_text_colour)
             .bg(self.currently_selected_bg_colour);
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod test {
-
     use super::{CanvasStyling, ColourScheme};
     use crate::Config;
     use tui::style::{Color, Style};
@@ -245,7 +251,6 @@ mod test {
         );
 
         colours.set_scroll_entry_text_color("red").unwrap();
-
         assert_eq!(
             colours.currently_selected_text_style,
             Style::default()
@@ -254,7 +259,22 @@ mod test {
         );
 
         colours.set_scroll_entry_bg_color("magenta").unwrap();
+        assert_eq!(
+            colours.currently_selected_text_style,
+            Style::default().fg(Color::Red).bg(Color::Magenta),
+        );
 
+        colours.set_scroll_entry_text_color("fake red").unwrap_err();
+        assert_eq!(
+            colours.currently_selected_text_style,
+            Style::default()
+                .fg(Color::Red)
+                .bg(colours.currently_selected_bg_colour),
+        );
+
+        colours
+            .set_scroll_entry_bg_color("fake magenta")
+            .unwrap_err();
         assert_eq!(
             colours.currently_selected_text_style,
             Style::default().fg(Color::Red).bg(Color::Magenta),
@@ -262,7 +282,7 @@ mod test {
     }
 
     #[test]
-    fn test_built_in_colour_schemes() {
+    fn built_in_colour_schemes_work() {
         let config = Config::default();
         CanvasStyling::new(ColourScheme::Default, &config).unwrap();
         CanvasStyling::new(ColourScheme::DefaultLight, &config).unwrap();

--- a/src/canvas/canvas_styling.rs
+++ b/src/canvas/canvas_styling.rs
@@ -98,9 +98,9 @@ impl Default for CanvasStyling {
 }
 
 macro_rules! try_set_colour {
-    ($styling:expr, $field:ident, $colours:expr, $colour_field:ident) => {
+    ($field:expr, $colours:expr, $colour_field:ident) => {
         if let Some(colour_str) = &$colours.$colour_field {
-            $styling.$field = str_to_fg(colour_str).context(concat!(
+            $field = str_to_fg(colour_str).context(concat!(
                 "update '",
                 stringify!($colour_field),
                 "' in your config file"
@@ -110,9 +110,9 @@ macro_rules! try_set_colour {
 }
 
 macro_rules! try_set_colour_list {
-    ($styling:expr, $field:ident, $colours:expr, $colour_field:ident) => {
+    ($field:expr, $colours:expr, $colour_field:ident) => {
         if let Some(colour_list) = &$colours.$colour_field {
-            $styling.$field = colour_list
+            $field = colour_list
                 .iter()
                 .map(|s| str_to_fg(s))
                 .collect::<error::Result<Vec<Style>>>()
@@ -157,42 +157,41 @@ impl CanvasStyling {
     }
 
     pub fn set_colours_from_palette(&mut self, colours: &ConfigColours) -> anyhow::Result<()> {
-        try_set_colour!(self, avg_colour_style, colours, avg_cpu_color);
-        try_set_colour!(self, all_colour_style, colours, all_cpu_color);
-        try_set_colour!(self, all_colour_style, colours, all_cpu_color);
-        try_set_colour_list!(self, cpu_colour_styles, colours, cpu_core_colors);
+        try_set_colour!(self.avg_colour_style, colours, avg_cpu_color);
+        try_set_colour!(self.all_colour_style, colours, all_cpu_color);
+        try_set_colour!(self.all_colour_style, colours, all_cpu_color);
+        try_set_colour_list!(self.cpu_colour_styles, colours, cpu_core_colors);
 
         #[cfg(not(target_os = "windows"))]
-        try_set_colour!(self, cache_style, colours, cache_color);
+        try_set_colour!(self.cache_style, colours, cache_color);
 
         #[cfg(feature = "zfs")]
-        try_set_colour!(self, arc_style, colours, arc_color);
+        try_set_colour!(self.arc_style, colours, arc_color);
 
         #[cfg(feature = "gpu")]
-        try_set_colour_list!(self, gpu_colour_styles, colours, gpu_core_colors);
+        try_set_colour_list!(self.gpu_colour_styles, colours, gpu_core_colors);
 
-        try_set_colour!(self, ram_style, colours, ram_color);
-        try_set_colour!(self, swap_style, colours, swap_color);
+        try_set_colour!(self.ram_style, colours, ram_color);
+        try_set_colour!(self.swap_style, colours, swap_color);
 
-        try_set_colour!(self, rx_style, colours, rx_color);
-        try_set_colour!(self, tx_style, colours, tx_color);
-        try_set_colour!(self, total_rx_style, colours, rx_total_color);
-        try_set_colour!(self, total_tx_style, colours, tx_total_color);
+        try_set_colour!(self.rx_style, colours, rx_color);
+        try_set_colour!(self.tx_style, colours, tx_color);
+        try_set_colour!(self.total_rx_style, colours, rx_total_color);
+        try_set_colour!(self.total_tx_style, colours, tx_total_color);
 
-        try_set_colour!(self, high_battery_colour, colours, high_battery_color);
-        try_set_colour!(self, medium_battery_colour, colours, medium_battery_color);
-        try_set_colour!(self, low_battery_colour, colours, low_battery_color);
+        try_set_colour!(self.high_battery_colour, colours, high_battery_color);
+        try_set_colour!(self.medium_battery_colour, colours, medium_battery_color);
+        try_set_colour!(self.low_battery_colour, colours, low_battery_color);
 
-        try_set_colour!(self, table_header_style, colours, table_header_color);
+        try_set_colour!(self.table_header_style, colours, table_header_color);
 
-        try_set_colour!(self, widget_title_style, colours, widget_title_color);
-        try_set_colour!(self, graph_style, colours, graph_color);
-        try_set_colour!(self, border_style, colours, border_color);
-        try_set_colour!(self, text_style, colours, text_color);
-        try_set_colour!(self, disabled_text_style, colours, disabled_text_color);
+        try_set_colour!(self.widget_title_style, colours, widget_title_color);
+        try_set_colour!(self.graph_style, colours, graph_color);
+        try_set_colour!(self.border_style, colours, border_color);
+        try_set_colour!(self.text_style, colours, text_color);
+        try_set_colour!(self.disabled_text_style, colours, disabled_text_color);
         try_set_colour!(
-            self,
-            highlighted_border_style,
+            self.highlighted_border_style,
             colours,
             highlighted_border_color
         );

--- a/src/canvas/canvas_styling/colour_utils.rs
+++ b/src/canvas/canvas_styling/colour_utils.rs
@@ -200,6 +200,7 @@ mod test {
 
     #[test]
     fn valid_hex_colours() {
+        // Check hex with 6 characters.
         assert_eq!(
             convert_hex_to_color("#ffffff").unwrap(),
             Color::Rgb(255, 255, 255)
@@ -216,6 +217,7 @@ mod test {
             Color::Rgb(18, 58, 188)
         );
 
+        // Check hex with 3 characters.
         assert_eq!(
             convert_hex_to_color("#fff").unwrap(),
             Color::Rgb(255, 255, 255)

--- a/src/components/data_table/styling.rs
+++ b/src/components/data_table/styling.rs
@@ -1,6 +1,6 @@
 use tui::style::Style;
 
-use crate::canvas::canvas_styling::CanvasColours;
+use crate::canvas::canvas_styling::CanvasStyling;
 
 #[derive(Default)]
 pub struct DataTableStyling {
@@ -13,7 +13,7 @@ pub struct DataTableStyling {
 }
 
 impl DataTableStyling {
-    pub fn from_colours(colours: &CanvasColours) -> Self {
+    pub fn from_colours(colours: &CanvasStyling) -> Self {
         Self {
             header_style: colours.table_header_style,
             border_style: colours.border_style,

--- a/src/options.rs
+++ b/src/options.rs
@@ -18,7 +18,7 @@ use starship_battery::Manager;
 
 use crate::{
     app::{filter::Filter, layout_manager::*, *},
-    canvas::{canvas_styling::CanvasColours, ColourScheme},
+    canvas::{canvas_styling::CanvasStyling, ColourScheme},
     constants::*,
     units::data_units::DataUnit,
     utils::error::{self, BottomError},
@@ -172,7 +172,7 @@ macro_rules! is_flag_enabled {
 pub fn build_app(
     matches: &ArgMatches, config: &mut Config, widget_layout: &BottomLayout,
     default_widget_id: u64, default_widget_type_option: &Option<BottomWidgetType>,
-    colours: &CanvasColours,
+    colours: &CanvasStyling,
 ) -> Result<App> {
     use BottomWidgetType::*;
 
@@ -872,12 +872,12 @@ mod test {
     use clap::ArgMatches;
 
     use super::{get_color_scheme, get_widget_layout, Config};
-    use crate::{app::App, canvas::canvas_styling::CanvasColours};
+    use crate::{app::App, canvas::canvas_styling::CanvasStyling};
 
     fn create_app(mut config: Config, matches: ArgMatches) -> App {
         let (layout, id, ty) = get_widget_layout(&matches, &config).unwrap();
         let colours =
-            CanvasColours::new(get_color_scheme(&matches, &config).unwrap(), &config).unwrap();
+            CanvasStyling::new(get_color_scheme(&matches, &config).unwrap(), &config).unwrap();
 
         super::build_app(&matches, &mut config, &layout, id, &ty, &colours).unwrap()
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -172,7 +172,7 @@ macro_rules! is_flag_enabled {
 pub fn build_app(
     matches: &ArgMatches, config: &mut Config, widget_layout: &BottomLayout,
     default_widget_id: u64, default_widget_type_option: &Option<BottomWidgetType>,
-    colours: &CanvasStyling,
+    styling: &CanvasStyling,
 ) -> Result<App> {
     use BottomWidgetType::*;
 
@@ -321,7 +321,7 @@ pub fn build_app(
                                     &app_config_fields,
                                     default_time_value,
                                     autohide_timer,
-                                    colours,
+                                    styling,
                                 ),
                             );
                         }
@@ -354,7 +354,7 @@ pub fn build_app(
                                     &app_config_fields,
                                     mode,
                                     table_config,
-                                    colours,
+                                    styling,
                                     &proc_columns,
                                 ),
                             );
@@ -362,13 +362,13 @@ pub fn build_app(
                         Disk => {
                             disk_state_map.insert(
                                 widget.widget_id,
-                                DiskTableWidget::new(&app_config_fields, colours),
+                                DiskTableWidget::new(&app_config_fields, styling),
                             );
                         }
                         Temp => {
                             temp_state_map.insert(
                                 widget.widget_id,
-                                TempWidgetState::new(&app_config_fields, colours),
+                                TempWidgetState::new(&app_config_fields, styling),
                             );
                         }
                         Battery => {
@@ -868,7 +868,6 @@ fn get_retention_ms(matches: &ArgMatches, config: &Config) -> error::Result<u64>
 
 #[cfg(test)]
 mod test {
-
     use clap::ArgMatches;
 
     use super::{get_color_scheme, get_widget_layout, Config};
@@ -876,10 +875,10 @@ mod test {
 
     fn create_app(mut config: Config, matches: ArgMatches) -> App {
         let (layout, id, ty) = get_widget_layout(&matches, &config).unwrap();
-        let colours =
+        let styling =
             CanvasStyling::new(get_color_scheme(&matches, &config).unwrap(), &config).unwrap();
 
-        super::build_app(&matches, &mut config, &layout, id, &ty, &colours).unwrap()
+        super::build_app(&matches, &mut config, &layout, id, &ty, &styling).unwrap()
     }
 
     // TODO: There's probably a better way to create clap options AND unify together to avoid the possibility of

--- a/src/widgets/cpu_graph.rs
+++ b/src/widgets/cpu_graph.rs
@@ -5,7 +5,7 @@ use tui::{style::Style, text::Text, widgets::Row};
 
 use crate::{
     app::{data_harvester::cpu::CpuDataType, AppConfigFields},
-    canvas::{canvas_styling::CanvasColours, Painter},
+    canvas::{canvas_styling::CanvasStyling, Painter},
     components::data_table::{
         Column, ColumnHeader, DataTable, DataTableColumn, DataTableProps, DataTableStyling,
         DataToCell,
@@ -22,7 +22,7 @@ pub struct CpuWidgetStyling {
 }
 
 impl CpuWidgetStyling {
-    fn from_colours(colours: &CanvasColours) -> Self {
+    fn from_colours(colours: &CanvasStyling) -> Self {
         let entries = if colours.cpu_colour_styles.is_empty() {
             vec![Style::default()]
         } else {
@@ -166,7 +166,7 @@ pub struct CpuWidgetState {
 impl CpuWidgetState {
     pub fn new(
         config: &AppConfigFields, current_display_time: u64, autohide_timer: Option<Instant>,
-        colours: &CanvasColours,
+        colours: &CanvasStyling,
     ) -> Self {
         const COLUMNS: [Column<CpuWidgetColumn>; 2] = [
             Column::soft(CpuWidgetColumn::CPU, Some(0.5)),

--- a/src/widgets/disk_table.rs
+++ b/src/widgets/disk_table.rs
@@ -5,7 +5,7 @@ use tui::text::Text;
 
 use crate::{
     app::AppConfigFields,
-    canvas::canvas_styling::CanvasColours,
+    canvas::canvas_styling::CanvasStyling,
     components::data_table::{
         ColumnHeader, DataTableColumn, DataTableProps, DataTableStyling, DataToCell, SortColumn,
         SortDataTable, SortDataTableProps, SortOrder, SortsRow,
@@ -213,7 +213,7 @@ impl SortsRow for DiskWidgetColumn {
 }
 
 impl DiskTableWidget {
-    pub fn new(config: &AppConfigFields, colours: &CanvasColours) -> Self {
+    pub fn new(config: &AppConfigFields, colours: &CanvasStyling) -> Self {
         let columns = [
             SortColumn::soft(DiskWidgetColumn::Disk, Some(0.2)),
             SortColumn::soft(DiskWidgetColumn::Mount, Some(0.2)),

--- a/src/widgets/process_table.rs
+++ b/src/widgets/process_table.rs
@@ -1119,14 +1119,14 @@ mod test {
 
     fn init_state(table_config: ProcTableConfig, columns: &[ProcWidgetColumn]) -> ProcWidgetState {
         let config = AppConfigFields::default();
-        let colours = CanvasStyling::default();
+        let styling = CanvasStyling::default();
         let columns = Some(columns.iter().cloned().collect());
 
         ProcWidgetState::new(
             &config,
             ProcWidgetMode::Normal,
             table_config,
-            &colours,
+            &styling,
             &columns,
         )
     }

--- a/src/widgets/process_table.rs
+++ b/src/widgets/process_table.rs
@@ -12,7 +12,7 @@ use crate::{
         query::*,
         AppConfigFields, AppSearchState,
     },
-    canvas::canvas_styling::CanvasColours,
+    canvas::canvas_styling::CanvasStyling,
     components::data_table::{
         Column, ColumnHeader, ColumnWidthBounds, DataTable, DataTableColumn, DataTableProps,
         DataTableStyling, SortColumn, SortDataTable, SortDataTableProps, SortOrder, SortsRow,
@@ -177,7 +177,7 @@ pub struct ProcWidgetState {
 }
 
 impl ProcWidgetState {
-    fn new_sort_table(config: &AppConfigFields, colours: &CanvasColours) -> SortTable {
+    fn new_sort_table(config: &AppConfigFields, colours: &CanvasStyling) -> SortTable {
         const COLUMNS: [Column<SortTableColumn>; 1] = [Column::hard(SortTableColumn, 7)];
 
         let props = DataTableProps {
@@ -194,7 +194,7 @@ impl ProcWidgetState {
     }
 
     fn new_process_table(
-        config: &AppConfigFields, colours: &CanvasColours, columns: Vec<SortColumn<ProcColumn>>,
+        config: &AppConfigFields, colours: &CanvasStyling, columns: Vec<SortColumn<ProcColumn>>,
         default_index: usize, default_order: SortOrder,
     ) -> ProcessTable {
         let inner_props = DataTableProps {
@@ -217,7 +217,7 @@ impl ProcWidgetState {
 
     pub fn new(
         config: &AppConfigFields, mode: ProcWidgetMode, table_config: ProcTableConfig,
-        colours: &CanvasColours, config_columns: &Option<IndexSet<ProcWidgetColumn>>,
+        colours: &CanvasStyling, config_columns: &Option<IndexSet<ProcWidgetColumn>>,
     ) -> Self {
         let process_search_state = {
             let mut pss = ProcessSearchState::default();
@@ -1119,7 +1119,7 @@ mod test {
 
     fn init_state(table_config: ProcTableConfig, columns: &[ProcWidgetColumn]) -> ProcWidgetState {
         let config = AppConfigFields::default();
-        let colours = CanvasColours::default();
+        let colours = CanvasStyling::default();
         let columns = Some(columns.iter().cloned().collect());
 
         ProcWidgetState::new(

--- a/src/widgets/temperature_table.rs
+++ b/src/widgets/temperature_table.rs
@@ -6,7 +6,7 @@ use tui::text::Text;
 
 use crate::{
     app::{data_harvester::temperature::TemperatureType, AppConfigFields},
-    canvas::canvas_styling::CanvasColours,
+    canvas::canvas_styling::CanvasStyling,
     components::data_table::{
         ColumnHeader, DataTableColumn, DataTableProps, DataTableStyling, DataToCell, SortColumn,
         SortDataTable, SortDataTableProps, SortOrder, SortsRow,
@@ -99,7 +99,7 @@ pub struct TempWidgetState {
 }
 
 impl TempWidgetState {
-    pub fn new(config: &AppConfigFields, colours: &CanvasColours) -> Self {
+    pub fn new(config: &AppConfigFields, colours: &CanvasStyling) -> Self {
         let columns = [
             SortColumn::soft(TempWidgetColumn::Sensor, Some(0.8)),
             SortColumn::soft(TempWidgetColumn::Temp, None).default_descending(),


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Greatly simplify a bunch of logic around setting colours. This also renames `CanvasColours` to `CanvasStyling` since we'll probably add non-colour-related text styling fields to the struct (e.g. bold modifiers).

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
