### PR TITLE
deps: bump battery to 0.8.1 to fix M1 health bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1186](https://github.com/ClementTsang/bottom/pull/1186): Fix for temperature sensor data gathering on Linux immediately halting if any method failed.
 - [#1191](https://github.com/ClementTsang/bottom/pull/1191): Fix ntfs3 mounts not being counted as a physical drive type.
+- [#1195](https://github.com/ClementTsang/bottom/pull/1195): Fix battery health being incorrectly reported on M1 macOS.
 
 ## Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,9 +1113,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "starship-battery"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417551ac84efa1810d79d04555d36cbc83ec5a323f2ef9ee7318e34055461b6f"
+checksum = "cdba3bd6d6ead031f1ebf9dd84ebb02cfdbe5b0e51104b4befd0a2fc3d24f87b"
 dependencies = [
  "cfg-if",
  "core-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,8 +96,8 @@ nvml-wrapper = { version = "0.9.0", optional = true }
 once_cell = "1.18.0"
 regex = "1.8.4"
 serde = { version = "1.0.164", features = ["derive"] }
-starship-battery = { version = "0.8.0", optional = true }
-sysinfo = "0.29.2"
+starship-battery = { version = "0.8.1", optional = true }
+sysinfo = "=0.29.2"
 thiserror = "1.0.40"
 time = { version = "0.3.22", features = ["formatting", "macros"] }
 toml_edit = { version = "0.19.10", features = ["serde"] }


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This fixes an issue where M1 macOS would report far lower battery health values than reasonable; the fix was done upstream in the starship-battery crate which we rely on, and so updating it fixes the issue.

Much thanks to @WenqingZong for reporting the issue in the first place and making the fix upstream!

## Issue

_If applicable, what issue does this address?_

Closes: #1164 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [x] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
