### PR TITLE
bug: fix core dump if the terminal is closed while bottom is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Bug Fixes
 
+- [#1230](https://github.com/ClementTsang/bottom/pull/1230): Fix core dump if the terminal is closed while bottom is open.
+
 ## [0.9.3] - 2023-06-25
 
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3]/[0.10.0] - Unreleased
+
+## Bug Fixes
+
 ## [0.9.3] - 2023-06-25
 
 ## Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bottom"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bottom"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Clement Tsang <cjhtsang@uwaterloo.ca>"]
 edition = "2021"
 repository = "https://github.com/ClementTsang/bottom"
@@ -133,9 +133,7 @@ filedescriptor = "0.8.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.11"
-cargo-husky = { version = "1.5.0", default-features = false, features = [
-    "user-hooks",
-] }
+cargo-husky = { version = "1.5.0", default-features = false, features = ["user-hooks"] }
 predicates = "3.0.3"
 
 [build-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,7 @@ pub fn check_if_terminal() {
 }
 
 /// A panic hook to properly restore the terminal in the case of a panic.
-/// Based on [spotify-tui's implementation](https://github.com/Rigellute/spotify-tui/blob/master/src/main.rs).
+/// Originally based on [spotify-tui's implementation](https://github.com/Rigellute/spotify-tui/blob/master/src/main.rs).
 pub fn panic_hook(panic_info: &PanicInfo<'_>) {
     let mut stdout = stdout();
 
@@ -305,28 +305,25 @@ pub fn panic_hook(panic_info: &PanicInfo<'_>) {
         },
     };
 
-    let stacktrace: String = format!("{:?}", backtrace::Backtrace::new());
+    let stacktrace = format!("{:?}", backtrace::Backtrace::new());
 
-    disable_raw_mode().unwrap();
-    execute!(
+    let _ = disable_raw_mode();
+    let _ = execute!(
         stdout,
         DisableBracketedPaste,
         DisableMouseCapture,
         LeaveAlternateScreen
-    )
-    .unwrap();
+    );
 
     // Print stack trace. Must be done after!
-    execute!(
-        stdout,
-        Print(format!(
-            "thread '<unnamed>' panicked at '{}', {}\n\r{}",
-            msg,
-            panic_info.location().unwrap(),
-            stacktrace
-        )),
-    )
-    .unwrap();
+    if let Some(panic_info) = panic_info.location() {
+        let _ = execute!(
+            stdout,
+            Print(format!(
+                "thread '<unnamed>' panicked at '{msg}', {panic_info}\n\r{stacktrace}",
+            )),
+        );
+    }
 }
 
 pub fn update_data(app: &mut App) {


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

The cause was:

- bottom thinks it's panicking if the terminal is closed.
- The panic hook tried to print out to the terminal - but the terminal was closed! It would unwrap and thus panic even harder.
- To solve this, we just make the panic hook calls not unwrap, since honestly if they fail it's whatever as far as I understand it.

## Issue

_If applicable, what issue does this address?_

Closes: #1227 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
