### PR TITLE
Chore: Minor cleanup - remove un-needed ident qualifiers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -57,7 +57,7 @@ fn btm_generate() -> io::Result<()> {
             let man = clap_mangen::Man::new(app);
             let mut buffer: Vec<u8> = Default::default();
             man.render(&mut buffer)?;
-            std::fs::write(manpage_out_dir.join("btm.1"), buffer)?;
+            fs::write(manpage_out_dir.join("btm.1"), buffer)?;
         }
         _ => {}
     }

--- a/src/app/data_harvester.rs
+++ b/src/app/data_harvester.rs
@@ -124,7 +124,7 @@ pub struct DataCollector {
     battery_list: Option<Vec<Battery>>,
 
     #[cfg(target_family = "unix")]
-    user_table: self::processes::UserTable,
+    user_table: processes::UserTable,
 }
 
 impl DataCollector {

--- a/src/app/data_harvester/cpu/sysinfo.rs
+++ b/src/app/data_harvester/cpu/sysinfo.rs
@@ -8,9 +8,7 @@ use sysinfo::{CpuExt, LoadAvg, System, SystemExt};
 use super::{CpuData, CpuDataType, CpuHarvest};
 use crate::app::data_harvester::cpu::LoadAvgHarvest;
 
-pub fn get_cpu_data_list(
-    sys: &sysinfo::System, show_average_cpu: bool,
-) -> crate::error::Result<CpuHarvest> {
+pub fn get_cpu_data_list(sys: &System, show_average_cpu: bool) -> crate::error::Result<CpuHarvest> {
     let mut cpu_deque: VecDeque<_> = sys
         .cpus()
         .iter()

--- a/src/app/data_harvester/disks/unix/linux/partition.rs
+++ b/src/app/data_harvester/disks/unix/linux/partition.rs
@@ -51,7 +51,7 @@ impl Partition {
                         .into_string()
                         .unwrap_or_else(|_| "Name Unavailable".to_string())
                 } else {
-                    let mut combined_path = std::path::PathBuf::new();
+                    let mut combined_path = PathBuf::new();
                     combined_path.push(device);
                     combined_path.pop(); // Pop the current file...
                     combined_path.push(path);
@@ -110,7 +110,7 @@ impl FromStr for Partition {
         let mut parts = line.splitn(5, ' ');
 
         let device = match parts.next() {
-            Some(device) if device == "none" => None,
+            Some("none") => None,
             Some(device) => Some(device.to_string()),
             None => {
                 bail!("missing device");

--- a/src/app/query.rs
+++ b/src/app/query.rs
@@ -717,7 +717,7 @@ impl Prefix {
             let rhs: f64 = rhs.into();
 
             match condition {
-                QueryComparison::Equal => (lhs - rhs).abs() < std::f64::EPSILON,
+                QueryComparison::Equal => (lhs - rhs).abs() < f64::EPSILON,
                 QueryComparison::Less => lhs < rhs,
                 QueryComparison::Greater => lhs > rhs,
                 QueryComparison::LessOrEqual => lhs <= rhs,

--- a/src/args.rs
+++ b/src/args.rs
@@ -84,7 +84,7 @@ Supported widget names:
     }
 };
 
-pub fn get_matches() -> clap::ArgMatches {
+pub fn get_matches() -> ArgMatches {
     build_app().get_matches()
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -38,9 +38,7 @@ fn main() -> Result<()> {
 
     #[cfg(feature = "logging")]
     {
-        if let Err(err) =
-            utils::logging::init_logger(log::LevelFilter::Debug, std::ffi::OsStr::new("debug.log"))
-        {
+        if let Err(err) = init_logger(log::LevelFilter::Debug, std::ffi::OsStr::new("debug.log")) {
             println!("Issue initializing logger: {err}");
         }
     }

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -12,7 +12,6 @@ use tui::{
 
 use crate::{
     app::{
-        self,
         layout_manager::{BottomColRow, BottomLayout, BottomWidgetType},
         App,
     },
@@ -227,7 +226,7 @@ impl Painter {
     }
 
     pub fn draw_data<B: Backend>(
-        &mut self, terminal: &mut Terminal<B>, app_state: &mut app::App,
+        &mut self, terminal: &mut Terminal<B>, app_state: &mut App,
     ) -> error::Result<()> {
         use BottomWidgetType::*;
 

--- a/src/canvas/canvas_styling.rs
+++ b/src/canvas/canvas_styling.rs
@@ -91,7 +91,7 @@ impl Default for CanvasStyling {
             high_battery_colour: Style::default().fg(Color::Green),
             medium_battery_colour: Style::default().fg(Color::Yellow),
             low_battery_colour: Style::default().fg(Color::Red),
-            invalid_query_style: Style::default().fg(tui::style::Color::Red),
+            invalid_query_style: Style::default().fg(Color::Red),
             disabled_text_style: Style::default().fg(Color::DarkGray),
         }
     }

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -546,9 +546,7 @@ pub fn convert_battery_harvest(current_data: &DataCollection) -> Vec<ConvertedBa
 }
 
 #[cfg(feature = "zfs")]
-pub fn convert_arc_labels(
-    current_data: &crate::app::data_farmer::DataCollection,
-) -> Option<(String, String)> {
+pub fn convert_arc_labels(current_data: &DataCollection) -> Option<(String, String)> {
     if current_data.arc_harvest.total_bytes > 0 {
         Some((
             format!(
@@ -572,9 +570,7 @@ pub fn convert_arc_labels(
 }
 
 #[cfg(feature = "zfs")]
-pub fn convert_arc_data_points(
-    current_data: &crate::app::data_farmer::DataCollection,
-) -> Vec<Point> {
+pub fn convert_arc_data_points(current_data: &DataCollection) -> Vec<Point> {
     let mut result: Vec<Point> = Vec::new();
     let current_time = current_data.current_instant;
 
@@ -602,9 +598,7 @@ pub struct ConvertedGpuData {
 }
 
 #[cfg(feature = "gpu")]
-pub fn convert_gpu_data(
-    current_data: &crate::app::data_farmer::DataCollection,
-) -> Option<Vec<ConvertedGpuData>> {
+pub fn convert_gpu_data(current_data: &DataCollection) -> Option<Vec<ConvertedGpuData>> {
     let current_time = current_data.current_instant;
 
     // convert points

--- a/src/options.rs
+++ b/src/options.rs
@@ -538,7 +538,7 @@ pub fn get_widget_layout(
 
             ret_bottom_layout
         } else {
-            return Err(error::BottomError::ConfigError(
+            return Err(BottomError::ConfigError(
                 "please have at least one widget under the '[[row]]' section.".to_string(),
             ));
         }

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -48,8 +48,8 @@ impl From<std::num::ParseIntError> for BottomError {
     }
 }
 
-impl From<std::string::String> for BottomError {
-    fn from(err: std::string::String) -> Self {
+impl From<String> for BottomError {
+    fn from(err: String) -> Self {
         BottomError::GenericError(err)
     }
 }

--- a/src/utils/gen_util.rs
+++ b/src/utils/gen_util.rs
@@ -178,7 +178,7 @@ fn truncate_str<U: Into<usize>>(content: &str, width: U) -> String {
 }
 
 #[inline]
-pub const fn sort_partial_fn<T: std::cmp::PartialOrd>(is_descending: bool) -> fn(T, T) -> Ordering {
+pub const fn sort_partial_fn<T: PartialOrd>(is_descending: bool) -> fn(T, T) -> Ordering {
     if is_descending {
         partial_ordering_desc
     } else {
@@ -188,7 +188,7 @@ pub const fn sort_partial_fn<T: std::cmp::PartialOrd>(is_descending: bool) -> fn
 
 /// Returns an [`Ordering`] between two [`PartialOrd`]s.
 #[inline]
-pub fn partial_ordering<T: std::cmp::PartialOrd>(a: T, b: T) -> Ordering {
+pub fn partial_ordering<T: PartialOrd>(a: T, b: T) -> Ordering {
     a.partial_cmp(&b).unwrap_or(Ordering::Equal)
 }
 
@@ -197,7 +197,7 @@ pub fn partial_ordering<T: std::cmp::PartialOrd>(a: T, b: T) -> Ordering {
 /// This is simply a wrapper function around [`partial_ordering`] that reverses
 /// the result.
 #[inline]
-pub fn partial_ordering_desc<T: std::cmp::PartialOrd>(a: T, b: T) -> Ordering {
+pub fn partial_ordering_desc<T: PartialOrd>(a: T, b: T) -> Ordering {
     partial_ordering(a, b).reverse()
 }
 

--- a/src/widgets/process_table.rs
+++ b/src/widgets/process_table.rs
@@ -140,7 +140,7 @@ impl<'de> Deserialize<'de> for ProcWidgetColumn {
             "state" => Ok(ProcWidgetColumn::State),
             "user" => Ok(ProcWidgetColumn::User),
             "time" => Ok(ProcWidgetColumn::Time),
-            _ => Err(D::Error::custom("doesn't match any column type")),
+            _ => Err(Error::custom("doesn't match any column type")),
         }
     }
 }

--- a/src/widgets/process_table/proc_widget_column.rs
+++ b/src/widgets/process_table/proc_widget_column.rs
@@ -47,7 +47,7 @@ impl<'de> Deserialize<'de> for ProcColumn {
             "state" => Ok(ProcColumn::State),
             "user" => Ok(ProcColumn::User),
             "time" => Ok(ProcColumn::Time),
-            _ => Err(D::Error::custom("doesn't match any column type")),
+            _ => Err(Error::custom("doesn't match any column type")),
         }
     }
 }

--- a/src/widgets/process_table/sort_table.rs
+++ b/src/widgets/process_table/sort_table.rs
@@ -10,7 +10,7 @@ use crate::{
 pub struct SortTableColumn;
 
 impl ColumnHeader for SortTableColumn {
-    fn text(&self) -> std::borrow::Cow<'static, str> {
+    fn text(&self) -> Cow<'static, str> {
         "Sort By".into()
     }
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -24,7 +24,7 @@ fn cross_runner() -> Option<String> {
     const TARGET_RUNNER: &str = "CARGO_TARGET_RUNNER";
     const CROSS_RUNNER: &str = "CROSS_RUNNER";
 
-    let env_mapping = std::env::vars_os()
+    let env_mapping = env::vars_os()
         .filter_map(|(k, v)| {
             let (k, v) = (k.to_string_lossy(), v.to_string_lossy());
 


### PR DESCRIPTION
Keep code a bit tidier and consistent (i.e. if an identifier already has a `use` entry above, why in some cases still prove a full path to it?)