### PR TITLE
bug: fix overflow/underflow with graph timespan zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Bug Fixes
 
-- [https://github.com/ClementTsang/bottom/pull/1216](https://github.com/ClementTsang/bottom/pull/1216): Fix arguments not being sorted alphabetically.
+- [#1216](https://github.com/ClementTsang/bottom/pull/1216): Fix arguments not being sorted alphabetically.
+- [#1219](https://github.com/ClementTsang/bottom/pull/1219): Fix overflow/underflow in graph timespan zoom.
 
 ## [0.9.2] - 2023-06-11
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2173,8 +2173,10 @@ impl App {
                     .widget_states
                     .get_mut(&self.current_widget.widget_id)
                 {
-                    let new_time = cpu_widget_state.current_display_time
-                        + self.app_config_fields.time_interval;
+                    let new_time = cpu_widget_state
+                        .current_display_time
+                        .saturating_add(self.app_config_fields.time_interval);
+
                     if new_time <= self.app_config_fields.retention_ms {
                         cpu_widget_state.current_display_time = new_time;
                         self.states.cpu_state.force_update = Some(self.current_widget.widget_id);
@@ -2199,8 +2201,10 @@ impl App {
                     .widget_states
                     .get_mut(&self.current_widget.widget_id)
                 {
-                    let new_time = mem_widget_state.current_display_time
-                        + self.app_config_fields.time_interval;
+                    let new_time = mem_widget_state
+                        .current_display_time
+                        .saturating_add(self.app_config_fields.time_interval);
+
                     if new_time <= self.app_config_fields.retention_ms {
                         mem_widget_state.current_display_time = new_time;
                         self.states.mem_state.force_update = Some(self.current_widget.widget_id);
@@ -2225,8 +2229,10 @@ impl App {
                     .widget_states
                     .get_mut(&self.current_widget.widget_id)
                 {
-                    let new_time = net_widget_state.current_display_time
-                        + self.app_config_fields.time_interval;
+                    let new_time = net_widget_state
+                        .current_display_time
+                        .saturating_add(self.app_config_fields.time_interval);
+
                     if new_time <= self.app_config_fields.retention_ms {
                         net_widget_state.current_display_time = new_time;
                         self.states.net_state.force_update = Some(self.current_widget.widget_id);
@@ -2257,8 +2263,10 @@ impl App {
                     .widget_states
                     .get_mut(&self.current_widget.widget_id)
                 {
-                    let new_time = cpu_widget_state.current_display_time
-                        - self.app_config_fields.time_interval;
+                    let new_time = cpu_widget_state
+                        .current_display_time
+                        .saturating_sub(self.app_config_fields.time_interval);
+
                     if new_time >= constants::STALE_MIN_MILLISECONDS {
                         cpu_widget_state.current_display_time = new_time;
                         self.states.cpu_state.force_update = Some(self.current_widget.widget_id);
@@ -2283,8 +2291,10 @@ impl App {
                     .widget_states
                     .get_mut(&self.current_widget.widget_id)
                 {
-                    let new_time = mem_widget_state.current_display_time
-                        - self.app_config_fields.time_interval;
+                    let new_time = mem_widget_state
+                        .current_display_time
+                        .saturating_sub(self.app_config_fields.time_interval);
+
                     if new_time >= constants::STALE_MIN_MILLISECONDS {
                         mem_widget_state.current_display_time = new_time;
                         self.states.mem_state.force_update = Some(self.current_widget.widget_id);
@@ -2309,8 +2319,10 @@ impl App {
                     .widget_states
                     .get_mut(&self.current_widget.widget_id)
                 {
-                    let new_time = net_widget_state.current_display_time
-                        - self.app_config_fields.time_interval;
+                    let new_time = net_widget_state
+                        .current_display_time
+                        .saturating_sub(self.app_config_fields.time_interval);
+
                     if new_time >= constants::STALE_MIN_MILLISECONDS {
                         net_widget_state.current_display_time = new_time;
                         self.states.net_state.force_update = Some(self.current_widget.widget_id);


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Basically, you could overflow/underflow the time span which would skip checks.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
