### PR TITLE
ci: downgrade to checkout v3 when building releases in non-GH containers

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -123,7 +123,14 @@ jobs:
             }
     steps:
       - name: Checkout repository
+        if: matrix.info.container == ''
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 1
+
+      - name: Checkout repository (non-GitHub container)
+        if: matrix.info.container != ''
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Looks like `checkout@v4` action causes some problems with the quay container (see https://github.com/actions/checkout/issues/1474), this PR just adds an exception for it to use the previous v3 checkout action.

## Issue

_If applicable, what issue does this address?_

Closes: #1351

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

[Test build job](https://github.com/ClementTsang/bottom/actions/runs/7118078437)

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
