### PR TITLE
other: enforce unused_imports lint again

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -4,9 +4,13 @@
 #![deny(clippy::missing_safety_doc)]
 
 // Primarily used for debug purposes.
-#[cfg(feature = "log")]
-#[macro_use]
-extern crate log;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "log")] {
+        #[allow(unused_imports)]
+        #[macro_use]
+        extern crate log;
+    }
+}
 
 use std::{
     boxed::Box,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,8 +1,7 @@
-#![warn(rust_2018_idioms)]
+#![deny(rust_2018_idioms)]
 #![deny(clippy::todo)]
 #![deny(clippy::unimplemented)]
 #![deny(clippy::missing_safety_doc)]
-#[allow(unused_imports)] // TODO: Deny unused imports.
 
 // Primarily used for debug purposes.
 #[cfg(feature = "log")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ pub type Pid = usize;
 #[cfg(target_family = "unix")]
 pub type Pid = libc::pid_t;
 
+/// Events sent to the main thread.
 #[derive(Debug)]
 pub enum BottomEvent {
     Resize,
@@ -86,6 +87,7 @@ pub enum BottomEvent {
     Terminate,
 }
 
+/// Events sent to the collection thread.
 #[derive(Debug)]
 pub enum ThreadEvent {
     Reset,
@@ -245,19 +247,17 @@ pub fn read_config(config_location: Option<&String>) -> error::Result<Option<Pat
 pub fn create_or_get_config(config_path: &Option<PathBuf>) -> error::Result<Config> {
     if let Some(path) = config_path {
         if let Ok(config_string) = fs::read_to_string(path) {
-            // We found a config file!
             Ok(toml_edit::de::from_str(config_string.as_str())?)
         } else {
-            // Config file DNE...
             if let Some(parent_path) = path.parent() {
                 fs::create_dir_all(parent_path)?;
             }
-            // fs::File::create(path)?.write_all(CONFIG_TOP_HEAD.as_bytes())?;
+
             fs::File::create(path)?.write_all(CONFIG_TEXT.as_bytes())?;
             Ok(Config::default())
         }
     } else {
-        // Don't write, the config path was somehow None...
+        // Don't write...
         Ok(Config::default())
     }
 }
@@ -268,10 +268,10 @@ pub fn try_drawing(
 ) -> error::Result<()> {
     if let Err(err) = painter.draw_data(terminal, app) {
         cleanup_terminal(terminal)?;
-        return Err(err);
+        Err(err)
+    } else {
+        Ok(())
     }
-
-    Ok(())
 }
 
 pub fn cleanup_terminal(
@@ -327,7 +327,7 @@ pub fn panic_hook(panic_info: &PanicInfo<'_>) {
     )
     .unwrap();
 
-    // Print stack trace.  Must be done after!
+    // Print stack trace. Must be done after!
     execute!(
         stdout,
         Print(format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,13 @@
 #![deny(clippy::missing_safety_doc)]
 
 // Primarily used for debug purposes.
-#[cfg(feature = "log")]
-#[macro_use]
-extern crate log;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "log")] {
+        #[allow(unused_imports)]
+        #[macro_use]
+        extern crate log;
+    }
+}
 
 use std::{
     boxed::Box,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,12 @@
 //! than the actual usage of the application. If you are instead looking for documentation regarding the *usage* of
 //! bottom, refer to [here](https://clementtsang.github.io/bottom/stable/).
 
-#![warn(rust_2018_idioms)]
+#![deny(rust_2018_idioms)]
 #![deny(clippy::todo)]
 #![deny(clippy::unimplemented)]
 #![deny(clippy::missing_safety_doc)]
-#[allow(unused_imports)] // TODO: Deny unused imports.
-// Only used for builds not intended for release.
+
+// Primarily used for debug purposes.
 #[cfg(feature = "log")]
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

I think there shouldn't be any issues with enforcing this now...

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
