### PR TITLE
other: use f32 for process percentage values

### DIFF
--- a/src/app/data_harvester/processes.rs
+++ b/src/app/data_harvester/processes.rs
@@ -45,10 +45,10 @@ pub struct ProcessHarvest {
     pub parent_pid: Option<Pid>,
 
     /// CPU usage as a percentage.
-    pub cpu_usage_percent: f64,
+    pub cpu_usage_percent: f32,
 
     /// Memory usage as a percentage.
-    pub mem_usage_percent: f64,
+    pub mem_usage_percent: f32,
 
     /// Memory usage as bytes.
     pub mem_usage_bytes: u64,

--- a/src/app/data_harvester/processes/linux.rs
+++ b/src/app/data_harvester/processes/linux.rs
@@ -110,7 +110,7 @@ fn cpu_usage_calculation(prev_idle: &mut f64, prev_non_idle: &mut f64) -> error:
 fn get_linux_cpu_usage(
     stat: &Stat, cpu_usage: f64, cpu_fraction: f64, prev_proc_times: u64,
     use_current_cpu_total: bool,
-) -> (f64, u64) {
+) -> (f32, u64) {
     // Based heavily on https://stackoverflow.com/a/23376195 and https://stackoverflow.com/a/1424556
     let new_proc_times = stat.utime + stat.stime;
     let diff = (new_proc_times - prev_proc_times) as f64; // No try_from for u64 -> f64... oh well.
@@ -118,9 +118,12 @@ fn get_linux_cpu_usage(
     if cpu_usage == 0.0 {
         (0.0, new_proc_times)
     } else if use_current_cpu_total {
-        ((diff / cpu_usage) * 100.0, new_proc_times)
+        (((diff / cpu_usage) * 100.0) as f32, new_proc_times)
     } else {
-        ((diff / cpu_usage) * 100.0 * cpu_fraction, new_proc_times)
+        (
+            ((diff / cpu_usage) * 100.0 * cpu_fraction) as f32,
+            new_proc_times,
+        )
     }
 }
 
@@ -181,7 +184,7 @@ fn read_proc(
     );
     let parent_pid = Some(stat.ppid);
     let mem_usage_bytes = stat.rss_bytes();
-    let mem_usage_percent = mem_usage_bytes as f64 / total_memory as f64 * 100.0;
+    let mem_usage_percent = (mem_usage_bytes as f64 / total_memory as f64 * 100.0) as f32;
 
     // This can fail if permission is denied!
     let (total_read_bytes, total_write_bytes, read_bytes_per_sec, write_bytes_per_sec) =

--- a/src/app/data_harvester/processes/unix/process_ext.rs
+++ b/src/app/data_harvester/processes/unix/process_ext.rs
@@ -61,7 +61,7 @@ pub(crate) trait UnixProcessExt {
                 pcu / cpu_usage
             } else {
                 pcu
-            };
+            } as f32;
 
             let disk_usage = process_val.disk_usage();
             let process_state = {
@@ -76,7 +76,7 @@ pub(crate) trait UnixProcessExt {
                 name,
                 command,
                 mem_usage_percent: if total_memory > 0 {
-                    process_val.memory() as f64 * 100.0 / total_memory as f64
+                    (process_val.memory() as f64 * 100.0 / total_memory as f64) as f32
                 } else {
                     0.0
                 },
@@ -114,7 +114,7 @@ pub(crate) trait UnixProcessExt {
                         *cpu_usages.get(&process.pid).unwrap()
                     } else {
                         *cpu_usages.get(&process.pid).unwrap() / num_processors
-                    };
+                    } as f32;
                 }
             }
         }

--- a/src/app/data_harvester/processes/windows.rs
+++ b/src/app/data_harvester/processes/windows.rs
@@ -63,7 +63,7 @@ pub fn sysinfo_process_data(
             pcu / cpu_usage
         } else {
             pcu
-        };
+        } as f32;
 
         let disk_usage = process_val.disk_usage();
         let process_state = (process_val.status().to_string(), 'R');
@@ -76,7 +76,7 @@ pub fn sysinfo_process_data(
                 process_val.memory() as f64 * 100.0 / total_memory as f64
             } else {
                 0.0
-            },
+            } as f32,
             mem_usage_bytes: process_val.memory(),
             cpu_usage_percent: process_cpu_usage,
             read_bytes_per_sec: disk_usage.read_bytes,

--- a/src/app/frozen_state.rs
+++ b/src/app/frozen_state.rs
@@ -37,6 +37,7 @@ impl FrozenState {
             self.thaw();
             false
         } else {
+            // Could we use an Arc instead? Is it worth it?
             self.freeze(Box::new(data.clone()));
             true
         }

--- a/src/app/query.rs
+++ b/src/app/query.rs
@@ -711,7 +711,12 @@ impl Prefix {
     }
 
     pub fn check(&self, process: &ProcessHarvest, is_using_command: bool) -> bool {
-        fn matches_condition(condition: &QueryComparison, lhs: f64, rhs: f64) -> bool {
+        fn matches_condition<I: Into<f64>, J: Into<f64>>(
+            condition: &QueryComparison, lhs: I, rhs: J,
+        ) -> bool {
+            let lhs: f64 = lhs.into();
+            let rhs: f64 = rhs.into();
+
             match condition {
                 QueryComparison::Equal => (lhs - rhs).abs() < std::f64::EPSILON,
                 QueryComparison::Less => lhs < rhs,

--- a/src/clap.rs
+++ b/src/clap.rs
@@ -257,7 +257,7 @@ pub fn build_app() -> Command {
             If it doesn't exist, one is created.",
         );
 
-    // TODO: Fix this, its broken in the manpage
+    // TODO: File an issue with manpage, it cannot render charts correctly.
     let color = Arg::new("color")
         .long("color")
         .action(ArgAction::Set)

--- a/src/widgets/process_table/proc_widget_data.rs
+++ b/src/widgets/process_table/proc_widget_data.rs
@@ -82,10 +82,9 @@ impl Display for Id {
     }
 }
 
-// TODO: Can reduce this to 32 bytes.
 #[derive(PartialEq, Clone, Debug)]
 pub enum MemUsage {
-    Percent(f64),
+    Percent(f32),
     Bytes(u64),
 }
 
@@ -170,7 +169,7 @@ pub struct ProcWidgetData {
     pub pid: Pid,
     pub ppid: Option<Pid>,
     pub id: Id,
-    pub cpu_usage_percent: f64,
+    pub cpu_usage_percent: f32,
     pub mem_usage: MemUsage,
     pub rps: u64,
     pub wps: u64,


### PR DESCRIPTION
This cuts down memory by a tiny bit, and we don't need a full f64 for percentage values.

## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
