### PR TITLE
bug: missing windows syscall to close the handle on drop when killing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Bug Fixes
 
 - [#1230](https://github.com/ClementTsang/bottom/pull/1230): Fix core dump if the terminal is closed while bottom is open.
+- [#1245](https://github.com/ClementTsang/bottom/pull/1245): Fix killing processes in Windows leaving a handle open.
 
 ## Changes
 

--- a/src/app/process_killer.rs
+++ b/src/app/process_killer.rs
@@ -1,9 +1,8 @@
 //! This file is meant to house (OS specific) implementations on how to kill processes.
 
-use windows::Win32::Foundation::CloseHandle;
 #[cfg(target_os = "windows")]
 use windows::Win32::{
-    Foundation::HANDLE,
+    Foundation::{CloseHandle, HANDLE},
     System::Threading::{
         OpenProcess, TerminateProcess, PROCESS_QUERY_INFORMATION, PROCESS_TERMINATE,
     },

--- a/src/app/process_killer.rs
+++ b/src/app/process_killer.rs
@@ -1,5 +1,6 @@
 //! This file is meant to house (OS specific) implementations on how to kill processes.
 
+use windows::Win32::Foundation::CloseHandle;
 #[cfg(target_os = "windows")]
 use windows::Win32::{
     Foundation::HANDLE,
@@ -27,13 +28,23 @@ impl Process {
     }
 
     fn kill(self) -> Result<(), String> {
-        // SAFETY: Windows API call, tread carefully with the args.
+        // SAFETY: Windows API call, this is safe as we are passing in the handle.
         let result = unsafe { TerminateProcess(self.0, 1) };
         if result.0 == 0 {
             return Err("process may have already been terminated.".to_string());
         }
 
         Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl Drop for Process {
+    fn drop(&mut self) {
+        // SAFETY: Windows API call, this is safe as we are passing in the handle.
+        unsafe {
+            CloseHandle(self.0);
+        }
     }
 }
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

On dropping the `Process` struct, we should close the handle to avoid keeping it open permanently.

## Issue

_If applicable, what issue does this address?_

Closes: #1242

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [x] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
