### PR TITLE
Added possibility to use "--memory_use_mega_prefix"

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -50,6 +50,7 @@ pub struct AppConfigFields {
     pub show_average_cpu: bool, // TODO: Unify this in CPU options
     pub use_current_cpu_total: bool,
     pub unnormalized_cpu: bool,
+    pub memory_use_mega_prefix: bool,
     pub use_basic_mode: bool,
     pub default_time_value: u64,
     pub time_interval: u64,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -275,6 +275,7 @@ fn main() -> Result<()> {
                                     convert_gpu_data(&app.data_collection);
                             }
 
+<<<<<<< HEAD
                             app.converted_data.mem_labels = convert_mem_label(
                                 &app.data_collection.memory_harvest,
                                 app.app_config_fields.memory_use_mega_prefix,
@@ -283,6 +284,12 @@ fn main() -> Result<()> {
                                 &app.data_collection.swap_harvest,
                                 app.app_config_fields.memory_use_mega_prefix,
                             );
+=======
+                            app.converted_data.mem_labels =
+                                convert_mem_label(&app.data_collection.memory_harvest, app.app_config_fields.memory_use_mega_prefix);
+                            app.converted_data.swap_labels =
+                                convert_mem_label(&app.data_collection.swap_harvest, app.app_config_fields.memory_use_mega_prefix);
+>>>>>>> 16bcf7d8 (added a feature)
                             #[cfg(not(target_os = "windows"))]
                             {
                                 app.converted_data.cache_labels = convert_mem_label(
@@ -293,10 +300,15 @@ fn main() -> Result<()> {
 
                             #[cfg(feature = "zfs")]
                             {
+<<<<<<< HEAD
                                 let arc_labels = convert_mem_label(
                                     &app.data_collection.arc_harvest,
                                     app.app_config_fields.memory_use_mega_prefix,
                                 );
+=======
+                                let arc_labels =
+                                    convert_mem_label(&app.data_collection.arc_harvest, app.app_config_fields.memory_use_mega_prefix);
+>>>>>>> 16bcf7d8 (added a feature)
                                 app.converted_data.arc_labels = arc_labels;
                             }
                         }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -277,17 +277,17 @@ fn main() -> Result<()> {
 
                             app.converted_data.mem_labels = convert_mem_label(
                                 &app.data_collection.memory_harvest,
-                                app.app_config_fields.memory_use_mega_prefix
+                                app.app_config_fields.memory_use_mega_prefix,
                             );
                             app.converted_data.swap_labels = convert_mem_label(
                                 &app.data_collection.swap_harvest,
-                                app.app_config_fields.memory_use_mega_prefix
+                                app.app_config_fields.memory_use_mega_prefix,
                             );
                             #[cfg(not(target_os = "windows"))]
                             {
                                 app.converted_data.cache_labels = convert_mem_label(
                                     &app.data_collection.cache_harvest,
-                                    app.app_config_fields.memory_use_mega_prefix
+                                    app.app_config_fields.memory_use_mega_prefix,
                                 );
                             }
 
@@ -295,7 +295,7 @@ fn main() -> Result<()> {
                             {
                                 let arc_labels = convert_mem_label(
                                     &app.data_collection.arc_harvest,
-                                    app.app_config_fields.memory_use_mega_prefix
+                                    app.app_config_fields.memory_use_mega_prefix,
                                 );
                                 app.converted_data.arc_labels = arc_labels;
                             }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -276,9 +276,9 @@ fn main() -> Result<()> {
                             }
 
                             app.converted_data.mem_labels =
-                                convert_mem_label(&app.data_collection.memory_harvest);
+                                convert_mem_label(&app.data_collection.memory_harvest, app.app_config_fields.memory_use_mega_prefix);
                             app.converted_data.swap_labels =
-                                convert_mem_label(&app.data_collection.swap_harvest);
+                                convert_mem_label(&app.data_collection.swap_harvest, app.app_config_fields.memory_use_mega_prefix);
                             #[cfg(not(target_os = "windows"))]
                             {
                                 app.converted_data.cache_labels =
@@ -288,7 +288,7 @@ fn main() -> Result<()> {
                             #[cfg(feature = "zfs")]
                             {
                                 let arc_labels =
-                                    convert_mem_label(&app.data_collection.arc_harvest);
+                                    convert_mem_label(&app.data_collection.arc_harvest, app.app_config_fields.memory_use_mega_prefix);
                                 app.converted_data.arc_labels = arc_labels;
                             }
                         }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -275,20 +275,28 @@ fn main() -> Result<()> {
                                     convert_gpu_data(&app.data_collection);
                             }
 
-                            app.converted_data.mem_labels =
-                                convert_mem_label(&app.data_collection.memory_harvest, app.app_config_fields.memory_use_mega_prefix);
-                            app.converted_data.swap_labels =
-                                convert_mem_label(&app.data_collection.swap_harvest, app.app_config_fields.memory_use_mega_prefix);
+                            app.converted_data.mem_labels = convert_mem_label(
+                                &app.data_collection.memory_harvest,
+                                app.app_config_fields.memory_use_mega_prefix
+                            );
+                            app.converted_data.swap_labels = convert_mem_label(
+                                &app.data_collection.swap_harvest,
+                                app.app_config_fields.memory_use_mega_prefix
+                            );
                             #[cfg(not(target_os = "windows"))]
                             {
-                                app.converted_data.cache_labels =
-                                    convert_mem_label(&app.data_collection.cache_harvest);
+                                app.converted_data.cache_labels = convert_mem_label(
+                                    &app.data_collection.cache_harvest,
+                                    app.app_config_fields.memory_use_mega_prefix
+                                );
                             }
 
                             #[cfg(feature = "zfs")]
                             {
-                                let arc_labels =
-                                    convert_mem_label(&app.data_collection.arc_harvest, app.app_config_fields.memory_use_mega_prefix);
+                                let arc_labels = convert_mem_label(
+                                    &app.data_collection.arc_harvest,
+                                    app.app_config_fields.memory_use_mega_prefix
+                                );
                                 app.converted_data.arc_labels = arc_labels;
                             }
                         }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -275,7 +275,6 @@ fn main() -> Result<()> {
                                     convert_gpu_data(&app.data_collection);
                             }
 
-<<<<<<< HEAD
                             app.converted_data.mem_labels = convert_mem_label(
                                 &app.data_collection.memory_harvest,
                                 app.app_config_fields.memory_use_mega_prefix,
@@ -284,12 +283,6 @@ fn main() -> Result<()> {
                                 &app.data_collection.swap_harvest,
                                 app.app_config_fields.memory_use_mega_prefix,
                             );
-=======
-                            app.converted_data.mem_labels =
-                                convert_mem_label(&app.data_collection.memory_harvest, app.app_config_fields.memory_use_mega_prefix);
-                            app.converted_data.swap_labels =
-                                convert_mem_label(&app.data_collection.swap_harvest, app.app_config_fields.memory_use_mega_prefix);
->>>>>>> 16bcf7d8 (added a feature)
                             #[cfg(not(target_os = "windows"))]
                             {
                                 app.converted_data.cache_labels = convert_mem_label(
@@ -300,15 +293,10 @@ fn main() -> Result<()> {
 
                             #[cfg(feature = "zfs")]
                             {
-<<<<<<< HEAD
                                 let arc_labels = convert_mem_label(
                                     &app.data_collection.arc_harvest,
                                     app.app_config_fields.memory_use_mega_prefix,
                                 );
-=======
-                                let arc_labels =
-                                    convert_mem_label(&app.data_collection.arc_harvest, app.app_config_fields.memory_use_mega_prefix);
->>>>>>> 16bcf7d8 (added a feature)
                                 app.converted_data.arc_labels = arc_labels;
                             }
                         }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -545,6 +545,8 @@ pub const CONFIG_TEXT: &str = r#"# This is a default config file for bottom.  Al
 #whole_word = false
 # Whether to make process searching use regex by default.
 #regex = false
+# Whether to display memory usage in megabibytes (MiB) or gigabibytes (GiB).
+#memory_use_mega_prefix = false
 # Defaults to Celsius.  Temperature is one of:
 #temperature_type = "k"
 #temperature_type = "f"

--- a/src/data_collection.rs
+++ b/src/data_collection.rs
@@ -104,6 +104,7 @@ pub struct DataCollector {
     temperature_type: TemperatureType,
     use_current_cpu_total: bool,
     unnormalized_cpu: bool,
+    memory_use_mega_prefix: bool,
     last_collection_time: Instant,
     total_rx: u64,
     total_tx: u64,
@@ -146,6 +147,7 @@ impl DataCollector {
             temperature_type: TemperatureType::Celsius,
             use_current_cpu_total: false,
             unnormalized_cpu: false,
+            memory_use_mega_prefix: false,
             last_collection_time: Instant::now(),
             total_rx: 0,
             total_tx: 0,
@@ -224,6 +226,10 @@ impl DataCollector {
 
     pub fn set_unnormalized_cpu(&mut self, unnormalized_cpu: bool) {
         self.unnormalized_cpu = unnormalized_cpu;
+    }
+
+    pub fn set_memory_use_mega_prefix(&mut self, memory_use_mega_prefix: bool) {
+        self.memory_use_mega_prefix = memory_use_mega_prefix;
     }
 
     pub fn set_show_average_cpu(&mut self, show_average_cpu: bool) {

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -266,13 +266,9 @@ pub fn convert_swap_data_points(current_data: &DataCollection) -> Vec<Point> {
 ///
 /// The expected usage is to divide out the given value with the returned denominator in order to be able to use it
 /// with the returned binary unit (e.g. divide 3000 bytes by 1024 to have a value in KiB).
-<<<<<<< HEAD
 fn get_mem_binary_unit_and_denominator(
     bytes: u64, memory_use_mega_prefix: bool,
 ) -> (&'static str, f64) {
-=======
-fn get_mem_binary_unit_and_denominator(bytes: u64, memory_use_mega_prefix: bool) -> (&'static str, f64) {
->>>>>>> 16bcf7d8 (added a feature)
     if memory_use_mega_prefix {
         if bytes < KIBI_LIMIT {
             // Stick with bytes if under a kibibyte.
@@ -283,7 +279,6 @@ fn get_mem_binary_unit_and_denominator(bytes: u64, memory_use_mega_prefix: bool)
             // Otherwise just use mebibytes, which is probably safe for most use cases.
             ("MiB", MEBI_LIMIT_F64)
         }
-<<<<<<< HEAD
     } else if bytes < KIBI_LIMIT {
         // Stick with bytes if under a kibibyte.
         ("B", 1.0)
@@ -293,27 +288,22 @@ fn get_mem_binary_unit_and_denominator(bytes: u64, memory_use_mega_prefix: bool)
         ("MiB", MEBI_LIMIT_F64)
     } else if bytes < TEBI_LIMIT {
         ("GiB", GIBI_LIMIT_F64)
-=======
->>>>>>> 16bcf7d8 (added a feature)
+    } else if bytes < KIBI_LIMIT {
+        // Stick with bytes if under a kibibyte.
+        ("B", 1.0)
+    } else if bytes < MEBI_LIMIT {
+        ("KiB", KIBI_LIMIT_F64)
+    } else if bytes < GIBI_LIMIT {
+        ("MiB", MEBI_LIMIT_F64)
+    } else if bytes < TEBI_LIMIT {
+        ("GiB", GIBI_LIMIT_F64)
     } else {
-        if bytes < KIBI_LIMIT {
-            // Stick with bytes if under a kibibyte.
-            ("B", 1.0)
-        } else if bytes < MEBI_LIMIT {
-            ("KiB", KIBI_LIMIT_F64)
-        } else if bytes < GIBI_LIMIT {
-            ("MiB", MEBI_LIMIT_F64)
-        } else if bytes < TEBI_LIMIT {
-            ("GiB", GIBI_LIMIT_F64)
-        } else {
-            // Otherwise just use tebibytes, which is probably safe for most use cases.
-            ("TiB", TEBI_LIMIT_F64)
-        }
+        // Otherwise just use tebibytes, which is probably safe for most use cases.
+        ("TiB", TEBI_LIMIT_F64)
     }
 }
 
 /// Returns the unit type and denominator for given total amount of memory in kibibytes.
-<<<<<<< HEAD
 pub fn convert_mem_label(
     harvest: &MemHarvest, memory_use_mega_prefix: bool,
 ) -> Option<(String, String)> {
@@ -321,12 +311,6 @@ pub fn convert_mem_label(
         Some((format!("{:3.0}%", harvest.use_percent.unwrap_or(0.0)), {
             let (unit, denominator) =
                 get_mem_binary_unit_and_denominator(harvest.total_bytes, memory_use_mega_prefix);
-=======
-pub fn convert_mem_label(harvest: &MemHarvest, memory_use_mega_prefix: bool) -> Option<(String, String)> {
-    if harvest.total_bytes > 0 {
-        Some((format!("{:3.0}%", harvest.use_percent.unwrap_or(0.0)), {
-            let (unit, denominator) = get_mem_binary_unit_and_denominator(harvest.total_bytes, memory_use_mega_prefix);
->>>>>>> 16bcf7d8 (added a feature)
 
             format!(
                 "   {:.1}{}/{:.1}{}",

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -266,27 +266,39 @@ pub fn convert_swap_data_points(current_data: &DataCollection) -> Vec<Point> {
 ///
 /// The expected usage is to divide out the given value with the returned denominator in order to be able to use it
 /// with the returned binary unit (e.g. divide 3000 bytes by 1024 to have a value in KiB).
-fn get_mem_binary_unit_and_denominator(bytes: u64) -> (&'static str, f64) {
-    if bytes < KIBI_LIMIT {
-        // Stick with bytes if under a kibibyte.
-        ("B", 1.0)
-    } else if bytes < MEBI_LIMIT {
-        ("KiB", KIBI_LIMIT_F64)
-    } else if bytes < GIBI_LIMIT {
-        ("MiB", MEBI_LIMIT_F64)
-    } else if bytes < TEBI_LIMIT {
-        ("GiB", GIBI_LIMIT_F64)
+fn get_mem_binary_unit_and_denominator(bytes: u64, memory_use_mega_prefix: bool) -> (&'static str, f64) {
+    if memory_use_mega_prefix {
+        if bytes < KIBI_LIMIT {
+            // Stick with bytes if under a kibibyte.
+            ("B", 1.0)
+        } else if bytes < MEBI_LIMIT {
+            ("KiB", KIBI_LIMIT_F64)
+        } else {
+            // Otherwise just use mebibytes, which is probably safe for most use cases.
+            ("MiB", MEBI_LIMIT_F64)
+        }
     } else {
-        // Otherwise just use tebibytes, which is probably safe for most use cases.
-        ("TiB", TEBI_LIMIT_F64)
+        if bytes < KIBI_LIMIT {
+            // Stick with bytes if under a kibibyte.
+            ("B", 1.0)
+        } else if bytes < MEBI_LIMIT {
+            ("KiB", KIBI_LIMIT_F64)
+        } else if bytes < GIBI_LIMIT {
+            ("MiB", MEBI_LIMIT_F64)
+        } else if bytes < TEBI_LIMIT {
+            ("GiB", GIBI_LIMIT_F64)
+        } else {
+            // Otherwise just use tebibytes, which is probably safe for most use cases.
+            ("TiB", TEBI_LIMIT_F64)
+        }
     }
 }
 
 /// Returns the unit type and denominator for given total amount of memory in kibibytes.
-pub fn convert_mem_label(harvest: &MemHarvest) -> Option<(String, String)> {
+pub fn convert_mem_label(harvest: &MemHarvest, memory_use_mega_prefix: bool) -> Option<(String, String)> {
     if harvest.total_bytes > 0 {
         Some((format!("{:3.0}%", harvest.use_percent.unwrap_or(0.0)), {
-            let (unit, denominator) = get_mem_binary_unit_and_denominator(harvest.total_bytes);
+            let (unit, denominator) = get_mem_binary_unit_and_denominator(harvest.total_bytes, memory_use_mega_prefix);
 
             format!(
                 "   {:.1}{}/{:.1}{}",
@@ -614,7 +626,7 @@ pub fn convert_gpu_data(current_data: &DataCollection) -> Option<Vec<ConvertedGp
                 mem_percent: format!("{:3.0}%", gpu.1.use_percent.unwrap_or(0.0)),
                 mem_total: {
                     let (unit, denominator) =
-                        get_mem_binary_unit_and_denominator(gpu.1.total_bytes);
+                        get_mem_binary_unit_and_denominator(gpu.1.total_bytes, false);
 
                     format!(
                         "   {:.1}{unit}/{:.1}{unit}",

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -279,20 +279,18 @@ fn get_mem_binary_unit_and_denominator(
             // Otherwise just use mebibytes, which is probably safe for most use cases.
             ("MiB", MEBI_LIMIT_F64)
         }
+    } else if bytes < KIBI_LIMIT {
+        // Stick with bytes if under a kibibyte.
+        ("B", 1.0)
+    } else if bytes < MEBI_LIMIT {
+        ("KiB", KIBI_LIMIT_F64)
+    } else if bytes < GIBI_LIMIT {
+        ("MiB", MEBI_LIMIT_F64)
+    } else if bytes < TEBI_LIMIT {
+        ("GiB", GIBI_LIMIT_F64)
     } else {
-        if bytes < KIBI_LIMIT {
-            // Stick with bytes if under a kibibyte.
-            ("B", 1.0)
-        } else if bytes < MEBI_LIMIT {
-            ("KiB", KIBI_LIMIT_F64)
-        } else if bytes < GIBI_LIMIT {
-            ("MiB", MEBI_LIMIT_F64)
-        } else if bytes < TEBI_LIMIT {
-            ("GiB", GIBI_LIMIT_F64)
-        } else {
-            // Otherwise just use tebibytes, which is probably safe for most use cases.
-            ("TiB", TEBI_LIMIT_F64)
-        }
+        // Otherwise just use tebibytes, which is probably safe for most use cases.
+        ("TiB", TEBI_LIMIT_F64)
     }
 }
 

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -266,7 +266,9 @@ pub fn convert_swap_data_points(current_data: &DataCollection) -> Vec<Point> {
 ///
 /// The expected usage is to divide out the given value with the returned denominator in order to be able to use it
 /// with the returned binary unit (e.g. divide 3000 bytes by 1024 to have a value in KiB).
-fn get_mem_binary_unit_and_denominator(bytes: u64, memory_use_mega_prefix: bool) -> (&'static str, f64) {
+fn get_mem_binary_unit_and_denominator(
+    bytes: u64, memory_use_mega_prefix: bool
+) -> (&'static str, f64) {
     if memory_use_mega_prefix {
         if bytes < KIBI_LIMIT {
             // Stick with bytes if under a kibibyte.
@@ -295,10 +297,13 @@ fn get_mem_binary_unit_and_denominator(bytes: u64, memory_use_mega_prefix: bool)
 }
 
 /// Returns the unit type and denominator for given total amount of memory in kibibytes.
-pub fn convert_mem_label(harvest: &MemHarvest, memory_use_mega_prefix: bool) -> Option<(String, String)> {
+pub fn convert_mem_label(
+    harvest: &MemHarvest, memory_use_mega_prefix: bool
+) -> Option<(String, String)> {
     if harvest.total_bytes > 0 {
         Some((format!("{:3.0}%", harvest.use_percent.unwrap_or(0.0)), {
-            let (unit, denominator) = get_mem_binary_unit_and_denominator(harvest.total_bytes, memory_use_mega_prefix);
+            let (unit, denominator) = 
+                get_mem_binary_unit_and_denominator(harvest.total_bytes, memory_use_mega_prefix);
 
             format!(
                 "   {:.1}{}/{:.1}{}",

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -267,7 +267,7 @@ pub fn convert_swap_data_points(current_data: &DataCollection) -> Vec<Point> {
 /// The expected usage is to divide out the given value with the returned denominator in order to be able to use it
 /// with the returned binary unit (e.g. divide 3000 bytes by 1024 to have a value in KiB).
 fn get_mem_binary_unit_and_denominator(
-    bytes: u64, memory_use_mega_prefix: bool
+    bytes: u64, memory_use_mega_prefix: bool,
 ) -> (&'static str, f64) {
     if memory_use_mega_prefix {
         if bytes < KIBI_LIMIT {
@@ -298,11 +298,11 @@ fn get_mem_binary_unit_and_denominator(
 
 /// Returns the unit type and denominator for given total amount of memory in kibibytes.
 pub fn convert_mem_label(
-    harvest: &MemHarvest, memory_use_mega_prefix: bool
+    harvest: &MemHarvest, memory_use_mega_prefix: bool,
 ) -> Option<(String, String)> {
     if harvest.total_bytes > 0 {
         Some((format!("{:3.0}%", harvest.use_percent.unwrap_or(0.0)), {
-            let (unit, denominator) = 
+            let (unit, denominator) =
                 get_mem_binary_unit_and_denominator(harvest.total_bytes, memory_use_mega_prefix);
 
             format!(

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -266,9 +266,13 @@ pub fn convert_swap_data_points(current_data: &DataCollection) -> Vec<Point> {
 ///
 /// The expected usage is to divide out the given value with the returned denominator in order to be able to use it
 /// with the returned binary unit (e.g. divide 3000 bytes by 1024 to have a value in KiB).
+<<<<<<< HEAD
 fn get_mem_binary_unit_and_denominator(
     bytes: u64, memory_use_mega_prefix: bool,
 ) -> (&'static str, f64) {
+=======
+fn get_mem_binary_unit_and_denominator(bytes: u64, memory_use_mega_prefix: bool) -> (&'static str, f64) {
+>>>>>>> 16bcf7d8 (added a feature)
     if memory_use_mega_prefix {
         if bytes < KIBI_LIMIT {
             // Stick with bytes if under a kibibyte.
@@ -279,6 +283,7 @@ fn get_mem_binary_unit_and_denominator(
             // Otherwise just use mebibytes, which is probably safe for most use cases.
             ("MiB", MEBI_LIMIT_F64)
         }
+<<<<<<< HEAD
     } else if bytes < KIBI_LIMIT {
         // Stick with bytes if under a kibibyte.
         ("B", 1.0)
@@ -288,13 +293,27 @@ fn get_mem_binary_unit_and_denominator(
         ("MiB", MEBI_LIMIT_F64)
     } else if bytes < TEBI_LIMIT {
         ("GiB", GIBI_LIMIT_F64)
+=======
+>>>>>>> 16bcf7d8 (added a feature)
     } else {
-        // Otherwise just use tebibytes, which is probably safe for most use cases.
-        ("TiB", TEBI_LIMIT_F64)
+        if bytes < KIBI_LIMIT {
+            // Stick with bytes if under a kibibyte.
+            ("B", 1.0)
+        } else if bytes < MEBI_LIMIT {
+            ("KiB", KIBI_LIMIT_F64)
+        } else if bytes < GIBI_LIMIT {
+            ("MiB", MEBI_LIMIT_F64)
+        } else if bytes < TEBI_LIMIT {
+            ("GiB", GIBI_LIMIT_F64)
+        } else {
+            // Otherwise just use tebibytes, which is probably safe for most use cases.
+            ("TiB", TEBI_LIMIT_F64)
+        }
     }
 }
 
 /// Returns the unit type and denominator for given total amount of memory in kibibytes.
+<<<<<<< HEAD
 pub fn convert_mem_label(
     harvest: &MemHarvest, memory_use_mega_prefix: bool,
 ) -> Option<(String, String)> {
@@ -302,6 +321,12 @@ pub fn convert_mem_label(
         Some((format!("{:3.0}%", harvest.use_percent.unwrap_or(0.0)), {
             let (unit, denominator) =
                 get_mem_binary_unit_and_denominator(harvest.total_bytes, memory_use_mega_prefix);
+=======
+pub fn convert_mem_label(harvest: &MemHarvest, memory_use_mega_prefix: bool) -> Option<(String, String)> {
+    if harvest.total_bytes > 0 {
+        Some((format!("{:3.0}%", harvest.use_percent.unwrap_or(0.0)), {
+            let (unit, denominator) = get_mem_binary_unit_and_denominator(harvest.total_bytes, memory_use_mega_prefix);
+>>>>>>> 16bcf7d8 (added a feature)
 
             format!(
                 "   {:.1}{}/{:.1}{}",

--- a/src/options.rs
+++ b/src/options.rs
@@ -75,6 +75,7 @@ pub struct ConfigFlags {
     left_legend: Option<bool>,
     current_usage: Option<bool>,
     unnormalized_cpu: Option<bool>,
+    memory_use_mega_prefix: Option<bool>,
     group_processes: Option<bool>,
     case_sensitive: Option<bool>,
     whole_word: Option<bool>,
@@ -271,6 +272,7 @@ pub fn init_app(
         left_legend: is_flag_enabled!(left_legend, matches, config),
         use_current_cpu_total: is_flag_enabled!(current_usage, matches, config),
         unnormalized_cpu: is_flag_enabled!(unnormalized_cpu, matches, config),
+        memory_use_mega_prefix: is_flag_enabled!(memory_use_mega_prefix, matches, config),
         use_basic_mode,
         default_time_value,
         time_interval: get_time_interval(matches, config, retention_ms)

--- a/src/options/args.rs
+++ b/src/options/args.rs
@@ -403,6 +403,12 @@ use CPU (3) as the default instead.
         .action(ArgAction::Version)
         .help("Prints version information.");
 
+    let memory_use_mega_prefix = Arg::new("memory_use_mega_prefix")
+        .long("memory_use_mega_prefix")
+        .action(ArgAction::SetTrue)
+        .help("Displays the memory widget with a mega prefix.")
+        .long_help("Displays the memory widget in megabibytes instead of rounding it to the nearest prefix. Defaults to rounding it to the nearest prefix. Example: 1.2GiB will be displayed as 1228MiB.");
+
     const VERSION: &str = match option_env!("NIGHTLY_VERSION") {
         Some(nightly_version) => nightly_version,
         None => crate_version!(),
@@ -426,6 +432,7 @@ use CPU (3) as the default instead.
         config_location,
         color,
         mem_as_value,
+        memory_use_mega_prefix,
         default_time_value,
         default_widget_count,
         default_widget_type,


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_
Added possibility to use "--memory_use_mega_prefix" flag to see the RAM memory in MiB even if it exceeds 1 GiB.

## Issue

_If applicable, what issue does this address?_
Added the request provided here: https://github.com/ClementTsang/bottom/discussions/695 and https://github.com/ClementTsang/bottom/issues/696

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [x] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
