### PR TITLE
ci: pin musl to 1.71.0 for now when building releases

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -61,6 +61,7 @@ jobs:
               os: "ubuntu-20.04",
               target: "x86_64-unknown-linux-musl",
               cross: false,
+              rust: "1.71.0",
             }
           - {
               os: "ubuntu-20.04",
@@ -130,7 +131,7 @@ jobs:
         if: matrix.info.container == ''
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.info.rust || 'stable' }}
           target: ${{ matrix.info.target }}
 
       - name: Set up Rust toolchain (non-GitHub container)
@@ -289,7 +290,7 @@ jobs:
       matrix:
         info:
           - { target: "x86_64-unknown-linux-gnu", cross: false, dpkg: amd64 }
-          - { target: "x86_64-unknown-linux-musl", cross: false, dpkg: amd64 }
+          - { target: "x86_64-unknown-linux-musl", cross: false, dpkg: amd64, rust: "1.71.0" }
           - {
               target: "aarch64-unknown-linux-gnu",
               cross: true,
@@ -323,7 +324,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.info.rust || 'stable' }}
           target: ${{ matrix.info.target }}
 
       # TODO: Could I use the previous jobs to skip this call?
@@ -411,7 +412,7 @@ jobs:
       matrix:
         info:
           - { target: "x86_64-unknown-linux-gnu" }
-          - { target: "x86_64-unknown-linux-musl" }
+          - { target: "x86_64-unknown-linux-musl", rust: "1.71.0" }
     steps:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -421,7 +422,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.info.rust || 'stable' }}
           target: ${{ matrix.info.target }}
 
       # TODO: Could I use the previous jobs to skip this call?


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

I have no idea why, but builds are failing for musl now when I try to build release builds as of Rust 1.72.0. Hm.

This pins musl to 1.71.0 for now while leaving everything else at `stable`.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
