### PR TITLE
add zfs io counters for linux and freebsd

### DIFF
--- a/src/app/data_farmer.rs
+++ b/src/app/data_farmer.rs
@@ -347,7 +347,12 @@ impl DataCollection {
                             None => device.name.split('/').last(),
                         }
                     } else {
-                        device.name.split('/').last()
+                        #[cfg(feature = "zfs")]
+                        if ! device.name.starts_with('/'){
+                            Some(device.name.as_str()) // use the whole zfs dataset name
+                        } else {
+                            device.name.split('/').last()
+                        }
                     }
                 }
             };

--- a/src/app/data_farmer.rs
+++ b/src/app/data_farmer.rs
@@ -353,6 +353,8 @@ impl DataCollection {
                         } else {
                             device.name.split('/').last()
                         }
+                        #[cfg(not(feature = "zfs"))]
+                        device.name.split('/').last()
                     }
                 }
             };

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -8,6 +8,10 @@ use crate::app::filter::Filter;
 cfg_if! {
     if #[cfg(target_os = "freebsd")] {
         mod freebsd;
+        mod io_counters;
+        #[cfg(feature = "zfs")]
+        mod zfs_io_counters;
+        pub use io_counters::IoCounters;
         pub(crate) use self::freebsd::*;
     } else if #[cfg(target_os = "windows")] {
         mod windows;
@@ -51,6 +55,8 @@ cfg_if! {
     if #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))] {
         mod io_counters;
         pub use io_counters::IoCounters;
+        #[cfg(feature = "zfs")]
+        mod zfs_io_counters;
 
         /// Returns the I/O usage of certain mount points.
         pub fn get_io_usage() -> anyhow::Result<IoHarvest> {

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -8,9 +8,11 @@ use crate::app::filter::Filter;
 cfg_if! {
     if #[cfg(target_os = "freebsd")] {
         mod freebsd;
+        #[cfg(feature = "zfs")]
         mod io_counters;
         #[cfg(feature = "zfs")]
         mod zfs_io_counters;
+        #[cfg(feature = "zfs")]
         pub use io_counters::IoCounters;
         pub(crate) use self::freebsd::*;
     } else if #[cfg(target_os = "windows")] {

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -18,6 +18,8 @@ cfg_if! {
         pub(crate) use self::windows::*;
     } else if #[cfg(target_os = "linux")] {
         mod unix;
+        #[cfg(feature = "zfs")]
+        mod zfs_io_counters;
         pub(crate) use self::unix::*;
     } else if #[cfg(target_os = "macos")] {
         mod unix;
@@ -55,8 +57,6 @@ cfg_if! {
     if #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))] {
         mod io_counters;
         pub use io_counters::IoCounters;
-        #[cfg(feature = "zfs")]
-        mod zfs_io_counters;
 
         /// Returns the I/O usage of certain mount points.
         pub fn get_io_usage() -> anyhow::Result<IoHarvest> {

--- a/src/app/data_harvester/disks/freebsd.rs
+++ b/src/app/data_harvester/disks/freebsd.rs
@@ -29,6 +29,7 @@ struct FileSystem {
 }
 
 pub fn get_io_usage() -> error::Result<IoHarvest> {
+    #[allow(unused_mut)]
     let mut io_harvest: HashMap<String, Option<IoData>> =
         get_disk_info().map(|storage_system_information| {
             storage_system_information

--- a/src/app/data_harvester/disks/io_counters.rs
+++ b/src/app/data_harvester/disks/io_counters.rs
@@ -1,6 +1,5 @@
 use std::ffi::OsStr;
 
-#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct IoCounters {
     name: String,
@@ -8,7 +7,6 @@ pub struct IoCounters {
     write_bytes: u64,
 }
 
-#[allow(dead_code)]
 impl IoCounters {
     pub fn new(name: String, read_bytes: u64, write_bytes: u64) -> Self {
         Self {

--- a/src/app/data_harvester/disks/io_counters.rs
+++ b/src/app/data_harvester/disks/io_counters.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsStr;
 
+#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct IoCounters {
     name: String,
@@ -7,6 +8,7 @@ pub struct IoCounters {
     write_bytes: u64,
 }
 
+#[allow(dead_code)]
 impl IoCounters {
     pub fn new(name: String, read_bytes: u64, write_bytes: u64) -> Self {
         Self {

--- a/src/app/data_harvester/disks/unix/linux/counters.rs
+++ b/src/app/data_harvester/disks/unix/linux/counters.rs
@@ -81,5 +81,13 @@ pub fn io_stats() -> anyhow::Result<Vec<anyhow::Result<IoCounters>>> {
         }
     }
 
+    #[cfg(feature = "zfs")]
+    {
+        use crate::app::data_harvester::disks::zfs_io_counters;
+        if let Ok(mut zfs_io) = zfs_io_counters::zfs_io_stats() {
+            results.append(&mut zfs_io);
+        }
+    }
+
     Ok(results)
 }

--- a/src/app/data_harvester/disks/zfs_io_counters.rs
+++ b/src/app/data_harvester/disks/zfs_io_counters.rs
@@ -10,15 +10,12 @@ pub fn zfs_io_stats() -> anyhow::Result<Vec<anyhow::Result<IoCounters>>> {
             e.ok().and_then(|ctl| {
                 let name = ctl.name();
                 if let Ok(name) = name {
-                    if name.contains("objset-") {
-                        if name.contains("dataset_name")
+                    if name.contains("objset-")
+                        && (name.contains("dataset_name")
                             || name.contains("nwritten")
-                            || name.contains("nread")
-                        {
-                            Some(ctl)
-                        } else {
-                            None
-                        }
+                            || name.contains("nread"))
+                    {
+                        Some(ctl)
                     } else {
                         None
                     }

--- a/src/app/data_harvester/disks/zfs_io_counters.rs
+++ b/src/app/data_harvester/disks/zfs_io_counters.rs
@@ -1,0 +1,155 @@
+use crate::app::data_harvester::disks::IoCounters;
+
+/// Returns zpool I/O stats. Pulls data from `sysctl kstat.zfs.{POOL}.dataset.{objset-*}`
+#[cfg(target_os = "freebsd")]
+pub fn zfs_io_stats() -> anyhow::Result<Vec<anyhow::Result<IoCounters>>> {
+    use sysctl::Sysctl;
+    let zfs_ctls: Vec<_> = sysctl::Ctl::new("kstat.zfs.")?
+        .into_iter()
+        .filter_map(|e| {
+            e.ok().and_then(|ctl| {
+                let name = ctl.name();
+                if let Ok(name) = name {
+                    if name.contains("objset-") {
+                        if name.contains("dataset_name")
+                            || name.contains("nwritten")
+                            || name.contains("nread")
+                        {
+                            Some(ctl)
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+        })
+        .collect();
+
+    use itertools::Itertools;
+    let results: Vec<anyhow::Result<IoCounters>> = zfs_ctls
+        .iter()
+        .chunks(3)
+        .into_iter()
+        .filter_map(|chunk| {
+            let mut nread = 0;
+            let mut nwrite = 0;
+            let mut ds_name = String::new();
+            for ctl in chunk {
+                if let Ok(name) = ctl.name() {
+                    if name.contains("dataset_name") {
+                        ds_name = ctl.value_string().ok()?;
+                    } else if name.contains("nread") {
+                        if let Ok(sysctl::CtlValue::U64(val)) = ctl.value() {
+                            nread = val;
+                        }
+                    } else if name.contains("nwritten") {
+                        if let Ok(sysctl::CtlValue::U64(val)) = ctl.value() {
+                            nwrite = val;
+                        }
+                    }
+                }
+            }
+            Some(Ok(IoCounters::new(ds_name.to_string(), nread, nwrite)))
+        })
+        .collect();
+    Ok(results)
+}
+
+/// Returns zpool I/O stats. Pulls data from `/proc/spl/kstat/zfs/*/objset-*`.
+#[cfg(target_os = "linux")]
+pub fn zfs_io_stats() -> anyhow::Result<Vec<anyhow::Result<IoCounters>>> {
+    if let Ok(zpools) = std::fs::read_dir("/proc/spl/kstat/zfs") {
+        let zpools_vec: Vec<std::path::PathBuf> = zpools
+            .filter_map(|e| {
+                e.ok().and_then(|d| {
+                    let p = d.path();
+                    if p.is_dir() {
+                        Some(p)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+        let results = zpools_vec
+            .iter()
+            .filter_map(|zpool| {
+                // go through each pool
+                if let Ok(datasets) = std::fs::read_dir(zpool) {
+                    let datasets_vec: Vec<std::path::PathBuf> =
+                        datasets // go through dataset
+                            .filter_map(|e| {
+                                e.ok().and_then(|d| {
+                                    let p = d.path();
+                                    if p.is_file() && p.to_str()?.contains("objset-") {
+                                        Some(p)
+                                    } else {
+                                        None
+                                    }
+                                })
+                            })
+                            .collect();
+                    let io_counters: Vec<anyhow::Result<IoCounters>> = datasets_vec
+                        .iter()
+                        .filter_map(|ds| {
+                            // get io-counter from each dataset
+                            if let Ok(contents) = std::fs::read_to_string(ds) {
+                                let mut read = 0;
+                                let mut write = 0;
+                                let mut name = "";
+                                contents.lines().for_each(|line| {
+                                    if let Some((label, value)) = line.split_once(' ') {
+                                        match label {
+                                            "dataset_name" => {
+                                                if let Some((_type, val)) =
+                                                    value.trim_start().rsplit_once(' ')
+                                                {
+                                                    name = val;
+                                                }
+                                            }
+                                            "nwritten" => {
+                                                if let Some((_type, val)) =
+                                                    value.trim_start().rsplit_once(' ')
+                                                {
+                                                    if let Ok(number) = val.parse::<u64>() {
+                                                        write = number;
+                                                    }
+                                                }
+                                            }
+                                            "nread" => {
+                                                if let Some((_type, val)) =
+                                                    value.trim_start().rsplit_once(' ')
+                                                {
+                                                    if let Ok(number) = val.parse::<u64>() {
+                                                        read = number;
+                                                    }
+                                                }
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+                                });
+                                let counter = IoCounters::new(name.to_owned(), read, write);
+                                //log::debug!("adding io counter for zfs {:?}", counter);
+                                Some(Ok(counter))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    Some(io_counters)
+                } else {
+                    None
+                }
+            })
+            .flatten()
+            .collect(); // combine io-counters
+        Ok(results)
+    } else {
+        Err(anyhow::anyhow!("Unable to open zfs proc directory"))
+    }
+}

--- a/src/app/data_harvester/disks/zfs_io_counters.rs
+++ b/src/app/data_harvester/disks/zfs_io_counters.rs
@@ -53,7 +53,7 @@ pub fn zfs_io_stats() -> anyhow::Result<Vec<anyhow::Result<IoCounters>>> {
                     }
                 }
             }
-            Some(Ok(IoCounters::new(ds_name.to_string(), nread, nwrite)))
+            Some(Ok(IoCounters::new(ds_name, nread, nwrite)))
         })
         .collect();
     Ok(results)


### PR DESCRIPTION
## Description

ZFS datasets in the disk menu lacked support for monitoring the read and written bytes.
This PR adds io-counters (read bytes and written bytes) for the named zfs datasets in the disks menu. 

Screens:
Linux:
![bottom-linux](https://github.com/ClementTsang/bottom/assets/7027701/03cdcdc2-39ea-4683-8029-0bf1dcf09227)

FreeBSD:
![bottom-freebsd-basic](https://github.com/ClementTsang/bottom/assets/7027701/a7e29346-d14e-466a-a50b-bd41296093fd)


## Testing

Tested on linux and freebsd, with and without zfs.

- [ ] _Windows_
- [ ] _macOS_
- [X] _Linux_
- [X] _FreeBSD_

## Checklist

_If relevant, ensure the following have been met:_

- [X] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [X] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [X] _The pull request passes the provided CI pipeline_
- [X] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_

I did **NOT** test with an extensive zfs setup (no draid/raidz/spares) just my simple mirror pools (maybe use file backed pools to test?)

If any of the Issues should be addressed or a different approach used please let me know.

Feel free to close this PR if it is unwanted.
