### PR TITLE
Chore: Remove un-needed lifetimes in a few calls

### DIFF
--- a/src/app/data_harvester/disks/unix/linux/partition.rs
+++ b/src/app/data_harvester/disks/unix/linux/partition.rs
@@ -110,7 +110,7 @@ impl FromStr for Partition {
         let mut parts = line.splitn(5, ' ');
 
         let device = match parts.next() {
-            Some(device) if device == "none" => None,
+            Some("none") => None,
             Some(device) => Some(device.to_string()),
             None => {
                 bail!("missing device");

--- a/src/components/data_table.rs
+++ b/src/components/data_table.rs
@@ -155,9 +155,9 @@ mod test {
     }
 
     impl DataToCell<&'static str> for TestType {
-        fn to_cell<'a>(
-            &'a self, _column: &&'static str, _calculated_width: u16,
-        ) -> Option<tui::text::Text<'a>> {
+        fn to_cell(
+            &self, _column: &&'static str, _calculated_width: u16,
+        ) -> Option<tui::text::Text<'_>> {
             None
         }
 

--- a/src/components/data_table/data_type.rs
+++ b/src/components/data_table/data_type.rs
@@ -8,7 +8,7 @@ where
     H: ColumnHeader,
 {
     /// Given data, a column, and its corresponding width, return what should be displayed in the [`DataTable`](super::DataTable).
-    fn to_cell<'a>(&'a self, column: &H, calculated_width: u16) -> Option<Text<'a>>;
+    fn to_cell(&self, column: &H, calculated_width: u16) -> Option<Text<'_>>;
 
     /// Apply styling to the generated [`Row`] of cells.
     ///

--- a/src/components/data_table/sortable.rs
+++ b/src/components/data_table/sortable.rs
@@ -359,9 +359,9 @@ mod test {
     }
 
     impl DataToCell<ColumnType> for TestType {
-        fn to_cell<'a>(
-            &'a self, _column: &ColumnType, _calculated_width: u16,
-        ) -> Option<tui::text::Text<'a>> {
+        fn to_cell(
+            &self, _column: &ColumnType, _calculated_width: u16,
+        ) -> Option<tui::text::Text<'_>> {
             None
         }
 

--- a/src/widgets/cpu_graph.rs
+++ b/src/widgets/cpu_graph.rs
@@ -76,7 +76,7 @@ impl CpuWidgetTableData {
 }
 
 impl DataToCell<CpuWidgetColumn> for CpuWidgetTableData {
-    fn to_cell<'a>(&'a self, column: &CpuWidgetColumn, calculated_width: u16) -> Option<Text<'a>> {
+    fn to_cell(&self, column: &CpuWidgetColumn, calculated_width: u16) -> Option<Text<'_>> {
         const CPU_TRUNCATE_BREAKPOINT: u16 = 5;
 
         // This is a bit of a hack, but apparently we can avoid having to do any fancy checks

--- a/src/widgets/disk_table.rs
+++ b/src/widgets/disk_table.rs
@@ -126,7 +126,7 @@ impl ColumnHeader for DiskWidgetColumn {
 }
 
 impl DataToCell<DiskWidgetColumn> for DiskWidgetData {
-    fn to_cell<'a>(&'a self, column: &DiskWidgetColumn, calculated_width: u16) -> Option<Text<'a>> {
+    fn to_cell(&self, column: &DiskWidgetColumn, calculated_width: u16) -> Option<Text<'_>> {
         if calculated_width == 0 {
             return None;
         }

--- a/src/widgets/process_table/proc_widget_data.rs
+++ b/src/widgets/process_table/proc_widget_data.rs
@@ -269,7 +269,7 @@ impl ProcWidgetData {
 }
 
 impl DataToCell<ProcColumn> for ProcWidgetData {
-    fn to_cell<'a>(&'a self, column: &ProcColumn, calculated_width: u16) -> Option<Text<'a>> {
+    fn to_cell(&self, column: &ProcColumn, calculated_width: u16) -> Option<Text<'_>> {
         if calculated_width == 0 {
             return None;
         }

--- a/src/widgets/process_table/sort_table.rs
+++ b/src/widgets/process_table/sort_table.rs
@@ -16,7 +16,7 @@ impl ColumnHeader for SortTableColumn {
 }
 
 impl DataToCell<SortTableColumn> for &'static str {
-    fn to_cell<'a>(&'a self, _column: &SortTableColumn, calculated_width: u16) -> Option<Text<'a>> {
+    fn to_cell(&self, _column: &SortTableColumn, calculated_width: u16) -> Option<Text<'_>> {
         if calculated_width == 0 {
             return None;
         }
@@ -33,7 +33,7 @@ impl DataToCell<SortTableColumn> for &'static str {
 }
 
 impl DataToCell<SortTableColumn> for Cow<'static, str> {
-    fn to_cell<'a>(&'a self, _column: &SortTableColumn, calculated_width: u16) -> Option<Text<'a>> {
+    fn to_cell(&self, _column: &SortTableColumn, calculated_width: u16) -> Option<Text<'_>> {
         if calculated_width == 0 {
             return None;
         }

--- a/src/widgets/temperature_table.rs
+++ b/src/widgets/temperature_table.rs
@@ -48,7 +48,7 @@ impl TempWidgetData {
 }
 
 impl DataToCell<TempWidgetColumn> for TempWidgetData {
-    fn to_cell<'a>(&'a self, column: &TempWidgetColumn, calculated_width: u16) -> Option<Text<'a>> {
+    fn to_cell(&self, column: &TempWidgetColumn, calculated_width: u16) -> Option<Text<'_>> {
         if calculated_width == 0 {
             return None;
         }


### PR DESCRIPTION
I am not certain if it will pass 1.70, but it does pass the latest Rust