### PR TITLE
feature: use better names for duplicate temp sensors found by `/sys/class/thermal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.2] - Unreleased
 
+## Bug Fixes
+
+- [#1186](https://github.com/ClementTsang/bottom/pull/1186): Fix for temperature sensor data gathering on Linux immediately halting if any method failed.
+
 ## Features
 
 - [#1172](https://github.com/ClementTsang/bottom/pull/1172): Support human times for `time_delta` and `default_time_value`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Features
 
 - [#1172](https://github.com/ClementTsang/bottom/pull/1172): Support human times for `time_delta` and `default_time_value`.
+- [#1187](https://github.com/ClementTsang/bottom/pull/1187): Use better names for duplicate temp sensors found by `/sys/class/thermal`.
 
 ## [0.9.1] - 2023-05-14
 

--- a/src/app/data_harvester/temperature/linux.rs
+++ b/src/app/data_harvester/temperature/linux.rs
@@ -245,7 +245,7 @@ pub fn get_temperature_data(
         get_from_hwmon(temp_type, filter).unwrap_or_default();
 
     if temperature_vec.is_empty() {
-        // If it's empty, try to fall back to checking `thermal_zone*`.
+        // If it's empty or it fails, try to fall back to checking `thermal_zone*`.
         temperature_vec = get_from_thermal_zone(temp_type, filter).unwrap_or_default();
     }
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This adds some numerical counters if there are duplicate temp sensors found by `/sys/class/thermal`.

For example, if you had 3 `iwlwifi` sensors, it would be labelled `iwlwifi`, `iwlwifi (1)`, and `iwlwifi (2)`, for easier differentiation.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
