### PR TITLE
ci: test if building with musl on Rust > 1.71 works again

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -62,7 +62,6 @@ jobs:
               os: "ubuntu-20.04",
               target: "x86_64-unknown-linux-musl",
               cross: false,
-              rust: "1.71.0",
             }
           - {
               os: "ubuntu-20.04",
@@ -297,12 +296,7 @@ jobs:
       matrix:
         info:
           - { target: "x86_64-unknown-linux-gnu", cross: false, dpkg: amd64 }
-          - {
-              target: "x86_64-unknown-linux-musl",
-              cross: false,
-              dpkg: amd64,
-              rust: "1.71.0",
-            }
+          - { target: "x86_64-unknown-linux-musl", cross: false, dpkg: amd64 }
           - {
               target: "aarch64-unknown-linux-gnu",
               cross: true,
@@ -424,7 +418,7 @@ jobs:
       matrix:
         info:
           - { target: "x86_64-unknown-linux-gnu" }
-          - { target: "x86_64-unknown-linux-musl", rust: "1.71.0" }
+          - { target: "x86_64-unknown-linux-musl" }
     steps:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -437,6 +437,7 @@ jobs:
         env:
           BTM_GENERATE: true
           BTM_BUILD_RELEASE_CALLER: ${{ inputs.caller }}
+          CROSS_CONTAINER_IN_CONTAINER: true
         with:
           command: build
           use-cross: ${{ matrix.info.cross || false }}

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -61,7 +61,7 @@ jobs:
           - {
               os: "ubuntu-20.04",
               target: "x86_64-unknown-linux-musl",
-              cross: false,
+              cross: true,
             }
           - {
               os: "ubuntu-20.04",
@@ -296,7 +296,7 @@ jobs:
       matrix:
         info:
           - { target: "x86_64-unknown-linux-gnu", cross: false, dpkg: amd64 }
-          - { target: "x86_64-unknown-linux-musl", cross: false, dpkg: amd64 }
+          - { target: "x86_64-unknown-linux-musl", cross: true, dpkg: amd64 }
           - {
               target: "aarch64-unknown-linux-gnu",
               cross: true,
@@ -356,7 +356,7 @@ jobs:
           gzip ./manpage/btm.1
 
       - name: Build Debian release (x86-64)
-        if: matrix.info.cross == false
+        if: startsWith(matrix.info.target, 'x86_64')
         env:
           BTM_GENERATE: true
         run: |
@@ -365,7 +365,7 @@ jobs:
           cp ./target/${{ matrix.info.target }}/debian/bottom_*.deb .
 
       - name: Build Debian release (ARM)
-        if: matrix.info.cross == true
+        if: startsWith(matrix.info.target, 'x86_64') != true
         env:
           BTM_GENERATE: true
         run: |
@@ -418,7 +418,7 @@ jobs:
       matrix:
         info:
           - { target: "x86_64-unknown-linux-gnu" }
-          - { target: "x86_64-unknown-linux-musl" }
+          - { target: "x86_64-unknown-linux-musl", cross: true }
     steps:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -439,6 +439,7 @@ jobs:
           BTM_BUILD_RELEASE_CALLER: ${{ inputs.caller }}
         with:
           command: build
+          use-cross: ${{ matrix.info.cross || false }}
           args: --release --locked --verbose --features deploy --target ${{ matrix.info.target }}
 
       - name: Move automatically generated completion/manpage
@@ -452,7 +453,6 @@ jobs:
           gzip ./manpage/btm.1
 
       - name: Build rpm release
-        if: matrix.info.cross == false
         env:
           BTM_GENERATE: true
         run: |

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -295,7 +295,7 @@ jobs:
       fail-fast: false
       matrix:
         info:
-          - { target: "x86_64-unknown-linux-gnu", cross: false, dpkg: amd64 }
+          - { target: "x86_64-unknown-linux-gnu", dpkg: amd64 }
           - { target: "x86_64-unknown-linux-musl", cross: true, dpkg: amd64 }
           - {
               target: "aarch64-unknown-linux-gnu",
@@ -342,7 +342,7 @@ jobs:
         with:
           command: build
           args: --release --locked --verbose --features deploy --target ${{ matrix.info.target }}
-          use-cross: ${{ matrix.info.cross }}
+          use-cross: ${{ matrix.info.cross || false }}
           cross-version: 0.2.5
 
       - name: Move automatically generated completion/manpage
@@ -441,6 +441,7 @@ jobs:
           command: build
           use-cross: ${{ matrix.info.cross || false }}
           args: --release --locked --verbose --features deploy --target ${{ matrix.info.target }}
+          cross-version: 0.2.5
 
       - name: Move automatically generated completion/manpage
         shell: bash


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Bumping to Rust 1.72 and onward causes CI to fail when building release builds on musl. This might be related to https://github.com/rust-lang/rust/issues/115430.

Regardless, seems like building via `cross` solves the issue.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Tested [here](https://github.com/ClementTsang/bottom/actions/runs/6288578367) via GHA.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
