### PR TITLE
bug: when getting Linux temps, don't bail ASAP if they fail

### DIFF
--- a/src/app/data_harvester/temperature/linux.rs
+++ b/src/app/data_harvester/temperature/linux.rs
@@ -11,8 +11,9 @@ use crate::app::{
 };
 
 /// Get temperature sensors from the linux sysfs interface `/sys/class/hwmon`.
-/// See [here](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-hwmon) for
-/// details.
+///
+/// See [the Linux kernel documentation](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-hwmon)
+/// for more details.
 ///
 /// This method will return `0` as the temperature for devices, such as GPUs,
 /// that support power management features and power themselves off.
@@ -191,8 +192,10 @@ fn get_from_hwmon(
 }
 
 /// Gets data from `/sys/class/thermal/thermal_zone*`. This should only be used if
-/// [`get_from_hwmon`] doesn't return anything. See
-/// [here](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-thermal) for details.
+/// [`get_from_hwmon`] doesn't return anything.
+///
+/// See [the Linux kernel documentation](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-thermal)
+/// for more details.
 fn get_from_thermal_zone(
     temp_type: &TemperatureType, filter: &Option<Filter>,
 ) -> Result<Vec<TempHarvest>> {

--- a/src/app/data_harvester/temperature/linux.rs
+++ b/src/app/data_harvester/temperature/linux.rs
@@ -238,11 +238,12 @@ fn get_from_thermal_zone(
 pub fn get_temperature_data(
     temp_type: &TemperatureType, filter: &Option<Filter>,
 ) -> Result<Option<Vec<TempHarvest>>> {
-    let mut temperature_vec: Vec<TempHarvest> = get_from_hwmon(temp_type, filter)?;
+    let mut temperature_vec: Vec<TempHarvest> =
+        get_from_hwmon(temp_type, filter).unwrap_or_default();
 
     if temperature_vec.is_empty() {
-        // If it's empty, fall back to checking `thermal_zone*`.
-        temperature_vec = get_from_thermal_zone(temp_type, filter)?;
+        // If it's empty, try to fall back to checking `thermal_zone*`.
+        temperature_vec = get_from_thermal_zone(temp_type, filter).unwrap_or_default();
     }
 
     #[cfg(feature = "nvidia")]


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This meant that if hwmon failed, it would never try and get temperatures from thermal or GPU. The same is true for thermal failing leading to GPU never running.

I'm guessing this could happen if, for example, `hwmon` doesn't exist --> returns an `Err`, which then meant the entire pipeline ends with an `Err`.

## Issue

_If applicable, what issue does this address?_

See: https://github.com/ClementTsang/bottom/discussions/1185

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
