### PR TITLE
bug: fat32 mounts don't show up in macOS

### DIFF
--- a/src/app/data_harvester/disks/unix/file_systems.rs
+++ b/src/app/data_harvester/disks/unix/file_systems.rs
@@ -117,7 +117,9 @@ impl FromStr for FileSystem {
             _ if s.eq_ignore_ascii_case("ext2") => Ok(FileSystem::Ext2),
             _ if s.eq_ignore_ascii_case("ext3") => Ok(FileSystem::Ext3),
             _ if s.eq_ignore_ascii_case("ext4") => Ok(FileSystem::Ext4),
-            _ if s.eq_ignore_ascii_case("vfat") => Ok(FileSystem::VFat),
+            _ if s.eq_ignore_ascii_case("msdos") || s.eq_ignore_ascii_case("vfat") => {
+                Ok(FileSystem::VFat)
+            }
             _ if s == "ntfs3" || s.eq_ignore_ascii_case("ntfs") => Ok(FileSystem::Ntfs),
             _ if s.eq_ignore_ascii_case("zfs") => Ok(FileSystem::Zfs),
             _ if s.eq_ignore_ascii_case("hfs") => Ok(FileSystem::Hfs),


### PR DESCRIPTION
## Description

Match `msdos` (fat32) as `vfat`

## Issue

Partitions mounted using the fat32(msdos) driver in macOS (Sonoma 14.0) won't show up because the name didn't match.

Relevant information provided by `diskutil list`
```
/dev/disk4 (external, physical):
   #:                       TYPE NAME                    SIZE       IDENTIFIER
   0:     FDisk_partition_scheme                        *123.0 GB   disk4
   1:             Windows_FAT_32 SANDISK                 123.0 GB   disk4s1
```

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Manually check on macOS (Sonoma)

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [x] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
