### PR TITLE
bug: ntfs3 mounts don't show up

### DIFF
--- a/src/app/data_harvester/disks/unix/file_systems.rs
+++ b/src/app/data_harvester/disks/unix/file_systems.rs
@@ -118,7 +118,7 @@ impl FromStr for FileSystem {
             _ if s.eq_ignore_ascii_case("ext3") => Ok(FileSystem::Ext3),
             _ if s.eq_ignore_ascii_case("ext4") => Ok(FileSystem::Ext4),
             _ if s.eq_ignore_ascii_case("vfat") => Ok(FileSystem::VFat),
-            _ if s.eq_ignore_ascii_case("ntfs") => Ok(FileSystem::Ntfs),
+            _ if s == "ntfs3" || s.eq_ignore_ascii_case("ntfs") => Ok(FileSystem::Ntfs),
             _ if s.eq_ignore_ascii_case("zfs") => Ok(FileSystem::Zfs),
             _ if s.eq_ignore_ascii_case("hfs") => Ok(FileSystem::Hfs),
             _ if s.eq_ignore_ascii_case("reiserfs") => Ok(FileSystem::Reiser3),


### PR DESCRIPTION
## Description

Match `ntfs3` as NTFS. I didn't use `eq_ignore_ascii_case` because it's specific to Linux and the letters won't be uppercase.

## Issue

Partitions mounted using the ntfs3 driver in linux (mainlined since 5.15) won't show up because the name didn't match.

Here's the relevant line in `/proc/mounts`:

```
/dev/sdb2 /mnt/hdd_4t ntfs3 rw,noatime,uid=0,gid=0,iocharset=utf8 0 0
```

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
