### PR TITLE
refactor: iteratively detect ASCII and build string when truncating

### DIFF
--- a/src/utils/gen_util.rs
+++ b/src/utils/gen_util.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::{cmp::Ordering, num::NonZeroUsize};
 
 use tui::text::{Line, Span, Text};
 use unicode_segmentation::UnicodeSegmentation;
@@ -59,6 +59,8 @@ pub fn get_decimal_prefix(quantity: u64, unit: &str) -> (f64, String) {
 }
 
 /// Truncates text if it is too long, and adds an ellipsis at the end if needed.
+///
+/// TODO: Maybe cache results from this function for some cases? e.g. columns
 pub fn truncate_to_text<'a, U: Into<usize>>(content: &str, width: U) -> Text<'a> {
     Text {
         lines: vec![Line::from(vec![Span::raw(truncate_str(content, width))])],
@@ -93,10 +95,67 @@ fn grapheme_width(g: &str) -> usize {
     }
 }
 
-/// Truncates a string with an ellipsis character.
+enum AsciiIterationResult {
+    Complete,
+    Remaining(usize),
+}
+
+/// Greedily add characters to the output until a non-ASCII grapheme is found, or
+/// the output is `width` long.
+#[inline]
+fn greedy_ascii_add(content: &str, width: NonZeroUsize) -> (String, AsciiIterationResult) {
+    let width: usize = width.into();
+
+    const SIZE_OF_CHAR: usize = std::mem::size_of::<char>();
+    let mut text = Vec::with_capacity(width + SIZE_OF_CHAR);
+
+    let s = content.as_bytes();
+
+    let mut current_index = 0;
+
+    while current_index < width - 1 {
+        let current_byte = s[current_index];
+        if current_byte.is_ascii() {
+            text.push(current_byte);
+            current_index += 1;
+        } else {
+            debug_assert!(text.is_ascii());
+
+            let current_index = AsciiIterationResult::Remaining(current_index);
+
+            // SAFETY: This conversion is safe to do unchecked, we only push ASCII characters up to
+            // this point.
+            let current_text = unsafe { String::from_utf8_unchecked(text) };
+
+            return (current_text, current_index);
+        }
+    }
+
+    // If we made it all the way through, then we probably hit the width limit.
+    debug_assert!(text.is_ascii());
+
+    let current_index = if s[current_index].is_ascii() {
+        let mut ellipsis = [0; 3];
+        '…'.encode_utf8(&mut ellipsis);
+        text.extend_from_slice(&ellipsis);
+        AsciiIterationResult::Complete
+    } else {
+        AsciiIterationResult::Remaining(current_index)
+    };
+
+    // SAFETY: This conversion is safe to do unchecked, we only push ASCII characters up to
+    // this point.
+    let current_text = unsafe { String::from_utf8_unchecked(text) };
+
+    (current_text, current_index)
+}
+
+/// Truncates a string to the specified width with an ellipsis character.
 ///
 /// NB: This probably does not handle EVERY case, but I think it handles most cases
 /// we will use this function for fine... hopefully.
+///
+/// TODO: Maybe fuzz this function?
 #[inline]
 fn truncate_str<U: Into<usize>>(content: &str, width: U) -> String {
     let width = width.into();
@@ -106,54 +165,54 @@ fn truncate_str<U: Into<usize>>(content: &str, width: U) -> String {
         // need to copy the entire string over.
 
         content.to_owned()
-    } else if width > 0 {
-        if content.is_ascii() {
-            // If the entire string is ASCII, we can use a much simpler approach
-            // in regards to what we truncate.
+    } else if let Some(nz_width) = NonZeroUsize::new(width) {
+        // What we are essentially doing is optimizing for the case that
+        // most, if not all of the string is ASCII. As such:
+        // - Step through each byte until (width - 1) is hit or we find a non-ascii
+        //   byte.
+        // - If the byte is ascii, then add it.
+        //
+        // If we didn't get a complete truncated string, then continue on treating the rest as graphemes.
 
-            let mut text = String::with_capacity(width);
-            let (keep, _throw) = content.split_at(width - 1);
-            text.push_str(keep);
-            text.push('…');
+        let (mut text, res) = greedy_ascii_add(content, nz_width);
+        match res {
+            AsciiIterationResult::Complete => text,
+            AsciiIterationResult::Remaining(current_index) => {
+                let mut curr_width = text.len();
+                let mut early_break = false;
 
-            text
-        } else {
-            // Otherwise iterate by grapheme and greedily fit as many graphemes
-            // as width will allow.
+                // This tracks the length of the last added string - note this does NOT match the grapheme *width*.
+                // Since the previous characters are always ASCII, this is always initialized as 1, unless the string
+                // is empty.
+                let mut last_added_str_len = if text.is_empty() { 0 } else { 1 };
 
-            let mut text = String::with_capacity(width);
-            let mut curr_width = 0;
-            let mut early_break = false;
+                // Cases to handle:
+                // - Completes adding the entire string.
+                // - Adds a character up to the boundary, then fails.
+                // - Adds a character not up to the boundary, then fails.
+                // Inspired by https://tomdebruijn.com/posts/rust-string-length-width-calculations/
+                for g in UnicodeSegmentation::graphemes(&content[current_index..], true) {
+                    let g_width = grapheme_width(g);
 
-            // This tracks the length of the last added string - note this does NOT match the grapheme *width*.
-            let mut last_added_str_len = 0;
-
-            // Cases to handle:
-            // - Completes adding the entire string.
-            // - Adds a character up to the boundary, then fails.
-            // - Adds a character not up to the boundary, then fails.
-            // Inspired by https://tomdebruijn.com/posts/rust-string-length-width-calculations/
-            for g in UnicodeSegmentation::graphemes(content, true) {
-                let g_width = grapheme_width(g);
-
-                if curr_width + g_width <= width {
-                    curr_width += g_width;
-                    last_added_str_len = g.len();
-                    text.push_str(g);
-                } else {
-                    early_break = true;
-                    break;
+                    if curr_width + g_width <= width {
+                        curr_width += g_width;
+                        last_added_str_len = g.len();
+                        text.push_str(g);
+                    } else {
+                        early_break = true;
+                        break;
+                    }
                 }
-            }
 
-            if early_break {
-                if curr_width == width {
-                    // Remove the last grapheme cluster added.
-                    text.truncate(text.len() - last_added_str_len);
+                if early_break {
+                    if curr_width == width {
+                        // Remove the last grapheme cluster added.
+                        text.truncate(text.len() - last_added_str_len);
+                    }
+                    text.push('…');
                 }
-                text.push('…');
+                text
             }
-            text
         }
     } else {
         String::default()

--- a/src/utils/gen_util.rs
+++ b/src/utils/gen_util.rs
@@ -100,54 +100,43 @@ enum AsciiIterationResult {
     Remaining(usize),
 }
 
-const SIZE_OF_USIZE: usize = std::mem::size_of::<usize>();
-
-/// Returns `true` if any byte in the word `v` is nonascii (>= 128).
-/// Taken from the slice code for determining non_ascii.
+/// Greedily add characters to the output until a non-ASCII grapheme is found, or
+/// the output is `width` long.
 #[inline]
-const fn contains_nonascii(v: usize) -> bool {
-    const NONASCII_MASK: usize = usize::from_ne_bytes([0x80; SIZE_OF_USIZE]);
-    (NONASCII_MASK & v) != 0
-}
-
-/// This should only be called if `width` is smaller than `bytes`, assuming bytes
-/// is fully ASCII. If it is not all ASCII, then it doesn't matter.
-#[inline]
-fn simple_build_ascii_str(bytes: &[u8], width: NonZeroUsize) -> (String, AsciiIterationResult) {
+fn greedy_ascii_add(content: &str, width: NonZeroUsize) -> (String, AsciiIterationResult) {
     let width: usize = width.into();
 
-    let mut raw_text = Vec::with_capacity(width);
+    let mut text = Vec::with_capacity(width);
+
+    let s = content.as_bytes();
 
     let mut current_index = 0;
 
     while current_index < width - 1 {
-        let current_byte = bytes[current_index];
+        let current_byte = s[current_index];
         if current_byte.is_ascii() {
-            raw_text.push(current_byte);
+            text.push(current_byte);
             current_index += 1;
         } else {
-            debug_assert!(raw_text.is_ascii());
+            debug_assert!(text.is_ascii());
 
             let current_index = AsciiIterationResult::Remaining(current_index);
 
-            // SAFETY: This conversion is safe to do unchecked, we only push ASCII characters
-            // up to this point.
-            let text = unsafe { String::from_utf8_unchecked(raw_text) };
+            // SAFETY: This conversion is safe to do unchecked, we only push ASCII characters up to
+            // this point.
+            let current_text = unsafe { String::from_utf8_unchecked(text) };
 
-            return (text, current_index);
+            return (current_text, current_index);
         }
     }
 
-    debug_assert!(raw_text.is_ascii());
+    // If we made it all the way through, then we probably hit the width limit.
+    debug_assert!(text.is_ascii());
 
-    // If the next character is not ASCII, then we may need to still check it.
-    // Otherwise, we always want to put the ellipsis as the while loop exited after
-    // the second last character was put, and we know this string is too wide for
-    // width.
-    let current_index = if bytes[current_index].is_ascii() {
+    let current_index = if s[current_index].is_ascii() {
         let mut ellipsis = [0; 3];
         '…'.encode_utf8(&mut ellipsis);
-        raw_text.extend_from_slice(&ellipsis);
+        text.extend_from_slice(&ellipsis);
         AsciiIterationResult::Complete
     } else {
         AsciiIterationResult::Remaining(current_index)
@@ -155,122 +144,9 @@ fn simple_build_ascii_str(bytes: &[u8], width: NonZeroUsize) -> (String, AsciiIt
 
     // SAFETY: This conversion is safe to do unchecked, we only push ASCII characters up to
     // this point.
-    let text = unsafe { String::from_utf8_unchecked(raw_text) };
+    let current_text = unsafe { String::from_utf8_unchecked(text) };
 
-    (text, current_index)
-}
-
-/// Read one usize at a time. Based on the `is_ascii` for slices in core.
-fn usize_build_ascii_str(
-    bytes: &[u8], width: NonZeroUsize, align_offset: usize,
-) -> (String, AsciiIterationResult) {
-    let width: usize = width.into();
-    let mut raw_text: Vec<u8>;
-    let len = bytes.len();
-
-    // We always read the first word unaligned, which means `align_offset` is
-    // 0, we'd read the same value again for the aligned read.
-    let offset_to_aligned = if align_offset == 0 {
-        SIZE_OF_USIZE
-    } else {
-        align_offset
-    };
-
-    const BYTES_PER_WORD: usize = SIZE_OF_USIZE / std::mem::size_of::<u8>();
-
-    let start = bytes.as_ptr();
-
-    {
-        // SAFETY: We verify `len < SIZE_OF_USIZE` above.
-        let first_word = unsafe { (start as *const usize).read_unaligned() };
-        if contains_nonascii(first_word) {
-            return (String::default(), AsciiIterationResult::Remaining(0));
-        } else {
-            // Only bother initializing if the first check succeeds.
-            raw_text = Vec::with_capacity(width);
-
-            for i in 0..BYTES_PER_WORD {
-                let c = unsafe { (start as *const u8).add(i).read_unaligned() };
-                raw_text.push(c);
-            }
-        }
-    }
-
-    debug_assert!(offset_to_aligned <= len);
-
-    // SAFETY: word_ptr is the (properly aligned) usize ptr we use to read the
-    // middle chunk of the slice.
-    let mut word_ptr = unsafe { start.add(offset_to_aligned) as *const usize };
-
-    // `byte_pos` is the byte index of `word_ptr`, used for loop end checks.
-    let mut byte_pos = offset_to_aligned;
-
-    while byte_pos < len - SIZE_OF_USIZE {
-        // Sanity check that the read is in bounds
-        debug_assert!(byte_pos + SIZE_OF_USIZE <= len);
-
-        // SAFETY: We know `word_ptr` is properly aligned (because of `align_offset`),
-        // and we know that we have enough bytes between `word_ptr` and the end
-        let word: usize = unsafe { word_ptr.read() };
-
-        if contains_nonascii(word) {
-            // SAFETY: We've only added ASCII characters so this is safe.
-            let text = unsafe { String::from_utf8_unchecked(raw_text) };
-            return (text, AsciiIterationResult::Remaining(byte_pos));
-        } else {
-            for i in 0..BYTES_PER_WORD {
-                let c = unsafe { (word as *const u8).add(i).read_unaligned() };
-                raw_text.push(c);
-            }
-        }
-
-        byte_pos += SIZE_OF_USIZE;
-
-        // SAFETY: We know that `byte_pos <= len - SIZE_OF_USIZE`, which means that
-        // after this `add`, `word_ptr` will be at most one-past-the-end.
-        word_ptr = unsafe { word_ptr.add(1) };
-    }
-
-    // Sanity check to ensure there really is only one `usize` left. This should
-    // be guaranteed by our loop condition.
-    debug_assert!(byte_pos <= len && len - byte_pos <= SIZE_OF_USIZE);
-
-    let last_index = len - SIZE_OF_USIZE;
-
-    // SAFETY: This relies on `len >= SIZE_OF_USIZE`, which we check at the start.
-    let last_word = unsafe { (start.add(last_index) as *const usize).read_unaligned() };
-
-    let current_index = if contains_nonascii(last_word) {
-        AsciiIterationResult::Remaining(last_index)
-    } else {
-        for i in 0..BYTES_PER_WORD {
-            let c = unsafe { (last_word as *const u8).add(i).read_unaligned() };
-            raw_text.push(c);
-        }
-        AsciiIterationResult::Complete
-    };
-
-    // SAFETY: We've only added ASCII characters so this is safe.
-    let text = unsafe { String::from_utf8_unchecked(raw_text) };
-
-    (text, current_index)
-}
-
-/// Continuously add characters to the output until a non-ASCII grapheme is found, or
-/// the output is `width` long.
-#[inline]
-fn build_ascii_str(content: &str, width: NonZeroUsize) -> (String, AsciiIterationResult) {
-    let bytes = content.as_bytes();
-    let len = bytes.len();
-    let align_offset = bytes.as_ptr().align_offset(SIZE_OF_USIZE);
-
-    // If we wouldn't gain anything from the word-at-a-time implementation, fall
-    // back to a scalar loop.
-    if len < SIZE_OF_USIZE || len < align_offset || SIZE_OF_USIZE < std::mem::align_of::<usize>() {
-        simple_build_ascii_str(bytes, width)
-    } else {
-        usize_build_ascii_str(bytes, width, align_offset)
-    }
+    (current_text, current_index)
 }
 
 /// Truncates a string to the specified width with an ellipsis character.
@@ -297,11 +173,12 @@ fn truncate_str<U: Into<usize>>(content: &str, width: U) -> String {
         //
         // If we didn't get a complete truncated string, then continue on treating the rest as graphemes.
 
-        let (mut text, res) = build_ascii_str(content, nz_width);
+        let (mut text, res) = greedy_ascii_add(content, nz_width);
         match res {
             AsciiIterationResult::Complete => text,
             AsciiIterationResult::Remaining(current_index) => {
                 let mut curr_width = text.len();
+                let mut early_break = false;
 
                 // This tracks the length of the last added string - note this does NOT match the grapheme *width*.
                 // Since the previous characters are always ASCII, this is always initialized as 1, unless the string
@@ -321,16 +198,18 @@ fn truncate_str<U: Into<usize>>(content: &str, width: U) -> String {
                         last_added_str_len = g.len();
                         text.push_str(g);
                     } else {
-                        if curr_width == width {
-                            // Remove the last grapheme cluster added.
-                            text.truncate(text.len() - last_added_str_len);
-                        }
-                        text.push('…');
-
+                        early_break = true;
                         break;
                     }
                 }
 
+                if early_break {
+                    if curr_width == width {
+                        // Remove the last grapheme cluster added.
+                        text.truncate(text.len() - last_added_str_len);
+                    }
+                    text.push('…');
+                }
                 text
             }
         }

--- a/src/utils/gen_util.rs
+++ b/src/utils/gen_util.rs
@@ -106,8 +106,7 @@ enum AsciiIterationResult {
 fn greedy_ascii_add(content: &str, width: NonZeroUsize) -> (String, AsciiIterationResult) {
     let width: usize = width.into();
 
-    const SIZE_OF_CHAR: usize = std::mem::size_of::<char>();
-    let mut text = Vec::with_capacity(width + SIZE_OF_CHAR);
+    let mut text = Vec::with_capacity(width);
 
     let s = content.as_bytes();
 
@@ -395,7 +394,7 @@ mod test {
     }
 
     #[test]
-    fn test_truncate_mixed() {
+    fn test_truncate_mixed_one() {
         let test = "Test (施氏食獅史) Test";
 
         assert_eq!(
@@ -416,6 +415,8 @@ mod test {
             "should truncate the t and replace the s with ellipsis"
         );
 
+        assert_eq!(truncate_str(test, 20_usize), "Test (施氏食獅史) T…");
+        assert_eq!(truncate_str(test, 19_usize), "Test (施氏食獅史) …");
         assert_eq!(truncate_str(test, 18_usize), "Test (施氏食獅史)…");
         assert_eq!(truncate_str(test, 17_usize), "Test (施氏食獅史…");
         assert_eq!(truncate_str(test, 16_usize), "Test (施氏食獅…");
@@ -425,6 +426,34 @@ mod test {
         assert_eq!(truncate_str(test, 8_usize), "Test (…");
         assert_eq!(truncate_str(test, 7_usize), "Test (…");
         assert_eq!(truncate_str(test, 6_usize), "Test …");
+        assert_eq!(truncate_str(test, 5_usize), "Test…");
+        assert_eq!(truncate_str(test, 4_usize), "Tes…");
+    }
+
+    #[test]
+    fn test_truncate_mixed_two() {
+        let test = "Test (施氏abc食abc獅史) Test";
+
+        assert_eq!(
+            truncate_str(test, 30_usize),
+            test,
+            "should match base string as there is extra room"
+        );
+
+        assert_eq!(
+            truncate_str(test, 28_usize),
+            test,
+            "should match base string as there is just enough room"
+        );
+
+        assert_eq!(truncate_str(test, 26_usize), "Test (施氏abc食abc獅史) T…");
+        assert_eq!(truncate_str(test, 21_usize), "Test (施氏abc食abc獅…");
+        assert_eq!(truncate_str(test, 20_usize), "Test (施氏abc食abc…");
+        assert_eq!(truncate_str(test, 16_usize), "Test (施氏abc食…");
+        assert_eq!(truncate_str(test, 15_usize), "Test (施氏abc…");
+        assert_eq!(truncate_str(test, 14_usize), "Test (施氏abc…");
+        assert_eq!(truncate_str(test, 11_usize), "Test (施氏…");
+        assert_eq!(truncate_str(test, 10_usize), "Test (施…");
     }
 
     #[test]


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This PR now does string truncation and ASCII detection side by side iteratively, as opposed to the previous method of doing one full ASCII check pass before building the string.

Benchmark code: https://gist.github.com/ClementTsang/e84ff878892928f4789ac724be3a56a9

Resulting charts:

![lines](https://github.com/ClementTsang/bottom/assets/34804052/8fa8ee2f-f55e-47fe-aebe-3e88b730d9fe)
![lines](https://github.com/ClementTsang/bottom/assets/34804052/35812d24-50e7-477f-8e10-2cdb766381c6)
![lines](https://github.com/ClementTsang/bottom/assets/34804052/0634e325-5e2a-4d10-846c-1fe2623bcb15)
![lines](https://github.com/ClementTsang/bottom/assets/34804052/53105e1a-104b-4a06-b41a-73c2b8f0908d)
![lines](https://github.com/ClementTsang/bottom/assets/34804052/ab5259e6-c48b-46d3-9897-3d8a684dd974)
![lines](https://github.com/ClementTsang/bottom/assets/34804052/b919f244-db92-4f10-9ae2-f13bb0996dbb)
![lines](https://github.com/ClementTsang/bottom/assets/34804052/152d3233-5b5c-492d-a425-6ffdbc22f634)
![lines](https://github.com/ClementTsang/bottom/assets/34804052/aee01224-f1d5-4817-a67b-77ace5237bbf)
![lines](https://github.com/ClementTsang/bottom/assets/34804052/6219fde2-d02d-4596-aa7b-3d50b8f16d9d)




## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
