### PR TITLE
refactor: remove TypedBuilder for col row

### DIFF
--- a/src/app/layout_manager.rs
+++ b/src/app/layout_manager.rs
@@ -538,161 +538,143 @@ impl BottomLayout {
             vec![
                 BottomCol::builder()
                     .canvas_handle_width(true)
-                    .children(vec![BottomColRow::builder()
-                        .canvas_handle_height(true)
-                        .children(vec![BottomWidget::builder()
-                            .canvas_handle_width(true)
-                            .widget_type(BottomWidgetType::Disk)
-                            .widget_id(4)
-                            .up_neighbour(Some(100))
-                            .left_neighbour(Some(8))
-                            .right_neighbour(Some(DEFAULT_WIDGET_ID + 2))
-                            .build()])
+                    .children(vec![BottomColRow::new(vec![BottomWidget::builder()
+                        .canvas_handle_width(true)
+                        .widget_type(BottomWidgetType::Disk)
+                        .widget_id(4)
+                        .up_neighbour(Some(100))
+                        .left_neighbour(Some(8))
+                        .right_neighbour(Some(DEFAULT_WIDGET_ID + 2))
                         .build()])
+                    .canvas_handle_height(true)])
                     .build(),
                 BottomCol::builder()
                     .canvas_handle_width(true)
                     .children(vec![
-                        BottomColRow::builder()
-                            .canvas_handle_height(true)
-                            .total_widget_ratio(3)
-                            .children(vec![
-                                BottomWidget::builder()
-                                    .canvas_handle_width(true)
-                                    .widget_type(BottomWidgetType::ProcSort)
-                                    .widget_id(DEFAULT_WIDGET_ID + 2)
-                                    .up_neighbour(Some(100))
-                                    .down_neighbour(Some(DEFAULT_WIDGET_ID + 1))
-                                    .left_neighbour(Some(4))
-                                    .right_neighbour(Some(DEFAULT_WIDGET_ID))
-                                    .width_ratio(1)
-                                    .parent_reflector(Some((WidgetDirection::Right, 2)))
-                                    .build(),
-                                BottomWidget::builder()
-                                    .canvas_handle_width(true)
-                                    .widget_type(BottomWidgetType::Proc)
-                                    .widget_id(DEFAULT_WIDGET_ID)
-                                    .up_neighbour(Some(100))
-                                    .down_neighbour(Some(DEFAULT_WIDGET_ID + 1))
-                                    .left_neighbour(Some(DEFAULT_WIDGET_ID + 2))
-                                    .right_neighbour(Some(7))
-                                    .width_ratio(2)
-                                    .build(),
-                            ])
-                            .build(),
-                        BottomColRow::builder()
-                            .canvas_handle_height(true)
-                            .children(vec![BottomWidget::builder()
+                        BottomColRow::new(vec![
+                            BottomWidget::builder()
                                 .canvas_handle_width(true)
-                                .widget_type(BottomWidgetType::ProcSearch)
-                                .widget_id(DEFAULT_WIDGET_ID + 1)
-                                .up_neighbour(Some(DEFAULT_WIDGET_ID))
+                                .widget_type(BottomWidgetType::ProcSort)
+                                .widget_id(DEFAULT_WIDGET_ID + 2)
+                                .up_neighbour(Some(100))
+                                .down_neighbour(Some(DEFAULT_WIDGET_ID + 1))
                                 .left_neighbour(Some(4))
+                                .right_neighbour(Some(DEFAULT_WIDGET_ID))
+                                .width_ratio(1)
+                                .parent_reflector(Some((WidgetDirection::Right, 2)))
+                                .build(),
+                            BottomWidget::builder()
+                                .canvas_handle_width(true)
+                                .widget_type(BottomWidgetType::Proc)
+                                .widget_id(DEFAULT_WIDGET_ID)
+                                .up_neighbour(Some(100))
+                                .down_neighbour(Some(DEFAULT_WIDGET_ID + 1))
+                                .left_neighbour(Some(DEFAULT_WIDGET_ID + 2))
                                 .right_neighbour(Some(7))
-                                .parent_reflector(Some((WidgetDirection::Up, 1)))
-                                .build()])
-                            .build(),
+                                .width_ratio(2)
+                                .build(),
+                        ])
+                        .canvas_handle_height(true)
+                        .total_widget_ratio(3),
+                        BottomColRow::new(vec![BottomWidget::builder()
+                            .canvas_handle_width(true)
+                            .widget_type(BottomWidgetType::ProcSearch)
+                            .widget_id(DEFAULT_WIDGET_ID + 1)
+                            .up_neighbour(Some(DEFAULT_WIDGET_ID))
+                            .left_neighbour(Some(4))
+                            .right_neighbour(Some(7))
+                            .parent_reflector(Some((WidgetDirection::Up, 1)))
+                            .build()])
+                        .canvas_handle_height(true),
                     ])
                     .build(),
                 BottomCol::builder()
                     .canvas_handle_width(true)
-                    .children(vec![BottomColRow::builder()
-                        .canvas_handle_height(true)
-                        .children(vec![BottomWidget::builder()
-                            .canvas_handle_width(true)
-                            .widget_type(BottomWidgetType::Temp)
-                            .widget_id(7)
-                            .up_neighbour(Some(100))
-                            .left_neighbour(Some(DEFAULT_WIDGET_ID))
-                            .right_neighbour(Some(8))
-                            .build()])
+                    .children(vec![BottomColRow::new(vec![BottomWidget::builder()
+                        .canvas_handle_width(true)
+                        .widget_type(BottomWidgetType::Temp)
+                        .widget_id(7)
+                        .up_neighbour(Some(100))
+                        .left_neighbour(Some(DEFAULT_WIDGET_ID))
+                        .right_neighbour(Some(8))
                         .build()])
+                    .canvas_handle_height(true)])
                     .build(),
                 BottomCol::builder()
                     .canvas_handle_width(true)
-                    .children(vec![BottomColRow::builder()
-                        .canvas_handle_height(true)
-                        .children(vec![BottomWidget::builder()
-                            .canvas_handle_width(true)
-                            .widget_type(BottomWidgetType::Battery)
-                            .widget_id(8)
-                            .up_neighbour(Some(100))
-                            .left_neighbour(Some(7))
-                            .right_neighbour(Some(4))
-                            .build()])
+                    .children(vec![BottomColRow::new(vec![BottomWidget::builder()
+                        .canvas_handle_width(true)
+                        .widget_type(BottomWidgetType::Battery)
+                        .widget_id(8)
+                        .up_neighbour(Some(100))
+                        .left_neighbour(Some(7))
+                        .right_neighbour(Some(4))
                         .build()])
+                    .canvas_handle_height(true)])
                     .build(),
             ]
         } else {
             vec![
                 BottomCol::builder()
                     .canvas_handle_width(true)
-                    .children(vec![BottomColRow::builder()
-                        .canvas_handle_height(true)
-                        .children(vec![BottomWidget::builder()
-                            .canvas_handle_width(true)
-                            .widget_type(BottomWidgetType::Disk)
-                            .widget_id(4)
-                            .up_neighbour(Some(100))
-                            .left_neighbour(Some(7))
-                            .right_neighbour(Some(DEFAULT_WIDGET_ID + 2))
-                            .build()])
+                    .children(vec![BottomColRow::new(vec![BottomWidget::builder()
+                        .canvas_handle_width(true)
+                        .widget_type(BottomWidgetType::Disk)
+                        .widget_id(4)
+                        .up_neighbour(Some(100))
+                        .left_neighbour(Some(7))
+                        .right_neighbour(Some(DEFAULT_WIDGET_ID + 2))
                         .build()])
+                    .canvas_handle_height(true)])
                     .build(),
                 BottomCol::builder()
                     .canvas_handle_width(true)
                     .children(vec![
-                        BottomColRow::builder()
-                            .canvas_handle_height(true)
-                            .children(vec![
-                                BottomWidget::builder()
-                                    .canvas_handle_width(true)
-                                    .widget_type(BottomWidgetType::ProcSort)
-                                    .widget_id(DEFAULT_WIDGET_ID + 2)
-                                    .up_neighbour(Some(100))
-                                    .down_neighbour(Some(DEFAULT_WIDGET_ID + 1))
-                                    .left_neighbour(Some(4))
-                                    .right_neighbour(Some(DEFAULT_WIDGET_ID))
-                                    .parent_reflector(Some((WidgetDirection::Right, 2)))
-                                    .build(),
-                                BottomWidget::builder()
-                                    .canvas_handle_width(true)
-                                    .widget_type(BottomWidgetType::Proc)
-                                    .widget_id(DEFAULT_WIDGET_ID)
-                                    .up_neighbour(Some(100))
-                                    .down_neighbour(Some(DEFAULT_WIDGET_ID + 1))
-                                    .left_neighbour(Some(DEFAULT_WIDGET_ID + 2))
-                                    .right_neighbour(Some(7))
-                                    .build(),
-                            ])
-                            .build(),
-                        BottomColRow::builder()
-                            .canvas_handle_height(true)
-                            .children(vec![BottomWidget::builder()
+                        BottomColRow::new(vec![
+                            BottomWidget::builder()
                                 .canvas_handle_width(true)
-                                .widget_type(BottomWidgetType::ProcSearch)
-                                .widget_id(DEFAULT_WIDGET_ID + 1)
-                                .up_neighbour(Some(DEFAULT_WIDGET_ID))
+                                .widget_type(BottomWidgetType::ProcSort)
+                                .widget_id(DEFAULT_WIDGET_ID + 2)
+                                .up_neighbour(Some(100))
+                                .down_neighbour(Some(DEFAULT_WIDGET_ID + 1))
                                 .left_neighbour(Some(4))
+                                .right_neighbour(Some(DEFAULT_WIDGET_ID))
+                                .parent_reflector(Some((WidgetDirection::Right, 2)))
+                                .build(),
+                            BottomWidget::builder()
+                                .canvas_handle_width(true)
+                                .widget_type(BottomWidgetType::Proc)
+                                .widget_id(DEFAULT_WIDGET_ID)
+                                .up_neighbour(Some(100))
+                                .down_neighbour(Some(DEFAULT_WIDGET_ID + 1))
+                                .left_neighbour(Some(DEFAULT_WIDGET_ID + 2))
                                 .right_neighbour(Some(7))
-                                .parent_reflector(Some((WidgetDirection::Up, 1)))
-                                .build()])
-                            .build(),
+                                .build(),
+                        ])
+                        .canvas_handle_height(true),
+                        BottomColRow::new(vec![BottomWidget::builder()
+                            .canvas_handle_width(true)
+                            .widget_type(BottomWidgetType::ProcSearch)
+                            .widget_id(DEFAULT_WIDGET_ID + 1)
+                            .up_neighbour(Some(DEFAULT_WIDGET_ID))
+                            .left_neighbour(Some(4))
+                            .right_neighbour(Some(7))
+                            .parent_reflector(Some((WidgetDirection::Up, 1)))
+                            .build()])
+                        .canvas_handle_height(true),
                     ])
                     .build(),
                 BottomCol::builder()
                     .canvas_handle_width(true)
-                    .children(vec![BottomColRow::builder()
-                        .canvas_handle_height(true)
-                        .children(vec![BottomWidget::builder()
-                            .canvas_handle_width(true)
-                            .widget_type(BottomWidgetType::Temp)
-                            .widget_id(7)
-                            .up_neighbour(Some(100))
-                            .left_neighbour(Some(DEFAULT_WIDGET_ID))
-                            .right_neighbour(Some(4))
-                            .build()])
+                    .children(vec![BottomColRow::new(vec![BottomWidget::builder()
+                        .canvas_handle_width(true)
+                        .widget_type(BottomWidgetType::Temp)
+                        .widget_id(7)
+                        .up_neighbour(Some(100))
+                        .left_neighbour(Some(DEFAULT_WIDGET_ID))
+                        .right_neighbour(Some(4))
                         .build()])
+                    .canvas_handle_height(true)])
                     .build(),
             ]
         };
@@ -704,57 +686,51 @@ impl BottomLayout {
                     .canvas_handle_height(true)
                     .children(vec![BottomCol::builder()
                         .canvas_handle_width(true)
-                        .children(vec![BottomColRow::builder()
-                            .canvas_handle_height(true)
-                            .children(vec![BottomWidget::builder()
-                                .canvas_handle_width(true)
-                                .widget_type(BottomWidgetType::BasicCpu)
-                                .widget_id(1)
-                                .down_neighbour(Some(2))
-                                .build()])
+                        .children(vec![BottomColRow::new(vec![BottomWidget::builder()
+                            .canvas_handle_width(true)
+                            .widget_type(BottomWidgetType::BasicCpu)
+                            .widget_id(1)
+                            .down_neighbour(Some(2))
                             .build()])
+                        .canvas_handle_height(true)])
                         .build()])
                     .build(),
                 BottomRow::builder()
                     .canvas_handle_height(true)
                     .children(vec![BottomCol::builder()
                         .canvas_handle_width(true)
-                        .children(vec![BottomColRow::builder()
-                            .canvas_handle_height(true)
-                            .children(vec![
-                                BottomWidget::builder()
-                                    .canvas_handle_width(true)
-                                    .widget_type(BottomWidgetType::BasicMem)
-                                    .widget_id(2)
-                                    .up_neighbour(Some(1))
-                                    .down_neighbour(Some(100))
-                                    .right_neighbour(Some(3))
-                                    .build(),
-                                BottomWidget::builder()
-                                    .canvas_handle_width(true)
-                                    .widget_type(BottomWidgetType::BasicNet)
-                                    .widget_id(3)
-                                    .up_neighbour(Some(1))
-                                    .down_neighbour(Some(100))
-                                    .left_neighbour(Some(2))
-                                    .build(),
-                            ])
-                            .build()])
+                        .children(vec![BottomColRow::new(vec![
+                            BottomWidget::builder()
+                                .canvas_handle_width(true)
+                                .widget_type(BottomWidgetType::BasicMem)
+                                .widget_id(2)
+                                .up_neighbour(Some(1))
+                                .down_neighbour(Some(100))
+                                .right_neighbour(Some(3))
+                                .build(),
+                            BottomWidget::builder()
+                                .canvas_handle_width(true)
+                                .widget_type(BottomWidgetType::BasicNet)
+                                .widget_id(3)
+                                .up_neighbour(Some(1))
+                                .down_neighbour(Some(100))
+                                .left_neighbour(Some(2))
+                                .build(),
+                        ])
+                        .canvas_handle_height(true)])
                         .build()])
                     .build(),
                 BottomRow::builder()
                     .canvas_handle_height(true)
                     .children(vec![BottomCol::builder()
                         .canvas_handle_width(true)
-                        .children(vec![BottomColRow::builder()
-                            .canvas_handle_height(true)
-                            .children(vec![BottomWidget::builder()
-                                .canvas_handle_width(true)
-                                .widget_type(BottomWidgetType::BasicTables)
-                                .widget_id(100)
-                                .up_neighbour(Some(2))
-                                .build()])
+                        .children(vec![BottomColRow::new(vec![BottomWidget::builder()
+                            .canvas_handle_width(true)
+                            .widget_type(BottomWidgetType::BasicTables)
+                            .widget_id(100)
+                            .up_neighbour(Some(2))
                             .build()])
+                        .canvas_handle_height(true)])
                         .build()])
                     .build(),
                 BottomRow::builder()
@@ -804,21 +780,45 @@ pub struct BottomCol {
     pub flex_grow: bool,
 }
 
-#[derive(Clone, Default, Debug, TypedBuilder)]
+#[derive(Clone, Default, Debug)]
 pub struct BottomColRow {
     pub children: Vec<BottomWidget>,
-
-    #[builder(default = 1)]
     pub total_widget_ratio: u32,
-
-    #[builder(default = 1)]
     pub col_row_height_ratio: u32,
-
-    #[builder(default = false)]
     pub canvas_handle_height: bool,
-
-    #[builder(default = false)]
     pub flex_grow: bool,
+}
+
+impl BottomColRow {
+    pub(crate) fn new(children: Vec<BottomWidget>) -> Self {
+        Self {
+            children,
+            total_widget_ratio: 1,
+            col_row_height_ratio: 1,
+            canvas_handle_height: false,
+            flex_grow: false,
+        }
+    }
+
+    pub(crate) fn total_widget_ratio(mut self, total_widget_ratio: u32) -> Self {
+        self.total_widget_ratio = total_widget_ratio;
+        self
+    }
+
+    pub(crate) fn col_row_height_ratio(mut self, col_row_height_ratio: u32) -> Self {
+        self.col_row_height_ratio = col_row_height_ratio;
+        self
+    }
+
+    pub(crate) fn canvas_handle_height(mut self, canvas_handle_height: bool) -> Self {
+        self.canvas_handle_height = canvas_handle_height;
+        self
+    }
+
+    pub(crate) fn flex_grow(mut self, flex_grow: bool) -> Self {
+        self.flex_grow = flex_grow;
+        self
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/src/options/layout_options.rs
+++ b/src/options/layout_options.rs
@@ -59,49 +59,39 @@ impl Row {
                                 BottomCol::builder()
                                     .col_width_ratio(width_ratio)
                                     .children(if left_legend {
-                                        vec![BottomColRow::builder()
-                                            .total_widget_ratio(20)
-                                            .children(vec![
-                                                BottomWidget::builder()
-                                                    .width_ratio(3)
-                                                    .widget_type(BottomWidgetType::CpuLegend)
-                                                    .widget_id(*iter_id)
-                                                    .canvas_handle_width(true)
-                                                    .parent_reflector(Some((
-                                                        WidgetDirection::Right,
-                                                        1,
-                                                    )))
-                                                    .build(),
-                                                BottomWidget::builder()
-                                                    .width_ratio(17)
-                                                    .widget_type(BottomWidgetType::Cpu)
-                                                    .widget_id(cpu_id)
-                                                    .flex_grow(true)
-                                                    .build(),
-                                            ])
-                                            .build()]
+                                        vec![BottomColRow::new(vec![
+                                            BottomWidget::builder()
+                                                .width_ratio(3)
+                                                .widget_type(BottomWidgetType::CpuLegend)
+                                                .widget_id(*iter_id)
+                                                .canvas_handle_width(true)
+                                                .parent_reflector(Some((WidgetDirection::Right, 1)))
+                                                .build(),
+                                            BottomWidget::builder()
+                                                .width_ratio(17)
+                                                .widget_type(BottomWidgetType::Cpu)
+                                                .widget_id(cpu_id)
+                                                .flex_grow(true)
+                                                .build(),
+                                        ])
+                                        .total_widget_ratio(20)]
                                     } else {
-                                        vec![BottomColRow::builder()
-                                            .total_widget_ratio(20)
-                                            .children(vec![
-                                                BottomWidget::builder()
-                                                    .width_ratio(17)
-                                                    .widget_type(BottomWidgetType::Cpu)
-                                                    .widget_id(cpu_id)
-                                                    .flex_grow(true)
-                                                    .build(),
-                                                BottomWidget::builder()
-                                                    .width_ratio(3)
-                                                    .widget_type(BottomWidgetType::CpuLegend)
-                                                    .widget_id(*iter_id)
-                                                    .canvas_handle_width(true)
-                                                    .parent_reflector(Some((
-                                                        WidgetDirection::Left,
-                                                        1,
-                                                    )))
-                                                    .build(),
-                                            ])
-                                            .build()]
+                                        vec![BottomColRow::new(vec![
+                                            BottomWidget::builder()
+                                                .width_ratio(17)
+                                                .widget_type(BottomWidgetType::Cpu)
+                                                .widget_id(cpu_id)
+                                                .flex_grow(true)
+                                                .build(),
+                                            BottomWidget::builder()
+                                                .width_ratio(3)
+                                                .widget_type(BottomWidgetType::CpuLegend)
+                                                .widget_id(*iter_id)
+                                                .canvas_handle_width(true)
+                                                .parent_reflector(Some((WidgetDirection::Left, 1)))
+                                                .build(),
+                                        ])
+                                        .total_widget_ratio(20)]
                                     })
                                     .build()
                             }
@@ -113,46 +103,37 @@ impl Row {
                                     .total_col_row_ratio(2)
                                     .col_width_ratio(width_ratio)
                                     .children(vec![
-                                        BottomColRow::builder()
-                                            .children(vec![
-                                                BottomWidget::builder()
-                                                    .widget_type(BottomWidgetType::ProcSort)
-                                                    .widget_id(*iter_id)
-                                                    .canvas_handle_width(true)
-                                                    .parent_reflector(Some((
-                                                        WidgetDirection::Right,
-                                                        2,
-                                                    )))
-                                                    .width_ratio(1)
-                                                    .build(),
-                                                BottomWidget::builder()
-                                                    .widget_type(BottomWidgetType::Proc)
-                                                    .widget_id(proc_id)
-                                                    .width_ratio(2)
-                                                    .build(),
-                                            ])
-                                            .total_widget_ratio(3)
-                                            .flex_grow(true)
-                                            .build(),
-                                        BottomColRow::builder()
-                                            .children(vec![BottomWidget::builder()
-                                                .widget_type(BottomWidgetType::ProcSearch)
-                                                .widget_id(proc_search_id)
-                                                .parent_reflector(Some((WidgetDirection::Up, 1)))
-                                                .build()])
-                                            .canvas_handle_height(true)
-                                            .build(),
+                                        BottomColRow::new(vec![
+                                            BottomWidget::builder()
+                                                .widget_type(BottomWidgetType::ProcSort)
+                                                .widget_id(*iter_id)
+                                                .canvas_handle_width(true)
+                                                .parent_reflector(Some((WidgetDirection::Right, 2)))
+                                                .width_ratio(1)
+                                                .build(),
+                                            BottomWidget::builder()
+                                                .widget_type(BottomWidgetType::Proc)
+                                                .widget_id(proc_id)
+                                                .width_ratio(2)
+                                                .build(),
+                                        ])
+                                        .total_widget_ratio(3)
+                                        .flex_grow(true),
+                                        BottomColRow::new(vec![BottomWidget::builder()
+                                            .widget_type(BottomWidgetType::ProcSearch)
+                                            .widget_id(proc_search_id)
+                                            .parent_reflector(Some((WidgetDirection::Up, 1)))
+                                            .build()])
+                                        .canvas_handle_height(true),
                                     ])
                                     .build()
                             }
                             _ => BottomCol::builder()
                                 .col_width_ratio(width_ratio)
-                                .children(vec![BottomColRow::builder()
-                                    .children(vec![BottomWidget::builder()
-                                        .widget_type(widget_type)
-                                        .widget_id(*iter_id)
-                                        .build()])
-                                    .build()])
+                                .children(vec![BottomColRow::new(vec![BottomWidget::builder()
+                                    .widget_type(widget_type)
+                                    .widget_id(*iter_id)
+                                    .build()])])
                                 .build(),
                         });
                     }
@@ -194,53 +175,49 @@ impl Row {
                                     *iter_id += 1;
                                     if left_legend {
                                         col_row_children.push(
-                                            BottomColRow::builder()
-                                                .col_row_height_ratio(col_row_height_ratio)
-                                                .total_widget_ratio(20)
-                                                .children(vec![
-                                                    BottomWidget::builder()
-                                                        .width_ratio(3)
-                                                        .widget_type(BottomWidgetType::CpuLegend)
-                                                        .widget_id(*iter_id)
-                                                        .canvas_handle_width(true)
-                                                        .parent_reflector(Some((
-                                                            WidgetDirection::Right,
-                                                            1,
-                                                        )))
-                                                        .build(),
-                                                    BottomWidget::builder()
-                                                        .width_ratio(17)
-                                                        .widget_type(BottomWidgetType::Cpu)
-                                                        .widget_id(cpu_id)
-                                                        .flex_grow(true)
-                                                        .build(),
-                                                ])
-                                                .build(),
+                                            BottomColRow::new(vec![
+                                                BottomWidget::builder()
+                                                    .width_ratio(3)
+                                                    .widget_type(BottomWidgetType::CpuLegend)
+                                                    .widget_id(*iter_id)
+                                                    .canvas_handle_width(true)
+                                                    .parent_reflector(Some((
+                                                        WidgetDirection::Right,
+                                                        1,
+                                                    )))
+                                                    .build(),
+                                                BottomWidget::builder()
+                                                    .width_ratio(17)
+                                                    .widget_type(BottomWidgetType::Cpu)
+                                                    .widget_id(cpu_id)
+                                                    .flex_grow(true)
+                                                    .build(),
+                                            ])
+                                            .col_row_height_ratio(col_row_height_ratio)
+                                            .total_widget_ratio(20),
                                         );
                                     } else {
                                         col_row_children.push(
-                                            BottomColRow::builder()
-                                                .col_row_height_ratio(col_row_height_ratio)
-                                                .total_widget_ratio(20)
-                                                .children(vec![
-                                                    BottomWidget::builder()
-                                                        .width_ratio(17)
-                                                        .widget_type(BottomWidgetType::Cpu)
-                                                        .widget_id(cpu_id)
-                                                        .flex_grow(true)
-                                                        .build(),
-                                                    BottomWidget::builder()
-                                                        .width_ratio(3)
-                                                        .widget_type(BottomWidgetType::CpuLegend)
-                                                        .widget_id(*iter_id)
-                                                        .canvas_handle_width(true)
-                                                        .parent_reflector(Some((
-                                                            WidgetDirection::Left,
-                                                            1,
-                                                        )))
-                                                        .build(),
-                                                ])
-                                                .build(),
+                                            BottomColRow::new(vec![
+                                                BottomWidget::builder()
+                                                    .width_ratio(17)
+                                                    .widget_type(BottomWidgetType::Cpu)
+                                                    .widget_id(cpu_id)
+                                                    .flex_grow(true)
+                                                    .build(),
+                                                BottomWidget::builder()
+                                                    .width_ratio(3)
+                                                    .widget_type(BottomWidgetType::CpuLegend)
+                                                    .widget_id(*iter_id)
+                                                    .canvas_handle_width(true)
+                                                    .parent_reflector(Some((
+                                                        WidgetDirection::Left,
+                                                        1,
+                                                    )))
+                                                    .build(),
+                                            ])
+                                            .col_row_height_ratio(col_row_height_ratio)
+                                            .total_widget_ratio(20),
                                         );
                                     }
                                 }
@@ -250,48 +227,39 @@ impl Row {
                                     let proc_search_id = *iter_id + 1;
                                     *iter_id += 2;
                                     col_row_children.push(
-                                        BottomColRow::builder()
-                                            .children(vec![
-                                                BottomWidget::builder()
-                                                    .widget_type(BottomWidgetType::ProcSort)
-                                                    .widget_id(*iter_id)
-                                                    .canvas_handle_width(true)
-                                                    .parent_reflector(Some((
-                                                        WidgetDirection::Right,
-                                                        2,
-                                                    )))
-                                                    .width_ratio(1)
-                                                    .build(),
-                                                BottomWidget::builder()
-                                                    .widget_type(BottomWidgetType::Proc)
-                                                    .widget_id(proc_id)
-                                                    .width_ratio(2)
-                                                    .build(),
-                                            ])
-                                            .col_row_height_ratio(col_row_height_ratio)
-                                            .total_widget_ratio(3)
-                                            .build(),
+                                        BottomColRow::new(vec![
+                                            BottomWidget::builder()
+                                                .widget_type(BottomWidgetType::ProcSort)
+                                                .widget_id(*iter_id)
+                                                .canvas_handle_width(true)
+                                                .parent_reflector(Some((WidgetDirection::Right, 2)))
+                                                .width_ratio(1)
+                                                .build(),
+                                            BottomWidget::builder()
+                                                .widget_type(BottomWidgetType::Proc)
+                                                .widget_id(proc_id)
+                                                .width_ratio(2)
+                                                .build(),
+                                        ])
+                                        .col_row_height_ratio(col_row_height_ratio)
+                                        .total_widget_ratio(3),
                                     );
                                     col_row_children.push(
-                                        BottomColRow::builder()
-                                            .col_row_height_ratio(col_row_height_ratio)
-                                            .children(vec![BottomWidget::builder()
-                                                .widget_type(BottomWidgetType::ProcSearch)
-                                                .widget_id(proc_search_id)
-                                                .parent_reflector(Some((WidgetDirection::Up, 1)))
-                                                .build()])
-                                            .canvas_handle_height(true)
-                                            .build(),
+                                        BottomColRow::new(vec![BottomWidget::builder()
+                                            .widget_type(BottomWidgetType::ProcSearch)
+                                            .widget_id(proc_search_id)
+                                            .parent_reflector(Some((WidgetDirection::Up, 1)))
+                                            .build()])
+                                        .canvas_handle_height(true)
+                                        .col_row_height_ratio(col_row_height_ratio),
                                     );
                                 }
                                 _ => col_row_children.push(
-                                    BottomColRow::builder()
-                                        .col_row_height_ratio(col_row_height_ratio)
-                                        .children(vec![BottomWidget::builder()
-                                            .widget_type(widget_type)
-                                            .widget_id(*iter_id)
-                                            .build()])
-                                        .build(),
+                                    BottomColRow::new(vec![BottomWidget::builder()
+                                        .widget_type(widget_type)
+                                        .widget_id(*iter_id)
+                                        .build()])
+                                    .col_row_height_ratio(col_row_height_ratio),
                                 ),
                             }
                         }


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Incrementally rolling out changes to remove `TypedBuilder`. This removes it for `BottomColRow`; I'll probably rewrite this in general in the future but I want to remove the dependency since I don't really need it otherwise.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
