### PR TITLE
bug: display arc max size in arc usage instead of system memory

### DIFF
--- a/src/app/data_harvester/memory/arc.rs
+++ b/src/app/data_harvester/memory/arc.rs
@@ -18,7 +18,7 @@ pub(crate) fn get_arc_usage() -> Option<MemHarvest> {
                         if let Some((label, value)) = line.split_once(' ') {
                             let to_write = match label {
                                 "size" => &mut mem_arc,
-                                "memory_all_bytes" => &mut mem_total,
+                                "c_max" => &mut mem_total,
                                 _ => {
                                     continue;
                                 }
@@ -45,7 +45,7 @@ pub(crate) fn get_arc_usage() -> Option<MemHarvest> {
                 use sysctl::Sysctl;
                 if let (Ok(mem_arc_value), Ok(mem_sys_value)) = (
                     sysctl::Ctl::new("kstat.zfs.misc.arcstats.size"),
-                    sysctl::Ctl::new("hw.physmem"),
+                    sysctl::Ctl::new("kstat.zfs.misc.arcstats.c_max"),
                 ) {
                     if let (Ok(sysctl::CtlValue::U64(arc)), Ok(sysctl::CtlValue::Ulong(mem))) =
                         (mem_arc_value.value(), mem_sys_value.value())


### PR DESCRIPTION
## Description

Previously the ARC usage showed it having a maximum size of the amount of ram in the system regardless of what [zfs_arc_max](https://docs.oracle.com/cd/E26505_01/html/E37386/chapterzfs-3.html) was set to.

<img width="933" alt="image" src="https://github.com/ClementTsang/bottom/assets/14242997/56319766-330d-4714-8155-91738eabca43">


## Testing

Changes were tested by changing the arc max size and ensuring the value was reflected in bottom.

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_
- [ ] _FreeBSD_

## Checklist

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
