### PR TITLE
deps: lock sysinfo to 0.29.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751e810399bba86e9326f5762b7f32ac5a085542df78da6a78d94e07d14d7c11"
+checksum = "6b949f01f9c23823744b71e0060472ecbde578ef68cc2a9e46d114efd77c3034"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ once_cell = "1.18.0"
 regex = "1.9.1"
 serde = { version = "1.0.171", features = ["derive"] }
 starship-battery = { version = "0.8.1", optional = true }
-sysinfo = "=0.29.4"
+sysinfo = "=0.29.5"
 thiserror = "1.0.43"
 time = { version = "0.3.23", features = ["formatting", "macros"] }
 toml_edit = { version = "0.19.12", features = ["serde"] }


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
