### PR TITLE
feature: support human times for `default_time_value` and `time_delta`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - Unreleased
+
+## Features
+
+- [#1172](https://github.com/ClementTsang/bottom/pull/1172): Support human times for `time_delta` and `default_time_value`.
+
 ## [0.9.1] - 2023-05-14
 
 ## Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bottom"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bottom"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Clement Tsang <cjhtsang@uwaterloo.ca>"]
 edition = "2021"
 repository = "https://github.com/ClementTsang/bottom"

--- a/src/options.rs
+++ b/src/options.rs
@@ -955,12 +955,14 @@ mod test {
     #[test]
     fn config_human_times() {
         let app = crate::clap::build_app();
-        let matches = app.get_matches_from(&["btm"]);
+        let matches = app.get_matches_from(["btm"]);
 
         let mut config = Config::default();
-        let mut flags = ConfigFlags::default();
-        flags.time_delta = Some("2 min".to_string());
-        flags.default_time_value = Some("300s".to_string());
+        let flags = ConfigFlags {
+            time_delta: Some("2 min".to_string()),
+            default_time_value: Some("300s".to_string()),
+            ..Default::default()
+        };
 
         config.flags = Some(flags);
 
@@ -978,12 +980,14 @@ mod test {
     #[test]
     fn config_number_times() {
         let app = crate::clap::build_app();
-        let matches = app.get_matches_from(&["btm"]);
+        let matches = app.get_matches_from(["btm"]);
 
         let mut config = Config::default();
-        let mut flags = ConfigFlags::default();
-        flags.time_delta = Some("120000".to_string());
-        flags.default_time_value = Some("300000".to_string());
+        let flags = ConfigFlags {
+            time_delta: Some("120000".to_string()),
+            default_time_value: Some("300000".to_string()),
+            ..Default::default()
+        };
 
         config.flags = Some(flags);
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This adds support for using human times (e.g. "1s", "20 min") `time_delta` and `default_time_value` flags.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
