### PR TITLE
ci: bump choco action to v3.0.0 and replace release deletion action

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -225,7 +225,7 @@ jobs:
         run: Install-WindowsFeature Net-Framework-Core
 
       - name: Install wixtoolset
-        uses: crazy-max/ghaction-chocolatey@5a5864861ce2c988001531e48993aa687c51f6c8 # 2.2.0
+        uses: crazy-max/ghaction-chocolatey@0e015857dd851f84fcb7fb53380eb5c4c8202333 # v3.0.0
         with:
           args: install -y wixtoolset
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,8 +61,11 @@ jobs:
           du -h -d 0 ./release/*
 
       - name: Delete tag and release if not mock
+        uses: ClementTsang/delete-tag-and-release@v0.4.0
         if: github.event.inputs.isMock != 'mock'
-        run: gh release delete nightly --cleanup-tag
+        with:
+          delete_release: true
+          tag_name: nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,12 +60,9 @@ jobs:
           echo "Generated $(ls ./release | wc -l) files:"
           du -h -d 0 ./release/*
 
-      - name: Delete tag and release
-        uses: ClementTsang/delete-tag-and-release@v0.3.1
+      - name: Delete tag and release if not mock
         if: github.event.inputs.isMock != 'mock'
-        with:
-          delete_release: true
-          tag_name: nightly
+        run: gh release delete nightly --cleanup-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -73,7 +70,7 @@ jobs:
         run: sleep 10
         if: github.event.inputs.isMock != 'mock'
 
-      - name: Add all release files to nightly release if not mock
+      - name: Add all release files and create nightly release if not mock
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # 0.1.15
         if: github.event.inputs.isMock != 'mock'
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,6 +48,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-release]
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 1
+
       - name: Get release artifacts
         uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
@@ -61,11 +66,8 @@ jobs:
           du -h -d 0 ./release/*
 
       - name: Delete tag and release if not mock
-        uses: ClementTsang/delete-tag-and-release@v0.4.0
         if: github.event.inputs.isMock != 'mock'
-        with:
-          delete_release: true
-          tag_name: nightly
+        run: gh release delete nightly --cleanup-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

To avoid node deprecation warnings, this bumps the choco action to v3.0.0 and switches to `gh release delete` to clean up the nightly release.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Nightly run: https://github.com/ClementTsang/bottom/actions/runs/7689376083

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
