### PR TITLE
refactor: remove unused typed-builder proc macro usage in options

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -11,7 +11,6 @@ use indexmap::IndexSet;
 use layout_options::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use typed_builder::*;
 
 #[cfg(feature = "battery")]
 use starship_battery::Manager;
@@ -44,7 +43,7 @@ pub struct Config {
     pub processes: Option<ProcessConfig>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ConfigFlags {
     pub hide_avg_cpu: Option<bool>,
     pub dot_marker: Option<bool>,


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
