### PR TITLE
chore(deps): upgrade ratatui to 0.26 and crossterm to 0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,13 +19,14 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -36,6 +37,12 @@ checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anstream"
@@ -135,6 +142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
 name = "bottom"
 version = "0.9.0"
 dependencies = [
@@ -157,7 +170,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "indexmap",
- "itertools",
+ "itertools 0.10.5",
  "kstring",
  "libc",
  "log",
@@ -213,6 +226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,7 +263,7 @@ checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "once_cell",
  "strsim 0.10.0",
@@ -278,6 +300,19 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "concat-string"
@@ -346,11 +381,11 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.2",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -362,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
@@ -554,6 +589,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +658,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +691,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -719,6 +779,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,7 +838,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "static_assertions",
@@ -815,7 +884,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd21b9f5a1cce3c3515c9ffa85f5c7443e07162dae0ccf4339bb7ca38ad3454"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libloading",
  "nvml-wrapper-sys",
  "static_assertions",
@@ -877,6 +946,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
 name = "predicates"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,7 +960,7 @@ dependencies = [
  "anstyle",
  "difflib",
  "float-cmp",
- "itertools",
+ "itertools 0.10.5",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -909,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -922,7 +997,7 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "hex",
  "lazy_static",
@@ -931,22 +1006,29 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ratatui"
-version = "0.20.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc0d032bccba900ee32151ec0265667535c230169f5a011154cdcd984e16829"
+checksum = "154b85ef15a5d1719bcaa193c3c81fe645cd120c156874cd660fe49fd21d1373"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.2",
  "cassowary",
+ "compact_str",
  "crossterm",
+ "indoc",
+ "itertools 0.12.1",
+ "lru",
+ "paste",
+ "stability",
+ "strum",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -979,7 +1061,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1034,7 +1116,7 @@ version = "0.36.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a38f9520be93aba504e8ca974197f46158de5dcaa9fa04b57c57cd6a679d658"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -1048,13 +1130,19 @@ version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.7",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -1094,7 +1182,7 @@ checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1119,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1152,6 +1240,16 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "stability"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "starship-battery"
@@ -1189,6 +1287,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1216,7 +1336,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed66d6a2ccbd656659289bc90767895b7abbdec897a0fc6031aca3ed1cb51d3e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -1272,7 +1392,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1597,4 +1717,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ backtrace = "0.3.67"
 cfg-if = "1.0.0"
 clap = { version = "4.2.7", features = ["default", "cargo", "wrap_help"] }
 concat-string = "1.0.1"
-crossterm = "0.26.1"
+crossterm = "0.27.0"
 ctrlc = { version = "3.2.5", features = ["termination"] }
 # dhat = "0.3.2"
 dirs = "5.0.1"
@@ -101,7 +101,7 @@ sysinfo = "=0.29.0"
 thiserror = "1.0.40"
 time = { version = "0.3.20", features = ["formatting", "macros"] }
 toml_edit = { version = "0.19.8", features = ["serde"] }
-tui = { version = "0.20.1", package = "ratatui" }
+tui = { version = "0.26.0", package = "ratatui" }
 typed-builder = "0.14.0"
 unicode-segmentation = "1.10.1"
 unicode-width = "0.1.10"

--- a/src/app/data_harvester/disks.rs
+++ b/src/app/data_harvester/disks.rs
@@ -82,7 +82,7 @@ cfg_if! {
 /// 2. Is the entry denied through any filter? That is, does it match an entry in a
 ///    filter where `is_list_ignored` is `true`? If so, we always deny this entry.
 /// 3. Anything else is allowed.
-pub(self) fn keep_disk_entry(
+fn keep_disk_entry(
     disk_name: &str, mount_point: &str, disk_filter: &Option<Filter>, mount_filter: &Option<Filter>,
 ) -> bool {
     match (disk_filter, mount_filter) {

--- a/src/app/query.rs
+++ b/src/app/query.rs
@@ -328,7 +328,6 @@ pub fn parse_query(
                                         }),
                                     )),
                                 });
-                            } else {
                             }
                         }
                         _ => {

--- a/src/app/states.rs
+++ b/src/app/states.rs
@@ -208,7 +208,7 @@ impl AppSearchState {
                         .next_boundary(chunk, start_position)
                         .unwrap();
                 }
-                _ => Err(err).unwrap(),
+                _ => panic!("{:?}", err),
             },
         }
     }
@@ -228,7 +228,7 @@ impl AppSearchState {
 
                     self.grapheme_cursor.prev_boundary(chunk, 0).unwrap();
                 }
-                _ => Err(err).unwrap(),
+                _ => panic!("{:?}", err),
             },
         }
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
     // let _profiler = dhat::Profiler::new_heap();
 
     let matches = clap::get_matches();
-    #[cfg(all(feature = "fern"))]
+    #[cfg(feature = "fern")]
     {
         if let Err(err) =
             utils::logging::init_logger(log::LevelFilter::Debug, std::ffi::OsStr::new("debug.log"))

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -5,7 +5,7 @@ use itertools::izip;
 use tui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
-    text::{Span, Spans},
+    text::{Line, Span},
     widgets::Paragraph,
     Frame, Terminal,
 };
@@ -62,7 +62,7 @@ pub struct Painter {
     pub colours: CanvasColours,
     height: u16,
     width: u16,
-    styled_help_text: Vec<Spans<'static>>,
+    styled_help_text: Vec<Line<'static>>,
     is_mac_os: bool, // TODO: This feels out of place...
 
     // TODO: Redo this entire thing.
@@ -212,10 +212,10 @@ impl Painter {
             }
         });
 
-        self.styled_help_text = styled_help_spans.into_iter().map(Spans::from).collect();
+        self.styled_help_text = styled_help_spans.into_iter().map(Line::from).collect();
     }
 
-    fn draw_frozen_indicator<B: Backend>(&self, f: &mut Frame<'_, B>, draw_loc: Rect) {
+    fn draw_frozen_indicator(&self, f: &mut Frame<'_>, draw_loc: Rect) {
         f.render_widget(
             Paragraph::new(Span::styled(
                 "Frozen, press 'f' to unfreeze",
@@ -228,8 +228,8 @@ impl Painter {
         )
     }
 
-    pub fn draw_data<B: Backend>(
-        &mut self, terminal: &mut Terminal<B>, app_state: &mut app::App,
+    pub fn draw_data(
+        &mut self, terminal: &mut Terminal<impl Backend>, app_state: &mut app::App,
     ) -> error::Result<()> {
         use BottomWidgetType::*;
 
@@ -771,8 +771,8 @@ impl Painter {
         Ok(())
     }
 
-    fn draw_widgets_with_constraints<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, widgets: &BottomColRow,
+    fn draw_widgets_with_constraints(
+        &self, f: &mut Frame<'_>, app_state: &mut App, widgets: &BottomColRow,
         widget_draw_locs: &[Rect],
     ) {
         use BottomWidgetType::*;

--- a/src/canvas/dialogs/dd_dialog.rs
+++ b/src/canvas/dialogs/dd_dialog.rs
@@ -2,10 +2,9 @@
 use std::cmp::min;
 
 use tui::{
-    backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     terminal::Frame,
-    text::{Span, Spans, Text},
+    text::{Line, Span, Text},
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 
@@ -22,15 +21,15 @@ impl Painter {
     pub fn get_dd_spans(&self, app_state: &App) -> Option<Text<'_>> {
         if let Some(dd_err) = &app_state.dd_err {
             return Some(Text::from(vec![
-                Spans::default(),
-                Spans::from("Failed to kill process."),
-                Spans::from(dd_err.clone()),
-                Spans::from("Please press ENTER or ESC to close this dialog."),
+                Line::default(),
+                Line::from("Failed to kill process."),
+                Line::from(dd_err.clone()),
+                Line::from("Please press ENTER or ESC to close this dialog."),
             ]));
         } else if let Some(to_kill_processes) = app_state.get_to_delete_processes() {
             if let Some(first_pid) = to_kill_processes.1.first() {
                 return Some(Text::from(vec![
-                    Spans::from(""),
+                    Line::from(""),
                     if app_state
                         .proc_state
                         .widget_states
@@ -39,19 +38,19 @@ impl Painter {
                         .unwrap_or(false)
                     {
                         if to_kill_processes.1.len() != 1 {
-                            Spans::from(format!(
+                            Line::from(format!(
                                 "Kill {} processes with the name \"{}\"?  Press ENTER to confirm.",
                                 to_kill_processes.1.len(),
                                 to_kill_processes.0
                             ))
                         } else {
-                            Spans::from(format!(
+                            Line::from(format!(
                                 "Kill 1 process with the name \"{}\"?  Press ENTER to confirm.",
                                 to_kill_processes.0
                             ))
                         }
                     } else {
-                        Spans::from(format!(
+                        Line::from(format!(
                             "Kill process \"{}\" with PID {}?  Press ENTER to confirm.",
                             to_kill_processes.0, first_pid
                         ))
@@ -63,8 +62,8 @@ impl Painter {
         None
     }
 
-    fn draw_dd_confirm_buttons<B: Backend>(
-        &self, f: &mut Frame<'_, B>, button_draw_loc: &Rect, app_state: &mut App,
+    fn draw_dd_confirm_buttons(
+        &self, f: &mut Frame<'_>, button_draw_loc: &Rect, app_state: &mut App,
     ) {
         if MAX_PROCESS_SIGNAL == 1 || !app_state.app_config_fields.is_advanced_kill {
             let (yes_button, no_button) = match app_state.delete_dialog_state.selected_signal {
@@ -352,12 +351,12 @@ impl Painter {
         }
     }
 
-    pub fn draw_dd_dialog<B: Backend>(
-        &self, f: &mut Frame<'_, B>, dd_text: Option<Text<'_>>, app_state: &mut App, draw_loc: Rect,
+    pub fn draw_dd_dialog(
+        &self, f: &mut Frame<'_>, dd_text: Option<Text<'_>>, app_state: &mut App, draw_loc: Rect,
     ) -> bool {
         if let Some(dd_text) = dd_text {
             let dd_title = if app_state.dd_err.is_some() {
-                Spans::from(vec![
+                Line::from(vec![
                     Span::styled(" Error ", self.colours.widget_title_style),
                     Span::styled(
                         format!(
@@ -371,7 +370,7 @@ impl Painter {
                     ),
                 ])
             } else {
-                Spans::from(vec![
+                Line::from(vec![
                     Span::styled(" Confirm Kill Process ", self.colours.widget_title_style),
                     Span::styled(
                         format!(

--- a/src/canvas/dialogs/help_dialog.rs
+++ b/src/canvas/dialogs/help_dialog.rs
@@ -1,11 +1,10 @@
 use std::cmp::{max, min};
 
 use tui::{
-    backend::Backend,
     layout::{Alignment, Rect},
     terminal::Frame,
+    text::Line,
     text::Span,
-    text::Spans,
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 use unicode_width::UnicodeWidthStr;
@@ -16,10 +15,8 @@ const HELP_BASE: &str = " Help ── Esc to close ";
 
 // TODO: [REFACTOR] Make generic dialog boxes to build off of instead?
 impl Painter {
-    pub fn draw_help_dialog<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect,
-    ) {
-        let help_title = Spans::from(vec![
+    pub fn draw_help_dialog(&self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect) {
+        let help_title = Line::from(vec![
             Span::styled(" Help ", self.colours.widget_title_style),
             Span::styled(
                 format!(

--- a/src/canvas/widgets/basic_table_arrows.rs
+++ b/src/canvas/widgets/basic_table_arrows.rs
@@ -1,9 +1,8 @@
 use tui::{
-    backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     terminal::Frame,
+    text::Line,
     text::Span,
-    text::Spans,
     widgets::{Block, Paragraph},
 };
 
@@ -13,8 +12,8 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_basic_table_arrows<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+    pub fn draw_basic_table_arrows(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         if let Some(current_table) = app_state.widget_map.get(&widget_id) {
             let current_table = if let BottomWidgetType::ProcSort = current_table.widget_type {
@@ -93,16 +92,16 @@ impl Painter {
                 usize::from(draw_loc.width).saturating_sub(6 + left_name.len() + right_name.len());
 
             let left_arrow_text = vec![
-                Spans::default(),
-                Spans::from(Span::styled(
+                Line::default(),
+                Line::from(Span::styled(
                     format!("◄ {}", left_name),
                     self.colours.text_style,
                 )),
             ];
 
             let right_arrow_text = vec![
-                Spans::default(),
-                Spans::from(Span::styled(
+                Line::default(),
+                Line::from(Span::styled(
                     format!("{} ►", right_name),
                     self.colours.text_style,
                 )),

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -1,8 +1,7 @@
 use tui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     terminal::Frame,
-    text::{Span, Spans},
+    text::{Line, Span},
     widgets::{Block, Borders, Cell, Paragraph, Row, Table, Tabs},
 };
 use unicode_segmentation::UnicodeSegmentation;
@@ -15,8 +14,8 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_battery_display<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
+    pub fn draw_battery_display(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
         widget_id: u64,
     ) {
         let should_get_widget_bounds = app_state.should_get_widget_bounds();
@@ -37,7 +36,7 @@ impl Painter {
 
             let title = if app_state.is_expanded {
                 const TITLE_BASE: &str = " Battery ── Esc to go back ";
-                Spans::from(vec![
+                Line::from(vec![
                     Span::styled(" Battery ", self.colours.widget_title_style),
                     Span::styled(
                         format!(
@@ -50,7 +49,7 @@ impl Painter {
                     ),
                 ])
             } else {
-                Spans::from(Span::styled(" Battery ", self.colours.widget_title_style))
+                Line::from(Span::styled(" Battery ", self.colours.widget_title_style))
             };
 
             let battery_block = if draw_border {
@@ -86,7 +85,7 @@ impl Painter {
                 Tabs::new(
                     battery_names
                         .iter()
-                        .map(|name| Spans::from((*name).clone()))
+                        .map(|name| Line::from((*name).clone()))
                         .collect::<Vec<_>>(),
                 )
                 .block(Block::default())
@@ -217,16 +216,18 @@ impl Painter {
 
                 // Draw
                 f.render_widget(
-                    Table::new(battery_rows)
-                        .block(battery_block)
-                        .header(Row::new(vec![""]).bottom_margin(table_gap))
-                        .widths(&[Constraint::Percentage(50), Constraint::Percentage(50)]),
+                    Table::new(
+                        battery_rows,
+                        [Constraint::Percentage(50), Constraint::Percentage(50)],
+                    )
+                    .block(battery_block)
+                    .header(Row::new(vec![""]).bottom_margin(table_gap)),
                     margined_draw_loc,
                 );
             } else {
-                let mut contents = vec![Spans::default(); table_gap.into()];
+                let mut contents = vec![Line::default(); table_gap.into()];
 
-                contents.push(Spans::from(Span::styled(
+                contents.push(Line::from(Span::styled(
                     "No data found for this battery",
                     self.colours.text_style,
                 )));

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -77,7 +77,7 @@ impl Painter {
 
                 // Very ugly way to sync the gauge limit across all gauges.
                 let hide_parts = columns
-                    .get(0)
+                    .first()
                     .map(|col| {
                         if col.width >= 12 {
                             LabelLimit::None

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -1,7 +1,6 @@
 use std::cmp::min;
 
 use tui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     terminal::Frame,
     widgets::Block,
@@ -17,8 +16,8 @@ use crate::{
 
 impl Painter {
     /// Inspired by htop.
-    pub fn draw_basic_cpu<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+    pub fn draw_basic_cpu(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         // Skip the first element, it's the "all" element
         if app_state.converted_data.cpu_data.len() > 1 {

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 
 use concat_string::concat_string;
 use tui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     symbols::Marker,
     terminal::Frame,
@@ -23,9 +22,7 @@ const AVG_POSITION: usize = 1;
 const ALL_POSITION: usize = 0;
 
 impl Painter {
-    pub fn draw_cpu<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
-    ) {
+    pub fn draw_cpu(&self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64) {
         let legend_width = (draw_loc.width as f64 * 0.15) as u16;
 
         if legend_width < 6 {
@@ -174,8 +171,8 @@ impl Painter {
         }
     }
 
-    fn draw_cpu_graph<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+    fn draw_cpu_graph(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         const Y_BOUNDS: [f64; 2] = [0.0, 100.5];
         const Y_LABELS: [Cow<'static, str>; 2] = [Cow::Borrowed("  0%"), Cow::Borrowed("100%")];
@@ -233,8 +230,8 @@ impl Painter {
         }
     }
 
-    fn draw_cpu_legend<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+    fn draw_cpu_legend(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let recalculate_column_widths = app_state.should_get_widget_bounds();
         if let Some(cpu_widget_state) = app_state.cpu_state.widget_states.get_mut(&(widget_id - 1))

--- a/src/canvas/widgets/disk_table.rs
+++ b/src/canvas/widgets/disk_table.rs
@@ -1,4 +1,4 @@
-use tui::{backend::Backend, layout::Rect, terminal::Frame};
+use tui::{layout::Rect, terminal::Frame};
 
 use crate::{
     app::{self},
@@ -7,8 +7,8 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_disk_table<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut app::App, draw_loc: Rect, widget_id: u64,
+    pub fn draw_disk_table(
+        &self, f: &mut Frame<'_>, app_state: &mut app::App, draw_loc: Rect, widget_id: u64,
     ) {
         let recalculate_column_widths = app_state.should_get_widget_bounds();
         if let Some(disk_widget_state) = app_state.disk_state.widget_states.get_mut(&widget_id) {

--- a/src/canvas/widgets/mem_basic.rs
+++ b/src/canvas/widgets/mem_basic.rs
@@ -1,5 +1,4 @@
 use tui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     terminal::Frame,
     widgets::Block,
@@ -10,8 +9,8 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_basic_memory<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+    pub fn draw_basic_memory(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let mem_data = &app_state.converted_data.mem_data;
         let mut draw_widgets: Vec<PipeGauge<'_>> = Vec::new();

--- a/src/canvas/widgets/mem_graph.rs
+++ b/src/canvas/widgets/mem_graph.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use tui::{
-    backend::Backend,
     layout::{Constraint, Rect},
     symbols::Marker,
     terminal::Frame,
@@ -14,8 +13,8 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_memory_graph<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+    pub fn draw_memory_graph(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         const Y_BOUNDS: [f64; 2] = [0.0, 100.5];
         const Y_LABELS: [Cow<'static, str>; 2] = [Cow::Borrowed("  0%"), Cow::Borrowed("100%")];

--- a/src/canvas/widgets/network_basic.rs
+++ b/src/canvas/widgets/network_basic.rs
@@ -1,16 +1,15 @@
 use tui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     terminal::Frame,
-    text::{Span, Spans},
+    text::{Line, Span},
     widgets::{Block, Paragraph},
 };
 
 use crate::{app::App, canvas::Painter, constants::*};
 
 impl Painter {
-    pub fn draw_basic_network<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+    pub fn draw_basic_network(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let divided_loc = Layout::default()
             .direction(Direction::Horizontal)
@@ -44,13 +43,13 @@ impl Painter {
         let total_tx_label = format!("Total TX: {}", &app_state.converted_data.total_tx_display);
 
         let net_text = vec![
-            Spans::from(Span::styled(rx_label, self.colours.rx_style)),
-            Spans::from(Span::styled(tx_label, self.colours.tx_style)),
+            Line::from(Span::styled(rx_label, self.colours.rx_style)),
+            Line::from(Span::styled(tx_label, self.colours.tx_style)),
         ];
 
         let total_net_text = vec![
-            Spans::from(Span::styled(total_rx_label, self.colours.total_rx_style)),
-            Spans::from(Span::styled(total_tx_label, self.colours.total_tx_style)),
+            Line::from(Span::styled(total_rx_label, self.colours.total_rx_style)),
+            Line::from(Span::styled(total_tx_label, self.colours.total_tx_style)),
         ];
 
         f.render_widget(Paragraph::new(net_text).block(Block::default()), net_loc[0]);

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -1,5 +1,4 @@
 use tui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     symbols::Marker,
     terminal::Frame,
@@ -19,8 +18,8 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_network<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+    pub fn draw_network(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         if app_state.app_config_fields.use_old_network_legend {
             const LEGEND_HEIGHT: u16 = 4;
@@ -51,8 +50,8 @@ impl Painter {
         }
     }
 
-    pub fn draw_network_graph<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+    pub fn draw_network_graph(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
         hide_legend: bool,
     ) {
         if let Some(network_widget_state) = app_state.net_state.widget_states.get_mut(&widget_id) {
@@ -166,8 +165,8 @@ impl Painter {
         }
     }
 
-    fn draw_network_labels<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+    fn draw_network_labels(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         const NETWORK_HEADERS: [&str; 4] = ["RX", "TX", "Total RX", "Total TX"];
 
@@ -185,8 +184,12 @@ impl Painter {
         ])];
 
         // Draw
+        let widths = std::iter::repeat(draw_loc.width.saturating_sub(2) / 4)
+            .take(4)
+            .map(Constraint::Length)
+            .collect::<Vec<_>>();
         f.render_widget(
-            Table::new(total_network)
+            Table::new(total_network, widths)
                 .header(Row::new(NETWORK_HEADERS.to_vec()).style(self.colours.table_header_style))
                 .block(Block::default().borders(Borders::ALL).border_style(
                     if app_state.current_widget.widget_id == widget_id {
@@ -195,13 +198,7 @@ impl Painter {
                         self.colours.border_style
                     },
                 ))
-                .style(self.colours.text_style)
-                .widths(
-                    &((std::iter::repeat(draw_loc.width.saturating_sub(2) / 4))
-                        .take(4)
-                        .map(Constraint::Length)
-                        .collect::<Vec<_>>()),
-                ),
+                .style(self.colours.text_style),
             draw_loc,
         );
     }

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -1,9 +1,8 @@
 use tui::{
-    backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::Style,
     terminal::Frame,
-    text::{Span, Spans},
+    text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
 };
 use unicode_segmentation::UnicodeSegmentation;
@@ -20,8 +19,8 @@ const SORT_MENU_WIDTH: u16 = 7;
 impl Painter {
     /// Draws and handles all process-related drawing.  Use this.
     /// - `widget_id` here represents the widget ID of the process widget itself!
-    pub fn draw_process_widget<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
+    pub fn draw_process_widget(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
         widget_id: u64,
     ) {
         if let Some(proc_widget_state) = app_state.proc_state.widget_states.get(&widget_id) {
@@ -68,8 +67,8 @@ impl Painter {
 
     /// Draws the process sort box.
     /// - `widget_id` represents the widget ID of the process widget itself.an
-    fn draw_processes_table<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+    fn draw_processes_table(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let should_get_widget_bounds = app_state.should_get_widget_bounds();
         if let Some(proc_widget_state) = app_state.proc_state.widget_states.get_mut(&widget_id) {
@@ -97,8 +96,8 @@ impl Painter {
     /// Draws the process search field.
     /// - `widget_id` represents the widget ID of the search box itself --- NOT the process widget
     /// state that is stored.
-    fn draw_search_field<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
+    fn draw_search_field(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, draw_border: bool,
         widget_id: u64,
     ) {
         fn build_query_span(
@@ -172,7 +171,7 @@ impl Painter {
                 self.colours.text_style,
             );
 
-            let mut search_text = vec![Spans::from({
+            let mut search_text = vec![Line::from({
                 let mut search_vec = vec![Span::styled(
                     SEARCH_TITLE,
                     if is_on_widget {
@@ -212,7 +211,7 @@ impl Painter {
             } else {
                 ("Case(Alt+C)", "Whole(Alt+W)", "Regex(Alt+R)")
             };
-            let option_text = Spans::from(vec![
+            let option_text = Line::from(vec![
                 Span::styled(case, case_style),
                 Span::raw("  "),
                 Span::styled(whole, whole_word_style),
@@ -220,7 +219,7 @@ impl Painter {
                 Span::styled(regex, regex_style),
             ]);
 
-            search_text.push(Spans::from(Span::styled(
+            search_text.push(Line::from(Span::styled(
                 if let Some(err) = &proc_widget_state.proc_search.search_state.error_message {
                     err.as_str()
                 } else {
@@ -294,8 +293,8 @@ impl Painter {
     /// Draws the process sort box.
     /// - `widget_id` represents the widget ID of the sort box itself --- NOT the process widget
     /// state that is stored.
-    fn draw_sort_table<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
+    fn draw_sort_table(
+        &self, f: &mut Frame<'_>, app_state: &mut App, draw_loc: Rect, widget_id: u64,
     ) {
         let should_get_widget_bounds = app_state.should_get_widget_bounds();
         if let Some(pws) = app_state.proc_state.widget_states.get_mut(&(widget_id - 2)) {

--- a/src/canvas/widgets/temperature_table.rs
+++ b/src/canvas/widgets/temperature_table.rs
@@ -1,4 +1,4 @@
-use tui::{backend::Backend, layout::Rect, terminal::Frame};
+use tui::{layout::Rect, terminal::Frame};
 
 use crate::{
     app,
@@ -7,8 +7,8 @@ use crate::{
 };
 
 impl Painter {
-    pub fn draw_temp_table<B: Backend>(
-        &self, f: &mut Frame<'_, B>, app_state: &mut app::App, draw_loc: Rect, widget_id: u64,
+    pub fn draw_temp_table(
+        &self, f: &mut Frame<'_>, app_state: &mut app::App, draw_loc: Rect, widget_id: u64,
     ) {
         let recalculate_column_widths = app_state.should_get_widget_bounds();
         if let Some(temp_widget_state) = app_state.temp_state.widget_states.get_mut(&widget_id) {

--- a/src/components/time_graph.rs
+++ b/src/components/time_graph.rs
@@ -2,11 +2,10 @@ use std::borrow::Cow;
 
 use concat_string::concat_string;
 use tui::{
-    backend::Backend,
     layout::{Constraint, Rect},
     style::Style,
     symbols::Marker,
-    text::{Span, Spans},
+    text::{Line, Span},
     widgets::{Block, Borders, GraphType},
     Frame,
 };
@@ -96,10 +95,10 @@ impl<'a> TimeGraph<'a> {
     }
 
     /// Generates a title for the [`TimeGraph`] widget, given the available space.
-    fn generate_title(&self, draw_loc: Rect) -> Spans<'_> {
+    fn generate_title(&self, draw_loc: Rect) -> Line<'_> {
         if self.is_expanded {
             let title_base = concat_string!(self.title, "── Esc to go back ");
-            Spans::from(vec![
+            Line::from(vec![
                 Span::styled(self.title.as_ref(), self.title_style),
                 Span::styled(
                     concat_string!(
@@ -113,7 +112,7 @@ impl<'a> TimeGraph<'a> {
                 ),
             ])
         } else {
-            Spans::from(Span::styled(self.title.as_ref(), self.title_style))
+            Line::from(Span::styled(self.title.as_ref(), self.title_style))
         }
     }
 
@@ -124,9 +123,7 @@ impl<'a> TimeGraph<'a> {
     /// - Draws with the higher time value on the left, and lower on the right.
     /// - Expects a [`TimeGraph`] to be passed in, which details how to draw the graph.
     /// - Expects `graph_data`, which represents *what* data to draw, and various details like style and optional legends.
-    pub fn draw_time_graph<B: Backend>(
-        &self, f: &mut Frame<'_, B>, draw_loc: Rect, graph_data: &[GraphData<'_>],
-    ) {
+    pub fn draw_time_graph(&self, f: &mut Frame<'_>, draw_loc: Rect, graph_data: &[GraphData<'_>]) {
         let x_axis = self.generate_x_axis();
         let y_axis = self.generate_y_axis();
 
@@ -182,7 +179,7 @@ mod test {
         layout::Rect,
         style::{Color, Style},
         symbols::Marker,
-        text::{Span, Spans},
+        text::{Line, Span},
     };
 
     use super::TimeGraph;
@@ -253,14 +250,14 @@ mod test {
         let title = time_graph.generate_title(draw_loc);
         assert_eq!(
             title,
-            Spans::from(Span::styled(" Network ", Style::default().fg(Color::Cyan)))
+            Line::from(Span::styled(" Network ", Style::default().fg(Color::Cyan)))
         );
 
         time_graph.is_expanded = true;
         let title = time_graph.generate_title(draw_loc);
         assert_eq!(
             title,
-            Spans::from(vec![
+            Line::from(vec![
                 Span::styled(" Network ", Style::default().fg(Color::Cyan)),
                 Span::styled("───── Esc to go back ", Style::default().fg(Color::Blue))
             ])

--- a/src/components/tui_widget/pipe_gauge.rs
+++ b/src/components/tui_widget/pipe_gauge.rs
@@ -2,7 +2,7 @@ use tui::{
     buffer::Buffer,
     layout::Rect,
     style::Style,
-    text::Spans,
+    text::Line,
     widgets::{Block, Widget},
 };
 
@@ -25,8 +25,8 @@ impl Default for LabelLimit {
 pub struct PipeGauge<'a> {
     block: Option<Block<'a>>,
     ratio: f64,
-    start_label: Option<Spans<'a>>,
-    inner_label: Option<Spans<'a>>,
+    start_label: Option<Line<'a>>,
+    inner_label: Option<Line<'a>>,
     label_style: Style,
     gauge_style: Style,
     hide_parts: LabelLimit,
@@ -60,7 +60,7 @@ impl<'a> PipeGauge<'a> {
     /// The label displayed before the bar.
     pub fn start_label<T>(mut self, start_label: T) -> Self
     where
-        T: Into<Spans<'a>>,
+        T: Into<Line<'a>>,
     {
         self.start_label = Some(start_label.into());
         self
@@ -69,7 +69,7 @@ impl<'a> PipeGauge<'a> {
     /// The label displayed inside the bar.
     pub fn inner_label<T>(mut self, inner_label: T) -> Self
     where
-        T: Into<Spans<'a>>,
+        T: Into<Line<'a>>,
     {
         self.inner_label = Some(inner_label.into());
         self
@@ -125,8 +125,8 @@ impl<'a> Widget for PipeGauge<'a> {
 
             match self.hide_parts {
                 LabelLimit::StartLabel => {
-                    let inner_label = self.inner_label.unwrap_or_else(|| Spans::from(""));
-                    let _ = buf.set_spans(
+                    let inner_label = self.inner_label.unwrap_or_else(|| Line::from(""));
+                    let _ = buf.set_line(
                         gauge_area.left(),
                         gauge_area.top(),
                         &inner_label,
@@ -139,8 +139,8 @@ impl<'a> Widget for PipeGauge<'a> {
                 LabelLimit::Auto(_)
                     if gauge_area.width < (inner_label_width + start_label_width + 1) as u16 =>
                 {
-                    let inner_label = self.inner_label.unwrap_or_else(|| Spans::from(""));
-                    let _ = buf.set_spans(
+                    let inner_label = self.inner_label.unwrap_or_else(|| Line::from(""));
+                    let _ = buf.set_line(
                         gauge_area.left(),
                         gauge_area.top(),
                         &inner_label,
@@ -151,8 +151,8 @@ impl<'a> Widget for PipeGauge<'a> {
                     return;
                 }
                 _ => {
-                    let start_label = self.start_label.unwrap_or_else(|| Spans::from(""));
-                    buf.set_spans(
+                    let start_label = self.start_label.unwrap_or_else(|| Line::from(""));
+                    buf.set_line(
                         gauge_area.left(),
                         gauge_area.top(),
                         &start_label,
@@ -162,10 +162,10 @@ impl<'a> Widget for PipeGauge<'a> {
             }
         };
 
-        let end_label = self.inner_label.unwrap_or_else(|| Spans::from(""));
+        let end_label = self.inner_label.unwrap_or_else(|| Line::from(""));
         match self.hide_parts {
             LabelLimit::Bars => {
-                let _ = buf.set_spans(
+                let _ = buf.set_line(
                     gauge_area
                         .right()
                         .saturating_sub(end_label.width() as u16 + 1),
@@ -177,7 +177,7 @@ impl<'a> Widget for PipeGauge<'a> {
             LabelLimit::Auto(width_limit)
                 if gauge_area.right().saturating_sub(col) < width_limit =>
             {
-                let _ = buf.set_spans(
+                let _ = buf.set_line(
                     gauge_area
                         .right()
                         .saturating_sub(end_label.width() as u16 + 1),
@@ -187,15 +187,15 @@ impl<'a> Widget for PipeGauge<'a> {
                 );
             }
             LabelLimit::Auto(_) | LabelLimit::None => {
-                let (start, _) = buf.set_spans(col, row, &Spans::from("["), gauge_area.width);
+                let (start, _) = buf.set_line(col, row, &Line::from("["), gauge_area.width);
                 if start >= gauge_area.right() {
                     return;
                 }
 
-                let (end, _) = buf.set_spans(
+                let (end, _) = buf.set_line(
                     (gauge_area.x + gauge_area.width).saturating_sub(1),
                     row,
-                    &Spans::from("]"),
+                    &Line::from("]"),
                     gauge_area.width,
                 );
 
@@ -207,6 +207,7 @@ impl<'a> Widget for PipeGauge<'a> {
                         bg: None,
                         add_modifier: self.gauge_style.add_modifier,
                         sub_modifier: self.gauge_style.sub_modifier,
+                        ..Default::default()
                     });
                 }
 
@@ -214,7 +215,7 @@ impl<'a> Widget for PipeGauge<'a> {
                     let gauge_end = gauge_area
                         .right()
                         .saturating_sub(end_label.width() as u16 + 1);
-                    buf.set_spans(gauge_end, row, &end_label, end_label.width() as u16);
+                    buf.set_line(gauge_end, row, &end_label, end_label.width() as u16);
                 }
             }
             LabelLimit::StartLabel => unreachable!(),

--- a/src/components/tui_widget/time_chart.rs
+++ b/src/components/tui_widget/time_chart.rs
@@ -282,10 +282,12 @@ impl<'a> TimeChart<'a> {
             let legend_height = self.datasets.len() as u16 + 2;
             // TODO constraints.apply will be removed in a future ratatui version, replace this
             // code with calls to Layout instead.
+            #[allow(deprecated)]
             let max_legend_width = self
                 .hidden_legend_constraints
                 .0
                 .apply(layout.graph_area.width);
+            #[allow(deprecated)]
             let max_legend_height = self
                 .hidden_legend_constraints
                 .1

--- a/src/components/tui_widget/time_chart.rs
+++ b/src/components/tui_widget/time_chart.rs
@@ -8,7 +8,7 @@ use tui::{
     layout::{Constraint, Rect},
     style::{Color, Style},
     symbols::{self, Marker},
-    text::{Span, Spans},
+    text::{self, Span},
     widgets::{
         canvas::{Line, Points},
         Block, Borders, GraphType, Widget,
@@ -25,7 +25,7 @@ pub type Point = (f64, f64);
 #[derive(Debug, Clone)]
 pub struct Axis<'a> {
     /// Title displayed next to axis end
-    pub title: Option<Spans<'a>>,
+    pub title: Option<text::Line<'a>>,
     /// Bounds for the axis (all data points outside these limits will not be represented)
     pub bounds: [f64; 2],
     /// A list of labels to put to the left or below the axis
@@ -49,7 +49,7 @@ impl<'a> Default for Axis<'a> {
 impl<'a> Axis<'a> {
     pub fn title<T>(mut self, title: T) -> Axis<'a>
     where
-        T: Into<Spans<'a>>,
+        T: Into<text::Line<'a>>,
     {
         self.title = Some(title.into());
         self
@@ -280,6 +280,8 @@ impl<'a> TimeChart<'a> {
         if let Some(inner_width) = self.datasets.iter().map(|d| d.name.width() as u16).max() {
             let legend_width = inner_width + 2;
             let legend_height = self.datasets.len() as u16 + 2;
+            // TODO constraints.apply will be removed in a future ratatui version, replace this
+            // code with calls to Layout instead.
             let max_legend_width = self
                 .hidden_legend_constraints
                 .0
@@ -551,7 +553,7 @@ impl<'a> Widget for TimeChart<'a> {
                 },
                 original_style,
             );
-            buf.set_spans(x, y, &title, width);
+            buf.set_line(x, y, &title, width);
         }
 
         if let Some((x, y)) = layout.title_y {
@@ -566,7 +568,7 @@ impl<'a> Widget for TimeChart<'a> {
                 },
                 original_style,
             );
-            buf.set_spans(x, y, &title, width);
+            buf.set_line(x, y, &title, width);
         }
     }
 }

--- a/src/components/tui_widget/time_chart/canvas.rs
+++ b/src/components/tui_widget/time_chart/canvas.rs
@@ -9,8 +9,7 @@ use tui::{
     buffer::Buffer,
     layout::Rect,
     style::{Color, Style},
-    symbols,
-    text::Spans,
+    symbols, text,
     widgets::{
         canvas::{Line, Points},
         Block, Widget,
@@ -122,7 +121,7 @@ impl Shape for Points<'_> {
 pub struct Label<'a> {
     x: f64,
     y: f64,
-    spans: Spans<'a>,
+    line: text::Line<'a>,
 }
 
 #[derive(Debug, Clone)]
@@ -363,8 +362,13 @@ impl<'a> Context<'a> {
     ) -> Context<'a> {
         let grid: Box<dyn Grid> = match marker {
             symbols::Marker::Dot => Box::new(CharGrid::new(width, height, '•')),
-            symbols::Marker::Block => Box::new(CharGrid::new(width, height, '▄')),
+            symbols::Marker::Block => Box::new(CharGrid::new(width, height, '█')),
             symbols::Marker::Braille => Box::new(BrailleGrid::new(width, height)),
+            symbols::Marker::Bar => Box::new(CharGrid::new(width, height, '▄')),
+            #[allow(clippy::unimplemented)]
+            symbols::Marker::HalfBlock => {
+                unimplemented!("HalfBlock marker not implemented in this vendored version")
+            }
         };
         Context {
             x_bounds,
@@ -542,7 +546,7 @@ where
         {
             let x = ((label.x - left) * resolution.0 / width) as u16 + canvas_area.left();
             let y = ((top - label.y) * resolution.1 / height) as u16 + canvas_area.top();
-            buf.set_spans(x, y, &label.spans, canvas_area.right() - x);
+            buf.set_line(x, y, &label.line, canvas_area.right() - x);
         }
     }
 }

--- a/src/data_conversion.rs
+++ b/src/data_conversion.rs
@@ -634,7 +634,7 @@ pub fn convert_gpu_data(
     let results = current_data
         .gpu_harvest
         .iter()
-        .zip(point_vec.into_iter())
+        .zip(point_vec)
         .map(|(gpu, points)| {
             let short_name = {
                 let last_words = gpu.0.split_whitespace().rev().take(2).collect::<Vec<_>>();

--- a/src/options.rs
+++ b/src/options.rs
@@ -231,7 +231,7 @@ pub fn build_app(
                 if columns.is_empty() {
                     None
                 } else {
-                    Some(IndexSet::from_iter(columns.into_iter()))
+                    Some(IndexSet::from_iter(columns))
                 }
             }
             None => None,

--- a/src/utils/gen_util.rs
+++ b/src/utils/gen_util.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use tui::text::{Span, Spans, Text};
+use tui::text::{Span, Text};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
@@ -98,9 +98,7 @@ pub fn get_decimal_prefix(quantity: u64, unit: &str) -> (f64, String) {
 
 /// Truncates text if it is too long, and adds an ellipsis at the end if needed.
 pub fn truncate_to_text<'a, U: Into<usize>>(content: &str, width: U) -> Text<'a> {
-    Text {
-        lines: vec![Spans(vec![Span::raw(truncate_str(content, width))])],
-    }
+    Span::raw(truncate_str(content, width)).into()
 }
 
 /// Returns the width of a str `s`. This takes into account some things like

--- a/src/widgets/process_table.rs
+++ b/src/widgets/process_table.rs
@@ -1063,10 +1063,7 @@ mod test {
         data.sort_by_key(|p| p.pid);
         sort_skip_pid_asc(&ProcColumn::CpuPercent, &mut data, SortOrder::Descending);
         assert_eq!(
-            vec![&c, &b, &a, &d]
-                .iter()
-                .map(|d| (d.pid))
-                .collect::<Vec<_>>(),
+            [&c, &b, &a, &d].iter().map(|d| (d.pid)).collect::<Vec<_>>(),
             data.iter().map(|d| (d.pid)).collect::<Vec<_>>(),
         );
 
@@ -1074,20 +1071,14 @@ mod test {
         data.sort_by_key(|p| p.pid);
         sort_skip_pid_asc(&ProcColumn::CpuPercent, &mut data, SortOrder::Ascending);
         assert_eq!(
-            vec![&a, &d, &b, &c]
-                .iter()
-                .map(|d| (d.pid))
-                .collect::<Vec<_>>(),
+            [&a, &d, &b, &c].iter().map(|d| (d.pid)).collect::<Vec<_>>(),
             data.iter().map(|d| (d.pid)).collect::<Vec<_>>(),
         );
 
         data.sort_by_key(|p| p.pid);
         sort_skip_pid_asc(&ProcColumn::MemoryPercent, &mut data, SortOrder::Descending);
         assert_eq!(
-            vec![&b, &a, &c, &d]
-                .iter()
-                .map(|d| (d.pid))
-                .collect::<Vec<_>>(),
+            [&b, &a, &c, &d].iter().map(|d| (d.pid)).collect::<Vec<_>>(),
             data.iter().map(|d| (d.pid)).collect::<Vec<_>>(),
         );
 
@@ -1095,10 +1086,7 @@ mod test {
         data.sort_by_key(|p| p.pid);
         sort_skip_pid_asc(&ProcColumn::MemoryPercent, &mut data, SortOrder::Ascending);
         assert_eq!(
-            vec![&c, &d, &a, &b]
-                .iter()
-                .map(|d| (d.pid))
-                .collect::<Vec<_>>(),
+            [&c, &d, &a, &b].iter().map(|d| (d.pid)).collect::<Vec<_>>(),
             data.iter().map(|d| (d.pid)).collect::<Vec<_>>(),
         );
     }


### PR DESCRIPTION
- chore(deps): upgrade ratatui to 0.26 and crossterm to 0.27
  - Three major breaking changes:
  - `Spans` was renamed to `Line` several versions ago
  - `Frame` no longer requires a `Backend` type parameter
  - `Table::new()` now requires a widths parameter
- fix: clippy lints

## Description

updates ratatui

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [x] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
