### PR TITLE
update ratatui version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -46,9 +46,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -60,36 +60,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -142,9 +142,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bottom"
@@ -162,7 +162,7 @@ dependencies = [
  "clap_mangen",
  "concat-string",
  "core-foundation",
- "crossterm 0.27.0",
+ "crossterm",
  "ctrlc",
  "dirs",
  "fern",
@@ -195,20 +195,20 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
 dependencies = [
  "memchr",
- "regex-automata 0.3.7",
+ "regex-automata",
  "serde",
 ]
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cargo-husky"
@@ -224,9 +224,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]
@@ -239,18 +239,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.10"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.9"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -318,9 +318,9 @@ checksum = "7439becb5fafc780b6f4de382b1a7a3e70234afe783854a4702ee8adbb838609"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -328,25 +328,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -355,40 +345,23 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
 ]
 
 [[package]]
@@ -397,7 +370,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -423,7 +396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
 dependencies = [
  "nix 0.27.1",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -463,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
 dependencies = [
  "powerfmt",
 ]
@@ -494,7 +467,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -518,7 +491,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -529,23 +502,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -585,9 +547,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -596,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "hashbrown"
@@ -615,12 +577,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "humantime"
@@ -646,15 +602,15 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -670,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "kstring"
@@ -691,9 +647,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libloading"
@@ -706,16 +662,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.11"
+name = "libredox"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -728,10 +695,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "mach2"
-version = "0.4.1"
+name = "lru"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
@@ -762,26 +738,25 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "static_assertions",
 ]
 
 [[package]]
@@ -790,7 +765,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cfg-if",
  "libc",
 ]
@@ -812,21 +787,11 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -863,18 +828,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "option-ext"
@@ -894,13 +859,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -919,14 +884,14 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
 dependencies = [
  "anstyle",
  "difflib",
  "float-cmp",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -950,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -968,24 +933,28 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8285baa38bdc9f879d92c0e37cb562ef38aa3aeefca22b3200186bc39242d3d5"
+checksum = "a5659e52e4ba6e07b2dad9f1158f578ef84a73762625ddb51536019f34d180eb"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cassowary",
- "crossterm 0.26.1",
+ "crossterm",
  "indoc",
+ "itertools 0.12.0",
+ "lru",
  "paste",
+ "stability",
+ "strum",
  "unicode-segmentation",
  "unicode-width",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -993,42 +962,31 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.16",
+ "libredox",
  "thiserror",
 ]
 
@@ -1040,15 +998,9 @@ checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
 
 [[package]]
 name = "regex-automata"
@@ -1081,22 +1033,28 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.25"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.15"
+name = "rustversion"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "same-file"
@@ -1130,7 +1088,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1185,9 +1143,19 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
+name = "stability"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "starship-battery"
@@ -1200,7 +1168,7 @@ dependencies = [
  "lazycell",
  "libc",
  "mach2",
- "nix 0.26.2",
+ "nix 0.26.4",
  "num-traits",
  "uom",
  "winapi",
@@ -1225,6 +1193,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.41",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.32"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1252,7 +1242,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -1282,7 +1272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1293,29 +1283,29 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.41",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "itoa",
@@ -1335,9 +1325,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
 dependencies = [
  "time-core",
 ]
@@ -1366,15 +1356,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1421,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -1453,9 +1443,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -1492,6 +1482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1610,9 +1609,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.14"
+version = "0.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
+checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
  "memchr",
 ]
@@ -1646,5 +1645,5 @@ checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.41",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
 
 [[package]]
 name = "assert_cmd"
@@ -391,12 +391,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.1"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
+checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
 dependencies = [
  "nix 0.27.1",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -491,7 +491,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]
@@ -1088,7 +1088,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -1104,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -1211,7 +1211,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -1227,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1298,7 +1298,7 @@ checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -1630,20 +1630,20 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ sysinfo = "=0.29.11"
 thiserror = "1.0.50"
 time = { version = "0.3.30", features = ["formatting", "macros"] }
 toml_edit = { version = "0.21.0", features = ["serde"] }
-tui = { version = "0.22.0", package = "ratatui" }
+tui = { version = "0.25.0", package = "ratatui" }
 unicode-segmentation = "1.10.1"
 unicode-width = "0.1.11"
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -287,7 +287,8 @@ fn main() -> Result<()> {
 
                             #[cfg(feature = "zfs")]
                             {
-                                let arc_labels = convert_arc_labels(&app.data_collection);
+                                let arc_labels =
+                                    convert_mem_label(&app.data_collection.arc_harvest);
                                 app.converted_data.arc_labels = arc_labels;
                             }
                         }

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -211,7 +211,7 @@ impl Painter {
         self.styled_help_text = styled_help_spans.into_iter().map(Line::from).collect();
     }
 
-    fn draw_frozen_indicator<B: Backend>(&self, f: &mut Frame<'_, B>, draw_loc: Rect) {
+    fn draw_frozen_indicator(&self, f: &mut Frame<'_>, draw_loc: Rect) {
         f.render_widget(
             Paragraph::new(Span::styled(
                 "Frozen, press 'f' to unfreeze",
@@ -295,7 +295,7 @@ impl Painter {
                     })
                     .split(vertical_dialog_chunk[1]);
 
-                self.draw_help_dialog(f, app_state, middle_dialog_chunk[1]);
+                self.draw_help_dialog::<B>(f, app_state, middle_dialog_chunk[1]);
             } else if app_state.delete_dialog_state.is_showing_dd {
                 let dd_text = self.get_dd_spans(app_state);
 
@@ -335,7 +335,7 @@ impl Painter {
 
                 // This is a bit nasty, but it works well... I guess.
                 app_state.delete_dialog_state.is_showing_dd =
-                    self.draw_dd_dialog(f, dd_text, app_state, middle_dialog_chunk[1]);
+                    self.draw_dd_dialog::<B>(f, dd_text, app_state, middle_dialog_chunk[1]);
             } else if app_state.is_expanded {
                 if let Some(frozen_draw_loc) = frozen_draw_loc {
                     self.draw_frozen_indicator(f, frozen_draw_loc);
@@ -346,32 +346,37 @@ impl Painter {
                     .constraints([Constraint::Percentage(100)])
                     .split(terminal_size);
                 match &app_state.current_widget.widget_type {
-                    Cpu => self.draw_cpu(f, app_state, rect[0], app_state.current_widget.widget_id),
-                    CpuLegend => self.draw_cpu(
+                    Cpu => self.draw_cpu::<B>(
+                        f,
+                        app_state,
+                        rect[0],
+                        app_state.current_widget.widget_id,
+                    ),
+                    CpuLegend => self.draw_cpu::<B>(
                         f,
                         app_state,
                         rect[0],
                         app_state.current_widget.widget_id - 1,
                     ),
-                    Mem | BasicMem => self.draw_memory_graph(
+                    Mem | BasicMem => self.draw_memory_graph::<B>(
                         f,
                         app_state,
                         rect[0],
                         app_state.current_widget.widget_id,
                     ),
-                    Disk => self.draw_disk_table(
+                    Disk => self.draw_disk_table::<B>(
                         f,
                         app_state,
                         rect[0],
                         app_state.current_widget.widget_id,
                     ),
-                    Temp => self.draw_temp_table(
+                    Temp => self.draw_temp_table::<B>(
                         f,
                         app_state,
                         rect[0],
                         app_state.current_widget.widget_id,
                     ),
-                    Net => self.draw_network_graph(
+                    Net => self.draw_network_graph::<B>(
                         f,
                         app_state,
                         rect[0],
@@ -386,9 +391,9 @@ impl Painter {
                                 _ => 0,
                             };
 
-                        self.draw_process_widget(f, app_state, rect[0], true, widget_id);
+                        self.draw_process_widget::<B>(f, app_state, rect[0], true, widget_id);
                     }
-                    Battery => self.draw_battery_display(
+                    Battery => self.draw_battery_display::<B>(
                         f,
                         app_state,
                         rect[0],
@@ -466,13 +471,13 @@ impl Painter {
                     .split(vertical_chunks[1]);
 
                 if vertical_chunks[0].width >= 2 {
-                    self.draw_basic_cpu(f, app_state, vertical_chunks[0], 1);
+                    self.draw_basic_cpu::<B>(f, app_state, vertical_chunks[0], 1);
                 }
                 if middle_chunks[0].width >= 2 {
-                    self.draw_basic_memory(f, app_state, middle_chunks[0], 2);
+                    self.draw_basic_memory::<B>(f, app_state, middle_chunks[0], 2);
                 }
                 if middle_chunks[1].width >= 2 {
-                    self.draw_basic_network(f, app_state, middle_chunks[1], 3);
+                    self.draw_basic_network::<B>(f, app_state, middle_chunks[1], 3);
                 }
 
                 let mut later_widget_id: Option<u64> = None;
@@ -481,9 +486,12 @@ impl Painter {
                     later_widget_id = Some(widget_id);
                     if vertical_chunks[3].width >= 2 {
                         match basic_table_widget_state.currently_displayed_widget_type {
-                            Disk => {
-                                self.draw_disk_table(f, app_state, vertical_chunks[3], widget_id)
-                            }
+                            Disk => self.draw_disk_table::<B>(
+                                f,
+                                app_state,
+                                vertical_chunks[3],
+                                widget_id,
+                            ),
                             Proc | ProcSort => {
                                 let wid = widget_id
                                     - match basic_table_widget_state.currently_displayed_widget_type
@@ -492,7 +500,7 @@ impl Painter {
                                         ProcSort => 2,
                                         _ => 0,
                                     };
-                                self.draw_process_widget(
+                                self.draw_process_widget::<B>(
                                     f,
                                     app_state,
                                     vertical_chunks[3],
@@ -500,10 +508,13 @@ impl Painter {
                                     wid,
                                 );
                             }
-                            Temp => {
-                                self.draw_temp_table(f, app_state, vertical_chunks[3], widget_id)
-                            }
-                            Battery => self.draw_battery_display(
+                            Temp => self.draw_temp_table::<B>(
+                                f,
+                                app_state,
+                                vertical_chunks[3],
+                                widget_id,
+                            ),
+                            Battery => self.draw_battery_display::<B>(
                                 f,
                                 app_state,
                                 vertical_chunks[3],
@@ -516,7 +527,7 @@ impl Painter {
                 }
 
                 if let Some(widget_id) = later_widget_id {
-                    self.draw_basic_table_arrows(f, app_state, vertical_chunks[2], widget_id);
+                    self.draw_basic_table_arrows::<B>(f, app_state, vertical_chunks[2], widget_id);
                 }
             } else {
                 // Draws using the passed in (or default) layout.
@@ -720,7 +731,7 @@ impl Painter {
                                     );
 
                                     // Side effect, draw here.
-                                    self.draw_widgets_with_constraints(
+                                    self.draw_widgets_with_constraints::<B>(
                                         f,
                                         app_state,
                                         widgets,
@@ -743,7 +754,7 @@ impl Painter {
                         .flat_map(|col| &col.children)
                         .zip(self.derived_widget_draw_locs.iter().flatten().flatten())
                         .for_each(|(widgets, widget_draw_locs)| {
-                            self.draw_widgets_with_constraints(
+                            self.draw_widgets_with_constraints::<B>(
                                 f,
                                 app_state,
                                 widgets,
@@ -768,7 +779,7 @@ impl Painter {
     }
 
     fn draw_widgets_with_constraints<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, widgets: &BottomColRow,
+        &self, f: &mut Frame<'_>, app_state: &mut App, widgets: &BottomColRow,
         widget_draw_locs: &[Rect],
     ) {
         use BottomWidgetType::*;
@@ -776,19 +787,28 @@ impl Painter {
             if widget_draw_loc.width >= 2 && widget_draw_loc.height >= 2 {
                 match &widget.widget_type {
                     Empty => {}
-                    Cpu => self.draw_cpu(f, app_state, *widget_draw_loc, widget.widget_id),
-                    Mem => self.draw_memory_graph(f, app_state, *widget_draw_loc, widget.widget_id),
-                    Net => self.draw_network(f, app_state, *widget_draw_loc, widget.widget_id),
-                    Temp => self.draw_temp_table(f, app_state, *widget_draw_loc, widget.widget_id),
-                    Disk => self.draw_disk_table(f, app_state, *widget_draw_loc, widget.widget_id),
-                    Proc => self.draw_process_widget(
+                    Cpu => self.draw_cpu::<B>(f, app_state, *widget_draw_loc, widget.widget_id),
+                    Mem => self.draw_memory_graph::<B>(
+                        f,
+                        app_state,
+                        *widget_draw_loc,
+                        widget.widget_id,
+                    ),
+                    Net => self.draw_network::<B>(f, app_state, *widget_draw_loc, widget.widget_id),
+                    Temp => {
+                        self.draw_temp_table::<B>(f, app_state, *widget_draw_loc, widget.widget_id)
+                    }
+                    Disk => {
+                        self.draw_disk_table::<B>(f, app_state, *widget_draw_loc, widget.widget_id)
+                    }
+                    Proc => self.draw_process_widget::<B>(
                         f,
                         app_state,
                         *widget_draw_loc,
                         true,
                         widget.widget_id,
                     ),
-                    Battery => self.draw_battery_display(
+                    Battery => self.draw_battery_display::<B>(
                         f,
                         app_state,
                         *widget_draw_loc,

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -295,7 +295,7 @@ impl Painter {
                     })
                     .split(vertical_dialog_chunk[1]);
 
-                self.draw_help_dialog::<B>(f, app_state, middle_dialog_chunk[1]);
+                self.draw_help_dialog(f, app_state, middle_dialog_chunk[1]);
             } else if app_state.delete_dialog_state.is_showing_dd {
                 let dd_text = self.get_dd_spans(app_state);
 
@@ -335,7 +335,7 @@ impl Painter {
 
                 // This is a bit nasty, but it works well... I guess.
                 app_state.delete_dialog_state.is_showing_dd =
-                    self.draw_dd_dialog::<B>(f, dd_text, app_state, middle_dialog_chunk[1]);
+                    self.draw_dd_dialog(f, dd_text, app_state, middle_dialog_chunk[1]);
             } else if app_state.is_expanded {
                 if let Some(frozen_draw_loc) = frozen_draw_loc {
                     self.draw_frozen_indicator(f, frozen_draw_loc);
@@ -346,37 +346,32 @@ impl Painter {
                     .constraints([Constraint::Percentage(100)])
                     .split(terminal_size);
                 match &app_state.current_widget.widget_type {
-                    Cpu => self.draw_cpu::<B>(
-                        f,
-                        app_state,
-                        rect[0],
-                        app_state.current_widget.widget_id,
-                    ),
-                    CpuLegend => self.draw_cpu::<B>(
+                    Cpu => self.draw_cpu(f, app_state, rect[0], app_state.current_widget.widget_id),
+                    CpuLegend => self.draw_cpu(
                         f,
                         app_state,
                         rect[0],
                         app_state.current_widget.widget_id - 1,
                     ),
-                    Mem | BasicMem => self.draw_memory_graph::<B>(
+                    Mem | BasicMem => self.draw_memory_graph(
                         f,
                         app_state,
                         rect[0],
                         app_state.current_widget.widget_id,
                     ),
-                    Disk => self.draw_disk_table::<B>(
+                    Disk => self.draw_disk_table(
                         f,
                         app_state,
                         rect[0],
                         app_state.current_widget.widget_id,
                     ),
-                    Temp => self.draw_temp_table::<B>(
+                    Temp => self.draw_temp_table(
                         f,
                         app_state,
                         rect[0],
                         app_state.current_widget.widget_id,
                     ),
-                    Net => self.draw_network_graph::<B>(
+                    Net => self.draw_network_graph(
                         f,
                         app_state,
                         rect[0],
@@ -391,9 +386,9 @@ impl Painter {
                                 _ => 0,
                             };
 
-                        self.draw_process_widget::<B>(f, app_state, rect[0], true, widget_id);
+                        self.draw_process_widget(f, app_state, rect[0], true, widget_id);
                     }
-                    Battery => self.draw_battery_display::<B>(
+                    Battery => self.draw_battery_display(
                         f,
                         app_state,
                         rect[0],
@@ -471,13 +466,13 @@ impl Painter {
                     .split(vertical_chunks[1]);
 
                 if vertical_chunks[0].width >= 2 {
-                    self.draw_basic_cpu::<B>(f, app_state, vertical_chunks[0], 1);
+                    self.draw_basic_cpu(f, app_state, vertical_chunks[0], 1);
                 }
                 if middle_chunks[0].width >= 2 {
-                    self.draw_basic_memory::<B>(f, app_state, middle_chunks[0], 2);
+                    self.draw_basic_memory(f, app_state, middle_chunks[0], 2);
                 }
                 if middle_chunks[1].width >= 2 {
-                    self.draw_basic_network::<B>(f, app_state, middle_chunks[1], 3);
+                    self.draw_basic_network(f, app_state, middle_chunks[1], 3);
                 }
 
                 let mut later_widget_id: Option<u64> = None;
@@ -486,12 +481,9 @@ impl Painter {
                     later_widget_id = Some(widget_id);
                     if vertical_chunks[3].width >= 2 {
                         match basic_table_widget_state.currently_displayed_widget_type {
-                            Disk => self.draw_disk_table::<B>(
-                                f,
-                                app_state,
-                                vertical_chunks[3],
-                                widget_id,
-                            ),
+                            Disk => {
+                                self.draw_disk_table(f, app_state, vertical_chunks[3], widget_id)
+                            }
                             Proc | ProcSort => {
                                 let wid = widget_id
                                     - match basic_table_widget_state.currently_displayed_widget_type
@@ -500,7 +492,7 @@ impl Painter {
                                         ProcSort => 2,
                                         _ => 0,
                                     };
-                                self.draw_process_widget::<B>(
+                                self.draw_process_widget(
                                     f,
                                     app_state,
                                     vertical_chunks[3],
@@ -508,13 +500,10 @@ impl Painter {
                                     wid,
                                 );
                             }
-                            Temp => self.draw_temp_table::<B>(
-                                f,
-                                app_state,
-                                vertical_chunks[3],
-                                widget_id,
-                            ),
-                            Battery => self.draw_battery_display::<B>(
+                            Temp => {
+                                self.draw_temp_table(f, app_state, vertical_chunks[3], widget_id)
+                            }
+                            Battery => self.draw_battery_display(
                                 f,
                                 app_state,
                                 vertical_chunks[3],
@@ -527,7 +516,7 @@ impl Painter {
                 }
 
                 if let Some(widget_id) = later_widget_id {
-                    self.draw_basic_table_arrows::<B>(f, app_state, vertical_chunks[2], widget_id);
+                    self.draw_basic_table_arrows(f, app_state, vertical_chunks[2], widget_id);
                 }
             } else {
                 // Draws using the passed in (or default) layout.
@@ -731,7 +720,7 @@ impl Painter {
                                     );
 
                                     // Side effect, draw here.
-                                    self.draw_widgets_with_constraints::<B>(
+                                    self.draw_widgets_with_constraints(
                                         f,
                                         app_state,
                                         widgets,
@@ -754,7 +743,7 @@ impl Painter {
                         .flat_map(|col| &col.children)
                         .zip(self.derived_widget_draw_locs.iter().flatten().flatten())
                         .for_each(|(widgets, widget_draw_locs)| {
-                            self.draw_widgets_with_constraints::<B>(
+                            self.draw_widgets_with_constraints(
                                 f,
                                 app_state,
                                 widgets,
@@ -778,7 +767,7 @@ impl Painter {
         Ok(())
     }
 
-    fn draw_widgets_with_constraints<B: Backend>(
+    fn draw_widgets_with_constraints(
         &self, f: &mut Frame<'_>, app_state: &mut App, widgets: &BottomColRow,
         widget_draw_locs: &[Rect],
     ) {
@@ -787,28 +776,19 @@ impl Painter {
             if widget_draw_loc.width >= 2 && widget_draw_loc.height >= 2 {
                 match &widget.widget_type {
                     Empty => {}
-                    Cpu => self.draw_cpu::<B>(f, app_state, *widget_draw_loc, widget.widget_id),
-                    Mem => self.draw_memory_graph::<B>(
-                        f,
-                        app_state,
-                        *widget_draw_loc,
-                        widget.widget_id,
-                    ),
-                    Net => self.draw_network::<B>(f, app_state, *widget_draw_loc, widget.widget_id),
-                    Temp => {
-                        self.draw_temp_table::<B>(f, app_state, *widget_draw_loc, widget.widget_id)
-                    }
-                    Disk => {
-                        self.draw_disk_table::<B>(f, app_state, *widget_draw_loc, widget.widget_id)
-                    }
-                    Proc => self.draw_process_widget::<B>(
+                    Cpu => self.draw_cpu(f, app_state, *widget_draw_loc, widget.widget_id),
+                    Mem => self.draw_memory_graph(f, app_state, *widget_draw_loc, widget.widget_id),
+                    Net => self.draw_network(f, app_state, *widget_draw_loc, widget.widget_id),
+                    Temp => self.draw_temp_table(f, app_state, *widget_draw_loc, widget.widget_id),
+                    Disk => self.draw_disk_table(f, app_state, *widget_draw_loc, widget.widget_id),
+                    Proc => self.draw_process_widget(
                         f,
                         app_state,
                         *widget_draw_loc,
                         true,
                         widget.widget_id,
                     ),
-                    Battery => self.draw_battery_display::<B>(
+                    Battery => self.draw_battery_display(
                         f,
                         app_state,
                         *widget_draw_loc,

--- a/src/canvas/dialogs/dd_dialog.rs
+++ b/src/canvas/dialogs/dd_dialog.rs
@@ -206,8 +206,8 @@ impl Painter {
         None
     }
 
-    fn draw_dd_confirm_buttons<B: Backend>(
-        &self, f: &mut Frame<'_, B>, button_draw_loc: &Rect, app_state: &mut App,
+    fn draw_dd_confirm_buttons(
+        &self, f: &mut Frame<'_>, button_draw_loc: &Rect, app_state: &mut App,
     ) {
         if MAX_PROCESS_SIGNAL == 1 || !app_state.app_config_fields.is_advanced_kill {
             let (yes_button, no_button) = match app_state.delete_dialog_state.selected_signal {
@@ -352,7 +352,7 @@ impl Painter {
     }
 
     pub fn draw_dd_dialog<B: Backend>(
-        &self, f: &mut Frame<'_, B>, dd_text: Option<Text<'_>>, app_state: &mut App, draw_loc: Rect,
+        &self, f: &mut Frame<'_>, dd_text: Option<Text<'_>>, app_state: &mut App, draw_loc: Rect,
     ) -> bool {
         if let Some(dd_text) = dd_text {
             let dd_title = if app_state.dd_err.is_some() {

--- a/src/canvas/dialogs/dd_dialog.rs
+++ b/src/canvas/dialogs/dd_dialog.rs
@@ -2,7 +2,6 @@
 use std::cmp::min;
 
 use tui::{
-    backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     terminal::Frame,
     text::{Line, Span, Text},
@@ -351,7 +350,7 @@ impl Painter {
         }
     }
 
-    pub fn draw_dd_dialog<B: Backend>(
+    pub fn draw_dd_dialog(
         &self, f: &mut Frame<'_>, dd_text: Option<Text<'_>>, app_state: &mut App, draw_loc: Rect,
     ) -> bool {
         if let Some(dd_text) = dd_text {

--- a/src/canvas/dialogs/help_dialog.rs
+++ b/src/canvas/dialogs/help_dialog.rs
@@ -17,7 +17,7 @@ const HELP_BASE: &str = " Help ── Esc to close ";
 // TODO: [REFACTOR] Make generic dialog boxes to build off of instead?
 impl Painter {
     pub fn draw_help_dialog<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect,
     ) {
         let help_title = Line::from(vec![
             Span::styled(" Help ", self.colours.widget_title_style),

--- a/src/canvas/dialogs/help_dialog.rs
+++ b/src/canvas/dialogs/help_dialog.rs
@@ -1,7 +1,6 @@
 use std::cmp::{max, min};
 
 use tui::{
-    backend::Backend,
     layout::{Alignment, Rect},
     terminal::Frame,
     text::Line,
@@ -16,9 +15,7 @@ const HELP_BASE: &str = " Help ── Esc to close ";
 
 // TODO: [REFACTOR] Make generic dialog boxes to build off of instead?
 impl Painter {
-    pub fn draw_help_dialog<B: Backend>(
-        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect,
-    ) {
+    pub fn draw_help_dialog(&self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect) {
         let help_title = Line::from(vec![
             Span::styled(" Help ", self.colours.widget_title_style),
             Span::styled(

--- a/src/canvas/widgets/basic_table_arrows.rs
+++ b/src/canvas/widgets/basic_table_arrows.rs
@@ -14,7 +14,7 @@ use crate::{
 
 impl Painter {
     pub fn draw_basic_table_arrows<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         if let Some(current_table) = app_state.widget_map.get(&widget_id) {
             let current_table = if let BottomWidgetType::ProcSort = current_table.widget_type {

--- a/src/canvas/widgets/basic_table_arrows.rs
+++ b/src/canvas/widgets/basic_table_arrows.rs
@@ -1,5 +1,4 @@
 use tui::{
-    backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     terminal::Frame,
     text::Line,
@@ -13,7 +12,7 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_basic_table_arrows<B: Backend>(
+    pub fn draw_basic_table_arrows(
         &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         if let Some(current_table) = app_state.widget_map.get(&widget_id) {

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -1,5 +1,4 @@
 use tui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     terminal::Frame,
     text::{Line, Span},
@@ -16,7 +15,7 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_battery_display<B: Backend>(
+    pub fn draw_battery_display(
         &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
         widget_id: u64,
     ) {

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -17,7 +17,7 @@ use crate::{
 
 impl Painter {
     pub fn draw_battery_display<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
         widget_id: u64,
     ) {
         let should_get_widget_bounds = app_state.should_get_widget_bounds();
@@ -249,19 +249,20 @@ impl Painter {
 
                 // Draw bar
                 f.render_widget(
-                    Table::new(battery_charge_rows)
+                    Table::new(battery_charge_rows, [Constraint::Percentage(100)])
                         .block(battery_block.clone())
-                        .header(header.clone())
-                        .widths(&[Constraint::Percentage(100)]),
+                        .header(header.clone()),
                     margined_draw_loc,
                 );
 
                 // Draw info
                 f.render_widget(
-                    Table::new(battery_rows)
-                        .block(battery_block)
-                        .header(header)
-                        .widths(&[Constraint::Percentage(50), Constraint::Percentage(50)]),
+                    Table::new(
+                        battery_rows,
+                        [Constraint::Percentage(50), Constraint::Percentage(50)],
+                    )
+                    .block(battery_block)
+                    .header(header),
                     margined_draw_loc,
                 );
             } else {

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -18,7 +18,7 @@ use crate::{
 impl Painter {
     /// Inspired by htop.
     pub fn draw_basic_cpu<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         // Skip the first element, it's the "all" element
         if app_state.converted_data.cpu_data.len() > 1 {

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -1,7 +1,6 @@
 use std::cmp::min;
 
 use tui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     terminal::Frame,
     widgets::Block,
@@ -17,7 +16,7 @@ use crate::{
 
 impl Painter {
     /// Inspired by htop.
-    pub fn draw_basic_cpu<B: Backend>(
+    pub fn draw_basic_cpu(
         &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         // Skip the first element, it's the "all" element

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -23,7 +23,7 @@ const ALL_POSITION: usize = 0;
 
 impl Painter {
     pub fn draw_cpu<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let legend_width = (draw_loc.width as f64 * 0.15) as u16;
 
@@ -36,7 +36,7 @@ impl Painter {
                     app_state.move_widget_selection(&WidgetDirection::Left);
                 }
             }
-            self.draw_cpu_graph(f, app_state, draw_loc, widget_id);
+            self.draw_cpu_graph::<B>(f, app_state, draw_loc, widget_id);
             if let Some(cpu_widget_state) =
                 app_state.states.cpu_state.widget_states.get_mut(&widget_id)
             {
@@ -80,8 +80,8 @@ impl Painter {
                 .constraints(constraints)
                 .split(draw_loc);
 
-            self.draw_cpu_graph(f, app_state, partitioned_draw_loc[graph_index], widget_id);
-            self.draw_cpu_legend(
+            self.draw_cpu_graph::<B>(f, app_state, partitioned_draw_loc[graph_index], widget_id);
+            self.draw_cpu_legend::<B>(
                 f,
                 app_state,
                 partitioned_draw_loc[legend_index],
@@ -176,7 +176,7 @@ impl Painter {
     }
 
     fn draw_cpu_graph<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         const Y_BOUNDS: [f64; 2] = [0.0, 100.5];
         const Y_LABELS: [Cow<'static, str>; 2] = [Cow::Borrowed("  0%"), Cow::Borrowed("100%")];
@@ -236,12 +236,12 @@ impl Painter {
                 legend_constraints: None,
                 marker,
             }
-            .draw_time_graph(f, draw_loc, &points);
+            .draw_time_graph::<B>(f, draw_loc, &points);
         }
     }
 
     fn draw_cpu_legend<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let recalculate_column_widths = app_state.should_get_widget_bounds();
         if let Some(cpu_widget_state) = app_state
@@ -262,7 +262,7 @@ impl Painter {
                 selection_state: SelectionState::new(app_state.is_expanded, is_on_widget),
             };
 
-            cpu_widget_state.table.draw(
+            cpu_widget_state.table.draw::<B>(
                 f,
                 &draw_info,
                 app_state.widget_map.get_mut(&widget_id),

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use tui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     symbols::Marker,
     terminal::Frame,
@@ -22,9 +21,7 @@ const AVG_POSITION: usize = 1;
 const ALL_POSITION: usize = 0;
 
 impl Painter {
-    pub fn draw_cpu<B: Backend>(
-        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
-    ) {
+    pub fn draw_cpu(&self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64) {
         let legend_width = (draw_loc.width as f64 * 0.15) as u16;
 
         if legend_width < 6 {
@@ -36,7 +33,7 @@ impl Painter {
                     app_state.move_widget_selection(&WidgetDirection::Left);
                 }
             }
-            self.draw_cpu_graph::<B>(f, app_state, draw_loc, widget_id);
+            self.draw_cpu_graph(f, app_state, draw_loc, widget_id);
             if let Some(cpu_widget_state) =
                 app_state.states.cpu_state.widget_states.get_mut(&widget_id)
             {
@@ -80,8 +77,8 @@ impl Painter {
                 .constraints(constraints)
                 .split(draw_loc);
 
-            self.draw_cpu_graph::<B>(f, app_state, partitioned_draw_loc[graph_index], widget_id);
-            self.draw_cpu_legend::<B>(
+            self.draw_cpu_graph(f, app_state, partitioned_draw_loc[graph_index], widget_id);
+            self.draw_cpu_legend(
                 f,
                 app_state,
                 partitioned_draw_loc[legend_index],
@@ -175,7 +172,7 @@ impl Painter {
         }
     }
 
-    fn draw_cpu_graph<B: Backend>(
+    fn draw_cpu_graph(
         &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         const Y_BOUNDS: [f64; 2] = [0.0, 100.5];
@@ -236,11 +233,11 @@ impl Painter {
                 legend_constraints: None,
                 marker,
             }
-            .draw_time_graph::<B>(f, draw_loc, &points);
+            .draw_time_graph(f, draw_loc, &points);
         }
     }
 
-    fn draw_cpu_legend<B: Backend>(
+    fn draw_cpu_legend(
         &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let recalculate_column_widths = app_state.should_get_widget_bounds();
@@ -262,7 +259,7 @@ impl Painter {
                 selection_state: SelectionState::new(app_state.is_expanded, is_on_widget),
             };
 
-            cpu_widget_state.table.draw::<B>(
+            cpu_widget_state.table.draw(
                 f,
                 &draw_info,
                 app_state.widget_map.get_mut(&widget_id),

--- a/src/canvas/widgets/disk_table.rs
+++ b/src/canvas/widgets/disk_table.rs
@@ -8,7 +8,7 @@ use crate::{
 
 impl Painter {
     pub fn draw_disk_table<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut app::App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut app::App, draw_loc: Rect, widget_id: u64,
     ) {
         let recalculate_column_widths = app_state.should_get_widget_bounds();
         if let Some(disk_widget_state) = app_state
@@ -26,7 +26,7 @@ impl Painter {
                 selection_state: SelectionState::new(app_state.is_expanded, is_on_widget),
             };
 
-            disk_widget_state.table.draw(
+            disk_widget_state.table.draw::<B>(
                 f,
                 &draw_info,
                 app_state.widget_map.get_mut(&widget_id),

--- a/src/canvas/widgets/disk_table.rs
+++ b/src/canvas/widgets/disk_table.rs
@@ -1,4 +1,4 @@
-use tui::{backend::Backend, layout::Rect, terminal::Frame};
+use tui::{layout::Rect, terminal::Frame};
 
 use crate::{
     app::{self},
@@ -7,7 +7,7 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_disk_table<B: Backend>(
+    pub fn draw_disk_table(
         &self, f: &mut Frame<'_>, app_state: &mut app::App, draw_loc: Rect, widget_id: u64,
     ) {
         let recalculate_column_widths = app_state.should_get_widget_bounds();
@@ -26,7 +26,7 @@ impl Painter {
                 selection_state: SelectionState::new(app_state.is_expanded, is_on_widget),
             };
 
-            disk_widget_state.table.draw::<B>(
+            disk_widget_state.table.draw(
                 f,
                 &draw_info,
                 app_state.widget_map.get_mut(&widget_id),

--- a/src/canvas/widgets/mem_basic.rs
+++ b/src/canvas/widgets/mem_basic.rs
@@ -11,7 +11,7 @@ use crate::{
 
 impl Painter {
     pub fn draw_basic_memory<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let mem_data = &app_state.converted_data.mem_data;
         let mut draw_widgets: Vec<PipeGauge<'_>> = Vec::new();

--- a/src/canvas/widgets/mem_basic.rs
+++ b/src/canvas/widgets/mem_basic.rs
@@ -1,5 +1,4 @@
 use tui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     terminal::Frame,
     widgets::Block,
@@ -10,7 +9,7 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_basic_memory<B: Backend>(
+    pub fn draw_basic_memory(
         &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let mem_data = &app_state.converted_data.mem_data;

--- a/src/canvas/widgets/mem_graph.rs
+++ b/src/canvas/widgets/mem_graph.rs
@@ -15,7 +15,7 @@ use crate::{
 
 impl Painter {
     pub fn draw_memory_graph<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         const Y_BOUNDS: [f64; 2] = [0.0, 100.5];
         const Y_LABELS: [Cow<'static, str>; 2] = [Cow::Borrowed("  0%"), Cow::Borrowed("100%")];
@@ -134,7 +134,7 @@ impl Painter {
                 legend_constraints: Some((Constraint::Ratio(3, 4), Constraint::Ratio(3, 4))),
                 marker,
             }
-            .draw_time_graph(f, draw_loc, &points);
+            .draw_time_graph::<B>(f, draw_loc, &points);
         }
 
         if app_state.should_get_widget_bounds() {

--- a/src/canvas/widgets/mem_graph.rs
+++ b/src/canvas/widgets/mem_graph.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use tui::{
-    backend::Backend,
     layout::{Constraint, Rect},
     symbols::Marker,
     terminal::Frame,
@@ -14,7 +13,7 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_memory_graph<B: Backend>(
+    pub fn draw_memory_graph(
         &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         const Y_BOUNDS: [f64; 2] = [0.0, 100.5];
@@ -134,7 +133,7 @@ impl Painter {
                 legend_constraints: Some((Constraint::Ratio(3, 4), Constraint::Ratio(3, 4))),
                 marker,
             }
-            .draw_time_graph::<B>(f, draw_loc, &points);
+            .draw_time_graph(f, draw_loc, &points);
         }
 
         if app_state.should_get_widget_bounds() {

--- a/src/canvas/widgets/network_basic.rs
+++ b/src/canvas/widgets/network_basic.rs
@@ -10,7 +10,7 @@ use crate::{app::App, canvas::Painter, constants::*};
 
 impl Painter {
     pub fn draw_basic_network<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let divided_loc = Layout::default()
             .direction(Direction::Horizontal)

--- a/src/canvas/widgets/network_basic.rs
+++ b/src/canvas/widgets/network_basic.rs
@@ -1,5 +1,4 @@
 use tui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     terminal::Frame,
     text::{Line, Span},
@@ -9,7 +8,7 @@ use tui::{
 use crate::{app::App, canvas::Painter, constants::*};
 
 impl Painter {
-    pub fn draw_basic_network<B: Backend>(
+    pub fn draw_basic_network(
         &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let divided_loc = Layout::default()

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -1,5 +1,4 @@
 use tui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     symbols::Marker,
     terminal::Frame,
@@ -18,7 +17,7 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_network<B: Backend>(
+    pub fn draw_network(
         &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         if app_state.app_config_fields.use_old_network_legend {
@@ -32,10 +31,10 @@ impl Painter {
                 ])
                 .split(draw_loc);
 
-            self.draw_network_graph::<B>(f, app_state, network_chunk[0], widget_id, true);
+            self.draw_network_graph(f, app_state, network_chunk[0], widget_id, true);
             self.draw_network_labels(f, app_state, network_chunk[1], widget_id);
         } else {
-            self.draw_network_graph::<B>(f, app_state, draw_loc, widget_id, false);
+            self.draw_network_graph(f, app_state, draw_loc, widget_id, false);
         }
 
         if app_state.should_get_widget_bounds() {
@@ -50,7 +49,7 @@ impl Painter {
         }
     }
 
-    pub fn draw_network_graph<B: Backend>(
+    pub fn draw_network_graph(
         &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
         hide_legend: bool,
     ) {
@@ -163,7 +162,7 @@ impl Painter {
                 legend_constraints: Some(legend_constraints),
                 marker,
             }
-            .draw_time_graph::<B>(f, draw_loc, &points);
+            .draw_time_graph(f, draw_loc, &points);
         }
     }
 

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -19,7 +19,7 @@ use crate::{
 
 impl Painter {
     pub fn draw_network<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         if app_state.app_config_fields.use_old_network_legend {
             const LEGEND_HEIGHT: u16 = 4;
@@ -32,10 +32,10 @@ impl Painter {
                 ])
                 .split(draw_loc);
 
-            self.draw_network_graph(f, app_state, network_chunk[0], widget_id, true);
+            self.draw_network_graph::<B>(f, app_state, network_chunk[0], widget_id, true);
             self.draw_network_labels(f, app_state, network_chunk[1], widget_id);
         } else {
-            self.draw_network_graph(f, app_state, draw_loc, widget_id, false);
+            self.draw_network_graph::<B>(f, app_state, draw_loc, widget_id, false);
         }
 
         if app_state.should_get_widget_bounds() {
@@ -51,7 +51,7 @@ impl Painter {
     }
 
     pub fn draw_network_graph<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
         hide_legend: bool,
     ) {
         if let Some(network_widget_state) =
@@ -163,12 +163,12 @@ impl Painter {
                 legend_constraints: Some(legend_constraints),
                 marker,
             }
-            .draw_time_graph(f, draw_loc, &points);
+            .draw_time_graph::<B>(f, draw_loc, &points);
         }
     }
 
-    fn draw_network_labels<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+    fn draw_network_labels(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         const NETWORK_HEADERS: [&str; 4] = ["RX", "TX", "Total RX", "Total TX"];
 
@@ -187,22 +187,22 @@ impl Painter {
 
         // Draw
         f.render_widget(
-            Table::new(total_network)
-                .header(Row::new(NETWORK_HEADERS).style(self.colours.table_header_style))
-                .block(Block::default().borders(Borders::ALL).border_style(
-                    if app_state.current_widget.widget_id == widget_id {
-                        self.colours.highlighted_border_style
-                    } else {
-                        self.colours.border_style
-                    },
-                ))
-                .style(self.colours.text_style)
-                .widths(
-                    &((std::iter::repeat(draw_loc.width.saturating_sub(2) / 4))
-                        .take(4)
-                        .map(Constraint::Length)
-                        .collect::<Vec<_>>()),
-                ),
+            Table::new(
+                total_network,
+                &((std::iter::repeat(draw_loc.width.saturating_sub(2) / 4))
+                    .take(4)
+                    .map(Constraint::Length)
+                    .collect::<Vec<_>>()),
+            )
+            .header(Row::new(NETWORK_HEADERS).style(self.colours.table_header_style))
+            .block(Block::default().borders(Borders::ALL).border_style(
+                if app_state.current_widget.widget_id == widget_id {
+                    self.colours.highlighted_border_style
+                } else {
+                    self.colours.border_style
+                },
+            ))
+            .style(self.colours.text_style),
             draw_loc,
         );
     }

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -1,5 +1,4 @@
 use tui::{
-    backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::Style,
     terminal::Frame,
@@ -20,7 +19,7 @@ const SORT_MENU_WIDTH: u16 = 7;
 impl Painter {
     /// Draws and handles all process-related drawing.  Use this.
     /// - `widget_id` here represents the widget ID of the process widget itself!
-    pub fn draw_process_widget<B: Backend>(
+    pub fn draw_process_widget(
         &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
         widget_id: u64,
     ) {
@@ -52,10 +51,10 @@ impl Painter {
                     .split(proc_draw_loc);
                 proc_draw_loc = processes_chunk[1];
 
-                self.draw_sort_table::<B>(f, app_state, processes_chunk[0], widget_id + 2);
+                self.draw_sort_table(f, app_state, processes_chunk[0], widget_id + 2);
             }
 
-            self.draw_processes_table::<B>(f, app_state, proc_draw_loc, widget_id);
+            self.draw_processes_table(f, app_state, proc_draw_loc, widget_id);
         }
 
         if let Some(proc_widget_state) = app_state
@@ -73,7 +72,7 @@ impl Painter {
 
     /// Draws the process sort box.
     /// - `widget_id` represents the widget ID of the process widget itself.an
-    fn draw_processes_table<B: Backend>(
+    fn draw_processes_table(
         &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let should_get_widget_bounds = app_state.should_get_widget_bounds();
@@ -95,7 +94,7 @@ impl Painter {
                 selection_state: SelectionState::new(app_state.is_expanded, is_on_widget),
             };
 
-            proc_widget_state.table.draw::<B>(
+            proc_widget_state.table.draw(
                 f,
                 &draw_info,
                 app_state.widget_map.get_mut(&widget_id),
@@ -311,7 +310,7 @@ impl Painter {
     /// Draws the process sort box.
     /// - `widget_id` represents the widget ID of the sort box itself --- NOT the process widget
     /// state that is stored.
-    fn draw_sort_table<B: Backend>(
+    fn draw_sort_table(
         &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let should_get_widget_bounds = app_state.should_get_widget_bounds();
@@ -332,7 +331,7 @@ impl Painter {
                 selection_state: SelectionState::new(app_state.is_expanded, is_on_widget),
             };
 
-            pws.sort_table.draw::<B>(
+            pws.sort_table.draw(
                 f,
                 &draw_info,
                 app_state.widget_map.get_mut(&widget_id),

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -21,7 +21,7 @@ impl Painter {
     /// Draws and handles all process-related drawing.  Use this.
     /// - `widget_id` here represents the widget ID of the process widget itself!
     pub fn draw_process_widget<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
         widget_id: u64,
     ) {
         if let Some(proc_widget_state) = app_state.states.proc_state.widget_states.get(&widget_id) {
@@ -52,10 +52,10 @@ impl Painter {
                     .split(proc_draw_loc);
                 proc_draw_loc = processes_chunk[1];
 
-                self.draw_sort_table(f, app_state, processes_chunk[0], widget_id + 2);
+                self.draw_sort_table::<B>(f, app_state, processes_chunk[0], widget_id + 2);
             }
 
-            self.draw_processes_table(f, app_state, proc_draw_loc, widget_id);
+            self.draw_processes_table::<B>(f, app_state, proc_draw_loc, widget_id);
         }
 
         if let Some(proc_widget_state) = app_state
@@ -74,7 +74,7 @@ impl Painter {
     /// Draws the process sort box.
     /// - `widget_id` represents the widget ID of the process widget itself.an
     fn draw_processes_table<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let should_get_widget_bounds = app_state.should_get_widget_bounds();
         if let Some(proc_widget_state) = app_state
@@ -95,7 +95,7 @@ impl Painter {
                 selection_state: SelectionState::new(app_state.is_expanded, is_on_widget),
             };
 
-            proc_widget_state.table.draw(
+            proc_widget_state.table.draw::<B>(
                 f,
                 &draw_info,
                 app_state.widget_map.get_mut(&widget_id),
@@ -107,8 +107,8 @@ impl Painter {
     /// Draws the process search field.
     /// - `widget_id` represents the widget ID of the search box itself --- NOT the process widget
     /// state that is stored.
-    fn draw_search_field<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
+    fn draw_search_field(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
         widget_id: u64,
     ) {
         fn build_query_span(
@@ -312,7 +312,7 @@ impl Painter {
     /// - `widget_id` represents the widget ID of the sort box itself --- NOT the process widget
     /// state that is stored.
     fn draw_sort_table<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let should_get_widget_bounds = app_state.should_get_widget_bounds();
         if let Some(pws) = app_state
@@ -332,7 +332,7 @@ impl Painter {
                 selection_state: SelectionState::new(app_state.is_expanded, is_on_widget),
             };
 
-            pws.sort_table.draw(
+            pws.sort_table.draw::<B>(
                 f,
                 &draw_info,
                 app_state.widget_map.get_mut(&widget_id),

--- a/src/canvas/widgets/temperature_table.rs
+++ b/src/canvas/widgets/temperature_table.rs
@@ -1,4 +1,4 @@
-use tui::{backend::Backend, layout::Rect, terminal::Frame};
+use tui::{layout::Rect, terminal::Frame};
 
 use crate::{
     app,
@@ -7,7 +7,7 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_temp_table<B: Backend>(
+    pub fn draw_temp_table(
         &self, f: &mut Frame<'_>, app_state: &mut app::App, draw_loc: Rect, widget_id: u64,
     ) {
         let recalculate_column_widths = app_state.should_get_widget_bounds();
@@ -26,7 +26,7 @@ impl Painter {
                 selection_state: SelectionState::new(app_state.is_expanded, is_on_widget),
             };
 
-            temp_widget_state.table.draw::<B>(
+            temp_widget_state.table.draw(
                 f,
                 &draw_info,
                 app_state.widget_map.get_mut(&widget_id),

--- a/src/canvas/widgets/temperature_table.rs
+++ b/src/canvas/widgets/temperature_table.rs
@@ -8,7 +8,7 @@ use crate::{
 
 impl Painter {
     pub fn draw_temp_table<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut app::App, draw_loc: Rect, widget_id: u64,
+        &self, f: &mut Frame<'_>, app_state: &mut app::App, draw_loc: Rect, widget_id: u64,
     ) {
         let recalculate_column_widths = app_state.should_get_widget_bounds();
         if let Some(temp_widget_state) = app_state
@@ -26,7 +26,7 @@ impl Painter {
                 selection_state: SelectionState::new(app_state.is_expanded, is_on_widget),
             };
 
-            temp_widget_state.table.draw(
+            temp_widget_state.table.draw::<B>(
                 f,
                 &draw_info,
                 app_state.widget_map.get_mut(&widget_id),

--- a/src/components/data_table/draw.rs
+++ b/src/components/data_table/draw.rs
@@ -5,7 +5,6 @@ use std::{
 
 use concat_string::concat_string;
 use tui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     text::{Line, Span, Text},
     widgets::{Block, Borders, Row, Table},
@@ -139,7 +138,7 @@ where
         })
     }
 
-    pub fn draw<B: Backend>(
+    pub fn draw(
         &mut self, f: &mut Frame<'_>, draw_info: &DrawInfo, widget: Option<&mut BottomWidget>,
         painter: &Painter,
     ) {

--- a/src/components/data_table/draw.rs
+++ b/src/components/data_table/draw.rs
@@ -140,7 +140,7 @@ where
     }
 
     pub fn draw<B: Backend>(
-        &mut self, f: &mut Frame<'_, B>, draw_info: &DrawInfo, widget: Option<&mut BottomWidget>,
+        &mut self, f: &mut Frame<'_>, draw_info: &DrawInfo, widget: Option<&mut BottomWidget>,
         painter: &Painter,
     ) {
         let draw_horizontal = !self.props.is_basic || draw_info.is_on_widget();
@@ -248,21 +248,8 @@ where
                     } else {
                         self.styling.text_style
                     };
-                    let mut table = Table::new(rows)
-                        .block(block)
-                        .highlight_style(highlight_style)
-                        .style(self.styling.text_style);
-
-                    if show_header {
-                        table = table.header(headers);
-                    }
-
-                    table
-                };
-
-                let table_state = &mut self.state.table_state;
-                f.render_stateful_widget(
-                    widget.widths(
+                    let mut table = Table::new(
+                        rows,
                         &(self
                             .state
                             .calculated_widths
@@ -275,15 +262,27 @@ where
                                 }
                             })
                             .collect::<Vec<_>>()),
-                    ),
-                    margined_draw_loc,
-                    table_state,
-                );
-            } else {
-                let table = Table::new(once(Row::new(Text::raw("No data"))))
+                    )
                     .block(block)
-                    .style(self.styling.text_style)
-                    .widths(&[Constraint::Percentage(100)]);
+                    .highlight_style(highlight_style)
+                    .style(self.styling.text_style);
+
+                    if show_header {
+                        table = table.header(headers);
+                    }
+
+                    table
+                };
+
+                let table_state = &mut self.state.table_state;
+                f.render_stateful_widget(widget, margined_draw_loc, table_state);
+            } else {
+                let table = Table::new(
+                    once(Row::new(Text::raw("No data"))),
+                    [Constraint::Percentage(100)],
+                )
+                .block(block)
+                .style(self.styling.text_style);
                 f.render_widget(table, margined_draw_loc);
             }
         }

--- a/src/components/time_graph.rs
+++ b/src/components/time_graph.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 
 use concat_string::concat_string;
 use tui::{
-    backend::Backend,
     layout::{Constraint, Rect},
     style::Style,
     symbols::Marker,
@@ -124,9 +123,7 @@ impl<'a> TimeGraph<'a> {
     /// - Draws with the higher time value on the left, and lower on the right.
     /// - Expects a [`TimeGraph`] to be passed in, which details how to draw the graph.
     /// - Expects `graph_data`, which represents *what* data to draw, and various details like style and optional legends.
-    pub fn draw_time_graph<B: Backend>(
-        &self, f: &mut Frame<'_>, draw_loc: Rect, graph_data: &[GraphData<'_>],
-    ) {
+    pub fn draw_time_graph(&self, f: &mut Frame<'_>, draw_loc: Rect, graph_data: &[GraphData<'_>]) {
         let x_axis = self.generate_x_axis();
         let y_axis = self.generate_y_axis();
 

--- a/src/components/time_graph.rs
+++ b/src/components/time_graph.rs
@@ -125,7 +125,7 @@ impl<'a> TimeGraph<'a> {
     /// - Expects a [`TimeGraph`] to be passed in, which details how to draw the graph.
     /// - Expects `graph_data`, which represents *what* data to draw, and various details like style and optional legends.
     pub fn draw_time_graph<B: Backend>(
-        &self, f: &mut Frame<'_, B>, draw_loc: Rect, graph_data: &[GraphData<'_>],
+        &self, f: &mut Frame<'_>, draw_loc: Rect, graph_data: &[GraphData<'_>],
     ) {
         let x_axis = self.generate_x_axis();
         let y_axis = self.generate_y_axis();

--- a/src/components/tui_widget/time_chart/canvas.rs
+++ b/src/components/tui_widget/time_chart/canvas.rs
@@ -363,7 +363,8 @@ impl<'a> Context<'a> {
     ) -> Context<'a> {
         let grid: Box<dyn Grid> = match marker {
             symbols::Marker::Dot => Box::new(CharGrid::new(width, height, '•')),
-            symbols::Marker::Block => Box::new(CharGrid::new(width, height, '▄')),
+            symbols::Marker::Block => Box::new(CharGrid::new(width, height, '█')),
+            symbols::Marker::HalfBlock => Box::new(CharGrid::new(width, height, '▀')),
             symbols::Marker::Braille => Box::new(BrailleGrid::new(width, height)),
             symbols::Marker::Bar => Box::new(CharGrid::new(width, height, '▄')),
         };

--- a/src/components/tui_widget/time_chart/canvas.rs
+++ b/src/components/tui_widget/time_chart/canvas.rs
@@ -364,9 +364,9 @@ impl<'a> Context<'a> {
         let grid: Box<dyn Grid> = match marker {
             symbols::Marker::Dot => Box::new(CharGrid::new(width, height, '•')),
             symbols::Marker::Block => Box::new(CharGrid::new(width, height, '█')),
-            symbols::Marker::HalfBlock => Box::new(CharGrid::new(width, height, '▀')),
-            symbols::Marker::Braille => Box::new(BrailleGrid::new(width, height)),
             symbols::Marker::Bar => Box::new(CharGrid::new(width, height, '▄')),
+            symbols::Marker::Braille => Box::new(BrailleGrid::new(width, height)),
+            symbols::Marker::HalfBlock => Box::new(CharGrid::new(width, height, '▀')),
         };
         Context {
             x_bounds,

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -547,30 +547,6 @@ pub fn convert_battery_harvest(current_data: &DataCollection) -> Vec<ConvertedBa
 }
 
 #[cfg(feature = "zfs")]
-pub fn convert_arc_labels(current_data: &DataCollection) -> Option<(String, String)> {
-    if current_data.arc_harvest.total_bytes > 0 {
-        Some((
-            format!(
-                "{:3.0}%",
-                current_data.arc_harvest.use_percent.unwrap_or(0.0)
-            ),
-            {
-                let (unit, denominator) =
-                    get_mem_binary_unit_and_denominator(current_data.arc_harvest.total_bytes);
-
-                format!(
-                    "   {:.1}{unit}/{:.1}{unit}",
-                    current_data.arc_harvest.used_bytes as f64 / denominator,
-                    (current_data.arc_harvest.total_bytes as f64 / denominator),
-                )
-            },
-        ))
-    } else {
-        None
-    }
-}
-
-#[cfg(feature = "zfs")]
 pub fn convert_arc_data_points(current_data: &DataCollection) -> Vec<Point> {
     let mut result: Vec<Point> = Vec::new();
     let current_time = current_data.current_instant;


### PR DESCRIPTION
## Description

Update `ratatui` to version `0.25.0` (api changes: moved the `Backend` type, moved `widths` to `new` and added a `Marker` for half block)
Use `convert_mem_label` instead of `convert_arc_labels`

## Testing

Ran on linux with arc enabled.

- [X] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [X] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [X] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [X] _The pull request passes the provided CI pipeline_
- [X] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_



Feel free to close if the dependency should remained pinned. 