### PR TITLE
ci: update cirrus-ci FreeBSD versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,9 @@
 %YAML 1.1
 ---
 # Configuration for CirrusCI. This is primarily used for testing and building FreeBSD and macOS M1, since other
-# CI platforms don't seem to support these platforms as of writing.
+# CI platforms don't seem to support these platforms as of writing (GH may support M1 soon though).
 #
-# Note that we set the YAML directive above to prevent some linting errors around the
-# templates.
+# Note that we set the YAML directive above to prevent some linting errors around the templates.
 
 setup_template: &SETUP_TEMPLATE
   setup_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,12 +45,12 @@ test_task:
   timeout_in: "20m"
   skip: "!changesInclude('.cargo/**', '.cirrus.yml', 'sample_configs/**', 'src/**', 'tests/**', 'build.rs', 'Cargo.lock', 'Cargo.toml', 'clippy.toml', 'rustfmt.toml')"
   matrix:
+    - name: "FreeBSD 14 Test"
+      freebsd_instance:
+        image_family: freebsd-14-0
     - name: "FreeBSD 13 Test"
       freebsd_instance:
-        image_family: freebsd-13-1
-    - name: "FreeBSD 12 Test"
-      freebsd_instance:
-        image_family: freebsd-12-3
+        image_family: freebsd-13-2
     - name: "macOS M1 Test"
       macos_instance:
         image: ghcr.io/cirruslabs/macos-monterey-base:latest
@@ -80,20 +80,20 @@ build_task:
     MANPAGE_DIR: "target/tmp/bottom/manpage/"
     # -PLACEHOLDER FOR CI-
   matrix:
+    - name: "FreeBSD 14 Build"
+      alias: "freebsd_14_0_build"
+      freebsd_instance:
+        image_family: freebsd-14-0
+      env:
+        TARGET: "x86_64-unknown-freebsd"
+        NAME: "x86_64-unknown-freebsd-14-0"
     - name: "FreeBSD 13 Build"
-      alias: "freebsd_13_1_build"
+      alias: "freebsd_13_2_build"
       freebsd_instance:
-        image_family: freebsd-13-1
+        image_family: freebsd-13-2
       env:
         TARGET: "x86_64-unknown-freebsd"
-        NAME: "x86_64-unknown-freebsd-13-1"
-    - name: "FreeBSD 12 Build"
-      alias: "freebsd_12_3_build"
-      freebsd_instance:
-        image_family: freebsd-12-3
-      env:
-        TARGET: "x86_64-unknown-freebsd"
-        NAME: "x86_64-unknown-freebsd-12-3"
+        NAME: "x86_64-unknown-freebsd-13-2"
     - name: "macOS M1 Build"
       alias: "macos_build"
       macos_instance:

--- a/scripts/cirrus/build.py
+++ b/scripts/cirrus/build.py
@@ -18,8 +18,8 @@ from urllib.request import Request, urlopen, urlretrieve
 
 URL = "https://api.cirrus-ci.com/graphql"
 TASKS = [
-    ("freebsd_12_3_build", "bottom_x86_64-unknown-freebsd-12-3.tar.gz"),
-    ("freebsd_13_1_build", "bottom_x86_64-unknown-freebsd-13-1.tar.gz"),
+    ("freebsd_12_3_build", "bottom_x86_64-unknown-freebsd-13-2.tar.gz"),
+    ("freebsd_13_1_build", "bottom_x86_64-unknown-freebsd-14-0.tar.gz"),
     ("macos_build", "bottom_aarch64-apple-darwin.tar.gz"),
 ]
 DL_URL_TEMPLATE = "https://api.cirrus-ci.com/v1/artifact/build/%s/%s/binaries/%s"
@@ -31,9 +31,7 @@ def make_query_request(key: str, branch: str, build_type: str):
 
     # Dumb but if it works...
     config_override = (
-        Path(".cirrus.yml")
-        .read_text()
-        .replace("# -PLACEHOLDER FOR CI-", 'BTM_BUILD_RELEASE_CALLER: "nightly"')
+        Path(".cirrus.yml").read_text().replace("# -PLACEHOLDER FOR CI-", 'BTM_BUILD_RELEASE_CALLER: "nightly"')
     )
     query = """
         mutation CreateCirrusCIBuild (
@@ -192,11 +190,7 @@ def main():
                         # Sleep for a minute if something went wrong, just in case.
                         sleep(60)
                 else:
-                    print(
-                        "Build failed to complete after {} minutes, bailing.".format(
-                            MINUTES
-                        )
-                    )
+                    print("Build failed to complete after {} minutes, bailing.".format(MINUTES))
 
         if not success:
             exit(2)


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Looks like the newest available FreeBSD images are 13-2 and 14-0, and the previously used ones aren't available anymore.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Nightly run [here](https://github.com/ClementTsang/bottom/actions/runs/7685249483).

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
