### PR TITLE
refactor: add fast branch if the string is short enough to not be truncated

### DIFF
--- a/src/utils/gen_util.rs
+++ b/src/utils/gen_util.rs
@@ -101,20 +101,19 @@ fn grapheme_width(g: &str) -> usize {
 fn truncate_str<U: Into<usize>>(content: &str, width: U) -> String {
     let width = width.into();
 
-    if width > 0 {
+    if content.len() <= width {
+        // If the entire string fits in the width, it'll definitely fit.
+        content.to_owned()
+    } else if width > 0 {
         if content.is_ascii() {
             // If the entire string is ASCII, we can use a much simpler approach.
 
-            if content.len() <= width {
-                content.to_owned()
-            } else {
-                let mut text = String::with_capacity(width);
-                let (keep, _throw) = content.split_at(width - 1);
-                text.push_str(keep);
-                text.push('…');
+            let mut text = String::with_capacity(width);
+            let (keep, _throw) = content.split_at(width - 1);
+            text.push_str(keep);
+            text.push('…');
 
-                text
-            }
+            text
         } else {
             let mut text = String::with_capacity(width);
             let mut curr_width = 0;

--- a/src/utils/gen_util.rs
+++ b/src/utils/gen_util.rs
@@ -102,11 +102,14 @@ fn truncate_str<U: Into<usize>>(content: &str, width: U) -> String {
     let width = width.into();
 
     if content.len() <= width {
-        // If the entire string fits in the width, it'll definitely fit.
+        // If the entire string fits in the width, then we just
+        // need to copy the entire string over.
+
         content.to_owned()
     } else if width > 0 {
         if content.is_ascii() {
-            // If the entire string is ASCII, we can use a much simpler approach.
+            // If the entire string is ASCII, we can use a much simpler approach
+            // in regards to what we truncate.
 
             let mut text = String::with_capacity(width);
             let (keep, _throw) = content.split_at(width - 1);
@@ -115,6 +118,9 @@ fn truncate_str<U: Into<usize>>(content: &str, width: U) -> String {
 
             text
         } else {
+            // Otherwise iterate by grapheme and greedily fit as many graphemes
+            // as width will allow.
+
             let mut text = String::with_capacity(width);
             let mut curr_width = 0;
             let mut early_break = false;


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Another branch to skip slicing/iteration if the string is short enough compared to the width given that it _must_ fit. This makes it fast to have a small string and/or a lot of space to accommodate it, which is likely the most usual case.

The `faster_ascii` below shows benchmark speed of each function (`original` is the implementation before #1330).

![lines](https://github.com/ClementTsang/bottom/assets/34804052/0da3fecb-e5aa-42a1-95f2-c709ea012407)
![lines](https://github.com/ClementTsang/bottom/assets/34804052/15f7721c-2c72-44ac-8f10-df767ecf5b2d)
![lines](https://github.com/ClementTsang/bottom/assets/34804052/29a0d4ab-eabd-40b9-987d-db1ab46ec395)
![lines](https://github.com/ClementTsang/bottom/assets/34804052/5beaa3a4-5f35-4ac4-a05e-582a5bec3519)


## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
