### PR TITLE
docs: bump mkdocs-related dependencies to latest

### DIFF
--- a/docs/content/configuration/config-file/data-filtering.md
+++ b/docs/content/configuration/config-file/data-filtering.md
@@ -8,7 +8,7 @@ You can hide specific disks, temperature sensors, and networks by name in the co
 
 For example, here's the disk widget with no filter:
 
-![Disk no filter](../../../assets/screenshots/config/disk-filtering/disk_no_filter.webp)
+![Disk no filter](../../assets/screenshots/config/disk-filtering/disk_no_filter.webp)
 
 The following in the config file would filter out some entries by disk name:
 
@@ -21,7 +21,7 @@ case_sensitive = false
 whole_word = false
 ```
 
-![Disk widget with just disk name filter](../../../assets/screenshots/config/disk-filtering/disk_name_filter.webp)
+![Disk widget with just disk name filter](../../assets/screenshots/config/disk-filtering/disk_name_filter.webp)
 
 If there are two potentially conflicting filters (i.e. when you are using both a disk and mount filter), the filter that explicitly allows an entry takes precedence over a filter that explicitly denies one. So for example, let's say we set a disk filter accepting anything with `/dev/sda`, but deny anything with `/mnt/.*` or `/`. So to do so, we write in the config file:
 
@@ -43,4 +43,4 @@ whole_word = true
 
 This gives us:
 
-![Disk widget with disk name and mount filter](../../../assets/screenshots/config/disk-filtering/disk_name_mount_filter.webp)
+![Disk widget with disk name and mount filter](../../assets/screenshots/config/disk-filtering/disk_name_mount_filter.webp)

--- a/docs/content/configuration/config-file/flags.md
+++ b/docs/content/configuration/config-file/flags.md
@@ -4,7 +4,7 @@
 
     This section is in progress, and is just copied from the old documentation.
 
-Most of the [command line flags](../../command-line-flags) have config file equivalents to avoid having to type them out
+Most of the [command line flags](../command-line-flags.md) have config file equivalents to avoid having to type them out
 each time:
 
 | Field                        | Type                                                                                           | Functionality                                                                        |

--- a/docs/content/configuration/config-file/layout.md
+++ b/docs/content/configuration/config-file/layout.md
@@ -31,7 +31,7 @@ The second column is split into two rows with a 1:1 ratio. The first is the temp
 
 This is what the layout would look like when run:
 
-![Sample layout](../../../assets/screenshots/config/layout/sample_layout.webp)
+![Sample layout](../../assets/screenshots/config/layout/sample_layout.webp)
 
 Each `[[row]]` represents a _row_ in the layout. A row can have any number of `child` values. Each `[[row.child]]`
 represents either a _column or a widget_. A column can have any number of `child` values as well. Each `[[row.child.child]]`

--- a/docs/content/contribution/development/build_process.md
+++ b/docs/content/contribution/development/build_process.md
@@ -36,7 +36,7 @@ Binaries are built currently for various targets. Note that not all of these are
     - `COMPLETION_DIR: "target/tmp/bottom/completion/"`
     - `MANPAGE_DIR: "target/tmp/bottom/manpage/"`
 
-    These generate the manpages and shell completions (see [Packaging](packaging-and-distribution.md) for some more information).
+    These generate the manpages and shell completions (see [Packaging](../packaging-and-distribution.md) for some more information).
 
 - Bundle the binaries and manpage/completions.
 - Cleanup.

--- a/docs/content/contribution/documentation.md
+++ b/docs/content/contribution/documentation.md
@@ -61,4 +61,4 @@ There are a few areas where documentation changes are often needed:
    This will serve a local version of the docs that you can open on your browser. It will update as you make changes.
 
 3. Once you have your documentation changes done, submit it as a pull request. For more information regarding that,
-   refer to [Issues, Pull Requests, and Discussions](../issues-and-pull-requests/).
+   refer to [Issues, Pull Requests, and Discussions](issues-and-pull-requests.md).

--- a/docs/content/contribution/packaging-and-distribution.md
+++ b/docs/content/contribution/packaging-and-distribution.md
@@ -64,4 +64,4 @@ the installation method and any details to the [`README.md`](https://github.com/
 file under the [Installation](https://github.com/ClementTsang/bottom#installation) section, as well as a corresponding
 table of contents entry. Once that's done, open a pull request - these will usually be approved of very quickly.
 
-You can find more info on the contribution process [here](../issues-and-pull-requests/#pull-requests).
+You can find more info on the contribution process [here](issues-and-pull-requests.md#pull-requests).

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -18,22 +18,22 @@ This site serves as extended documentation for bottom alongside the [`README.md`
 
 !!! Tip
 
-    It is a good idea to first check out the [Support](./support/official) page to see if your system is officially supported!
+    It is a good idea to first check out the [Support](support/official.md) page to see if your system is officially supported!
 
 !!! Tip
 
-    If you're facing some issues during/after installation, check out the [Troubleshooting](./troubleshooting) page for some common problems and solutions.
+    If you're facing some issues during/after installation, check out the [Troubleshooting](troubleshooting.md) page for some common problems and solutions.
 
 To install bottom, refer to [the installation section of the `README.md`](https://github.com/ClementTsang/bottom#installation),
 which contains a list of all the installation methods.
 
 ## Usage and configuration
 
-You can refer to the [usage](./usage/general-usage/) pages on how to use bottom (e.g. keybinds, some features, a general overview of what each widget does).
+You can refer to the [usage](usage/general-usage.md) pages on how to use bottom (e.g. keybinds, some features, a general overview of what each widget does).
 
-To configure bottom, refer to the [configuration](./configuration/command-line-flags/) pages (e.g. how it behaves, how it looks).
+To configure bottom, refer to the [configuration](configuration/command-line-flags.md) pages (e.g. how it behaves, how it looks).
 
 ## Contribution
 
-New contributors are always welcome! See the [contribution](./contribution/issues-and-pull-requests/) section for how to contribute to
+New contributors are always welcome! See the [contribution](contribution/issues-and-pull-requests.md) section for how to contribute to
 bottom, whether it be filing issues, writing documentation, creating pull requests, etc.

--- a/docs/content/usage/widgets/network.md
+++ b/docs/content/usage/widgets/network.md
@@ -12,7 +12,7 @@ received and transmitted.
 The legend displays the current reads and writes per second in bits, as well as the total amount read/written.
 
 The y-axis automatically scales based on shown read/write values, and by default, is a linear scale based on base-10 units (e.x. kilobit, gigabit, etc.).
-Through [configuration](../../../configuration/command-line-flags/), the read/write per second unit can be changed to bytes, while the y-axis can be changed to a
+Through [configuration](../../configuration/command-line-flags.md), the read/write per second unit can be changed to bytes, while the y-axis can be changed to a
 log scale and/or use base-2 units (e.x. kibibit, gibibit, etc.).
 
 One can also adjust the displayed time range through either the keyboard or mouse, with a range of 30s to 600s.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
-mkdocs == 1.5.2
-mkdocs-material == 9.2.8
-mkdocs-material-extensions == 1.1.1
+mkdocs == 1.5.3
+mkdocs-material == 9.4.8
+mkdocs-material-extensions == 1.3
 mdx_truly_sane_lists == 1.3
 mike == 1.1.2
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

bumps mkdocs-material to 9.4.8, mkdocs to 1.5.3, mkdocs-material-extensions to 1.3

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
