### PR TITLE
deps: bump ratatui to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +320,19 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "concat-string"
@@ -990,12 +1012,13 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5659e52e4ba6e07b2dad9f1158f578ef84a73762625ddb51536019f34d180eb"
+checksum = "154b85ef15a5d1719bcaa193c3c81fe645cd120c156874cd660fe49fd21d1373"
 dependencies = [
  "bitflags 2.4.1",
  "cassowary",
+ "compact_str",
  "crossterm",
  "indoc",
  "itertools 0.12.0",
@@ -1309,18 +1332,18 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ sysinfo = "=0.30.5"
 thiserror = "1.0.56"
 time = { version = "0.3.30", features = ["formatting", "macros"] }
 toml_edit = { version = "0.21.0", features = ["serde"] }
-tui = { version = "0.25.0", package = "ratatui" }
+tui = { version = "0.26.0", package = "ratatui" }
 unicode-segmentation = "1.10.1"
 unicode-width = "0.1.11"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2586,7 +2586,7 @@ impl App {
                                         .get_widget_state(self.current_widget.widget_id)
                                     {
                                         if let Some(visual_index) =
-                                            proc_widget_state.table.tui_selected()
+                                            proc_widget_state.table.ratatui_selected()
                                         {
                                             let is_tree_mode = matches!(
                                                 proc_widget_state.mode,
@@ -2614,7 +2614,7 @@ impl App {
                                         .get_widget_state(self.current_widget.widget_id - 2)
                                     {
                                         if let Some(visual_index) =
-                                            proc_widget_state.sort_table.tui_selected()
+                                            proc_widget_state.sort_table.ratatui_selected()
                                         {
                                             self.change_process_sort_position(
                                                 offset_clicked_entry as i64 - visual_index as i64,
@@ -2629,7 +2629,7 @@ impl App {
                                         .get_widget_state(self.current_widget.widget_id - 1)
                                     {
                                         if let Some(visual_index) =
-                                            cpu_widget_state.table.tui_selected()
+                                            cpu_widget_state.table.ratatui_selected()
                                         {
                                             self.change_cpu_legend_position(
                                                 offset_clicked_entry as i64 - visual_index as i64,
@@ -2644,7 +2644,7 @@ impl App {
                                         .get_widget_state(self.current_widget.widget_id)
                                     {
                                         if let Some(visual_index) =
-                                            temp_widget_state.table.tui_selected()
+                                            temp_widget_state.table.ratatui_selected()
                                         {
                                             self.change_temp_position(
                                                 offset_clicked_entry as i64 - visual_index as i64,
@@ -2659,7 +2659,7 @@ impl App {
                                         .get_widget_state(self.current_widget.widget_id)
                                     {
                                         if let Some(visual_index) =
-                                            disk_widget_state.table.tui_selected()
+                                            disk_widget_state.table.ratatui_selected()
                                         {
                                             self.change_disk_position(
                                                 offset_clicked_entry as i64 - visual_index as i64,

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -72,7 +72,8 @@ pub struct Painter {
 
 /// The constraints of a widget relative to its parent.
 ///
-/// This is used over ratatui's internal representation due to https://github.com/ClementTsang/bottom/issues/896.
+/// This is used over ratatui's internal representation due to
+/// <https://github.com/ClementTsang/bottom/issues/896>.
 pub enum LayoutConstraint {
     CanvasHandled,
     Grow,

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -499,6 +499,8 @@ impl Painter {
                 }
 
                 if self.derived_widget_draw_locs.is_empty() || app_state.is_force_redraw {
+                    // TODO: Can I remove this? Does ratatui's layout constraints work properly for fixing
+                    // https://github.com/ClementTsang/bottom/issues/896 now?
                     fn get_constraints(
                         direction: Direction, constraints: &[LayoutConstraint], area: Rect,
                     ) -> Vec<Rect> {

--- a/src/canvas/components/data_table.rs
+++ b/src/canvas/components/data_table.rs
@@ -152,6 +152,8 @@ impl<DataType: DataToCell<H>, H: ColumnHeader, S: SortType, C: DataTableColumn<H
 
 #[cfg(test)]
 mod test {
+    use std::num::NonZeroU16;
+
     use super::*;
 
     #[derive(Clone, PartialEq, Eq, Debug)]
@@ -161,7 +163,7 @@ mod test {
 
     impl DataToCell<&'static str> for TestType {
         fn to_cell(
-            &self, _column: &&'static str, _calculated_width: u16,
+            &self, _column: &&'static str, _calculated_width: NonZeroU16,
         ) -> Option<tui::text::Text<'_>> {
             None
         }

--- a/src/canvas/components/data_table.rs
+++ b/src/canvas/components/data_table.rs
@@ -144,8 +144,8 @@ impl<DataType: DataToCell<H>, H: ColumnHeader, S: SortType, C: DataTableColumn<H
         self.data.get(self.state.current_index)
     }
 
-    /// Returns tui-rs' internal selection.
-    pub fn tui_selected(&self) -> Option<usize> {
+    /// Returns ratatui's internal selection.
+    pub fn ratatui_selected(&self) -> Option<usize> {
         self.state.table_state.selected()
     }
 }

--- a/src/canvas/components/data_table/data_type.rs
+++ b/src/canvas/components/data_table/data_type.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU16;
+
 use tui::{text::Text, widgets::Row};
 
 use super::{ColumnHeader, DataTableColumn};
@@ -8,7 +10,7 @@ where
     H: ColumnHeader,
 {
     /// Given data, a column, and its corresponding width, return what should be displayed in the [`DataTable`](super::DataTable).
-    fn to_cell(&self, column: &H, calculated_width: u16) -> Option<Text<'_>>;
+    fn to_cell(&self, column: &H, calculated_width: NonZeroU16) -> Option<Text<'_>>;
 
     /// Apply styling to the generated [`Row`] of cells.
     ///

--- a/src/canvas/components/data_table/draw.rs
+++ b/src/canvas/components/data_table/draw.rs
@@ -249,18 +249,7 @@ where
                     };
                     let mut table = Table::new(
                         rows,
-                        &(self
-                            .state
-                            .calculated_widths
-                            .iter()
-                            .filter_map(|&width| {
-                                if width == 0 {
-                                    None
-                                } else {
-                                    Some(Constraint::Length(width))
-                                }
-                            })
-                            .collect::<Vec<_>>()),
+                        self.state.calculated_widths.iter().map(|nzu| nzu.get()),
                     )
                     .block(block)
                     .highlight_style(highlight_style)

--- a/src/canvas/components/data_table/sortable.rs
+++ b/src/canvas/components/data_table/sortable.rs
@@ -97,6 +97,8 @@ impl SortType for Sortable {
                             SortOrder::Ascending => UP_ARROW,
                             SortOrder::Descending => DOWN_ARROW,
                         };
+                        // TODO: I think I can get away with removing the truncate_to_text call since
+                        // I almost always bind to at least the header size...
                         truncate_to_text(&concat_string!(c.header(), arrow), width.get())
                     } else {
                         truncate_to_text(&c.header(), width.get())

--- a/src/canvas/components/data_table/state.rs
+++ b/src/canvas/components/data_table/state.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU16;
+
 use tui::{layout::Rect, widgets::TableState};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
@@ -25,7 +27,7 @@ pub struct DataTableState {
     pub table_state: TableState,
 
     /// The calculated widths.
-    pub calculated_widths: Vec<u16>,
+    pub calculated_widths: Vec<NonZeroU16>,
 
     /// The current inner [`Rect`].
     pub inner_rect: Rect,

--- a/src/canvas/components/data_table/state.rs
+++ b/src/canvas/components/data_table/state.rs
@@ -21,7 +21,7 @@ pub struct DataTableState {
     /// The direction of the last attempted scroll.
     pub scroll_direction: ScrollDirection,
 
-    /// tui-rs' internal table state.
+    /// ratatui's internal table state.
     pub table_state: TableState,
 
     /// The calculated widths.

--- a/src/canvas/components/time_graph.rs
+++ b/src/canvas/components/time_graph.rs
@@ -51,8 +51,8 @@ pub struct TimeGraph<'a> {
     /// Any legend constraints.
     pub legend_constraints: Option<(Constraint, Constraint)>,
 
-    /// The marker type. Unlike tui-rs' native charts, we assume
-    /// only a single type of market.
+    /// The marker type. Unlike ratatui's native charts, we assume
+    /// only a single type of marker.
     pub marker: Marker,
 }
 

--- a/src/canvas/components/tui_widget/time_chart.rs
+++ b/src/canvas/components/tui_widget/time_chart.rs
@@ -1,52 +1,54 @@
-mod canvas;
+//! A [`tui::widgets::Chart`] but slightly more specialized to show right-aligned timeseries
+//! data.
+//!
+//! Generally should be updated to be in sync with [`chart.rs`](https://github.com/ratatui-org/ratatui/blob/main/src/widgets/chart.rs);
+//! the specializations are factored out to `time_chart/points.rs`.
 
-use std::{borrow::Cow, cmp::max};
+mod canvas;
+mod points;
+
+use std::cmp::max;
 
 use canvas::*;
 use tui::{
     buffer::Buffer,
-    layout::{Constraint, Rect},
-    style::{Color, Style},
+    layout::{Alignment, Constraint, Flex, Layout, Rect},
+    style::{Color, Style, Styled},
     symbols::{self, Marker},
     text::{Line, Span},
-    widgets::{
-        canvas::{Line as CanvasLine, Points},
-        Block, Borders, GraphType, Widget,
-    },
+    widgets::{block::BlockExt, Block, Borders, GraphType, Widget},
 };
 use unicode_width::UnicodeWidthStr;
 
-use crate::utils::general::partial_ordering;
+pub const DEFAULT_LEGEND_CONSTRAINTS: (Constraint, Constraint) =
+    (Constraint::Ratio(1, 4), Constraint::Length(4));
 
 /// A single graph point.
 pub type Point = (f64, f64);
 
-/// An X or Y axis for the chart widget
-#[derive(Debug, Clone)]
+/// An X or Y axis for the [`TimeChart`] widget
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Axis<'a> {
     /// Title displayed next to axis end
-    pub title: Option<Line<'a>>,
+    pub(crate) title: Option<Line<'a>>,
     /// Bounds for the axis (all data points outside these limits will not be represented)
-    pub bounds: [f64; 2],
+    pub(crate) bounds: [f64; 2],
     /// A list of labels to put to the left or below the axis
-    pub labels: Option<Vec<Span<'a>>>,
-    /// The style used to draw the axis itself - NOT The labels.
-    pub style: Style,
+    pub(crate) labels: Option<Vec<Span<'a>>>,
+    /// The style used to draw the axis itself
+    pub(crate) style: Style,
+    /// The alignment of the labels of the Axis
+    pub(crate) labels_alignment: Alignment,
 }
 
-impl<'a> Default for Axis<'a> {
-    fn default() -> Axis<'a> {
-        Axis {
-            title: None,
-            bounds: [0.0, 0.0],
-            labels: None,
-            style: Default::default(),
-        }
-    }
-}
-
-#[allow(dead_code)]
 impl<'a> Axis<'a> {
+    /// Sets the axis title
+    ///
+    /// It will be displayed at the end of the axis. For an X axis this is the right, for a Y axis,
+    /// this is the top.
+    ///
+    /// This is a fluent setter method which must be chained or used as it consumes self
+    #[must_use = "method moves the value of self and returns the modified value"]
     pub fn title<T>(mut self, title: T) -> Axis<'a>
     where
         T: Into<Line<'a>>,
@@ -55,75 +57,253 @@ impl<'a> Axis<'a> {
         self
     }
 
+    /// Sets the bounds of this axis
+    ///
+    /// In other words, sets the min and max value on this axis.
+    ///
+    /// This is a fluent setter method which must be chained or used as it consumes self
+    #[must_use = "method moves the value of self and returns the modified value"]
     pub fn bounds(mut self, bounds: [f64; 2]) -> Axis<'a> {
         self.bounds = bounds;
         self
     }
 
+    /// Sets the axis labels
+    ///
+    /// - For the X axis, the labels are displayed left to right.
+    /// - For the Y axis, the labels are displayed bottom to top.
+    #[must_use = "method moves the value of self and returns the modified value"]
     pub fn labels(mut self, labels: Vec<Span<'a>>) -> Axis<'a> {
         self.labels = Some(labels);
         self
     }
 
-    pub fn style(mut self, style: Style) -> Axis<'a> {
-        self.style = style;
+    /// Sets the axis style.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn style<S: Into<Style>>(mut self, style: S) -> Axis<'a> {
+        self.style = style.into();
+        self
+    }
+
+    /// Sets the labels alignment of the axis
+    ///
+    /// The alignment behaves differently based on the axis:
+    /// - Y axis: The labels are aligned within the area on the left of the axis
+    /// - X axis: The first X-axis label is aligned relative to the Y-axis
+    ///
+    /// On the X axis, this parameter only affects the first label.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn labels_alignment(mut self, alignment: Alignment) -> Axis<'a> {
+        self.labels_alignment = alignment;
         self
     }
 }
 
+/// Allow users to specify the position of a legend in a [`TimeChart`]
+///
+/// See [`TimeChart::legend_position`]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+pub enum LegendPosition {
+    /// Legend is centered on top
+    Top,
+    /// Legend is in the top-right corner. This is the **default**.
+    #[default]
+    TopRight,
+    /// Legend is in the top-left corner
+    TopLeft,
+    /// Legend is centered on the left
+    Left,
+    /// Legend is centered on the right
+    Right,
+    /// Legend is centered on the bottom
+    Bottom,
+    /// Legend is in the bottom-right corner
+    BottomRight,
+    /// Legend is in the bottom-left corner
+    BottomLeft,
+}
+
+impl LegendPosition {
+    fn layout(
+        &self, area: Rect, legend_width: u16, legend_height: u16, x_title_width: u16,
+        y_title_width: u16,
+    ) -> Option<Rect> {
+        let mut height_margin = (area.height - legend_height) as i32;
+        if x_title_width != 0 {
+            height_margin -= 1;
+        }
+        if y_title_width != 0 {
+            height_margin -= 1;
+        }
+        if height_margin < 0 {
+            return None;
+        };
+
+        let (x, y) = match self {
+            Self::TopRight => {
+                if legend_width + y_title_width > area.width {
+                    (area.right() - legend_width, area.top() + 1)
+                } else {
+                    (area.right() - legend_width, area.top())
+                }
+            }
+            Self::TopLeft => {
+                if y_title_width != 0 {
+                    (area.left(), area.top() + 1)
+                } else {
+                    (area.left(), area.top())
+                }
+            }
+            Self::Top => {
+                let x = (area.width - legend_width) / 2;
+                if area.left() + y_title_width > x {
+                    (area.left() + x, area.top() + 1)
+                } else {
+                    (area.left() + x, area.top())
+                }
+            }
+            Self::Left => {
+                let mut y = (area.height - legend_height) / 2;
+                if y_title_width != 0 {
+                    y += 1;
+                }
+                if x_title_width != 0 {
+                    y = y.saturating_sub(1);
+                }
+                (area.left(), area.top() + y)
+            }
+            Self::Right => {
+                let mut y = (area.height - legend_height) / 2;
+                if y_title_width != 0 {
+                    y += 1;
+                }
+                if x_title_width != 0 {
+                    y = y.saturating_sub(1);
+                }
+                (area.right() - legend_width, area.top() + y)
+            }
+            Self::BottomLeft => {
+                if x_title_width + legend_width > area.width {
+                    (area.left(), area.bottom() - legend_height - 1)
+                } else {
+                    (area.left(), area.bottom() - legend_height)
+                }
+            }
+            Self::BottomRight => {
+                if x_title_width != 0 {
+                    (
+                        area.right() - legend_width,
+                        area.bottom() - legend_height - 1,
+                    )
+                } else {
+                    (area.right() - legend_width, area.bottom() - legend_height)
+                }
+            }
+            Self::Bottom => {
+                let x = area.left() + (area.width - legend_width) / 2;
+                if x + legend_width > area.right() - x_title_width {
+                    (x, area.bottom() - legend_height - 1)
+                } else {
+                    (x, area.bottom() - legend_height)
+                }
+            }
+        };
+
+        Some(Rect::new(x, y, legend_width, legend_height))
+    }
+}
+
 /// A group of data points
-#[derive(Debug, Clone)]
+///
+/// This is the main element composing a [`TimeChart`].
+///
+/// A dataset can be [named](Dataset::name). Only named datasets will be rendered in the legend.
+///
+/// After that, you can pass it data with [`Dataset::data`]. Data is an array of `f64` tuples
+/// (`(f64, f64)`), the first element being X and the second Y. It's also worth noting that, unlike
+/// the [`Rect`], here the Y axis is bottom to top, as in math.
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Dataset<'a> {
     /// Name of the dataset (used in the legend if shown)
-    name: Cow<'a, str>,
+    name: Option<Line<'a>>,
     /// A reference to the actual data
-    data: &'a [Point],
+    data: &'a [(f64, f64)],
+    /// Symbol used for each points of this dataset
+    marker: symbols::Marker,
     /// Determines graph type used for drawing points
     graph_type: GraphType,
     /// Style used to plot this dataset
     style: Style,
 }
 
-impl<'a> Default for Dataset<'a> {
-    fn default() -> Dataset<'a> {
-        Dataset {
-            name: Cow::from(""),
-            data: &[],
-            graph_type: GraphType::Scatter,
-            style: Style::default(),
-        }
-    }
-}
-
-#[allow(dead_code)]
 impl<'a> Dataset<'a> {
+    /// Sets the name of the dataset.
+    #[must_use = "method moves the value of self and returns the modified value"]
     pub fn name<S>(mut self, name: S) -> Dataset<'a>
     where
-        S: Into<Cow<'a, str>>,
+        S: Into<Line<'a>>,
     {
-        self.name = name.into();
+        self.name = Some(name.into());
         self
     }
 
-    pub fn data(mut self, data: &'a [Point]) -> Dataset<'a> {
+    /// Sets the data points of this dataset
+    ///
+    /// Points will then either be rendered as scrattered points or with lines between them
+    /// depending on [`Dataset::graph_type`].
+    ///
+    /// Data consist in an array of `f64` tuples (`(f64, f64)`), the first element being X and the
+    /// second Y. It's also worth noting that, unlike the [`Rect`], here the Y axis is bottom to
+    /// top, as in math.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn data(mut self, data: &'a [(f64, f64)]) -> Dataset<'a> {
         self.data = data;
         self
     }
 
+    /// Sets the kind of character to use to display this dataset
+    ///
+    /// You can use dots (`•`), blocks (`█`), bars (`▄`), braille (`⠓`, `⣇`, `⣿`) or half-blocks
+    /// (`█`, `▄`, and `▀`). See [symbols::Marker] for more details.
+    ///
+    /// Note [`Marker::Braille`](symbols::Marker::Braille) requires a font that supports Unicode
+    /// Braille Patterns.
+    ///
+    /// This is a fluent setter method which must be chained or used as it consumes self
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn marker(mut self, marker: symbols::Marker) -> Dataset<'a> {
+        self.marker = marker;
+        self
+    }
+
+    /// Sets how the dataset should be drawn
+    ///
+    /// [`TimeChart`] can draw either a [scatter](GraphType::Scatter) or [line](GraphType::Line) charts.
+    /// A scatter will draw only the points in the dataset while a line will also draw a line
+    /// between them. See [`GraphType`] for more details
+    #[must_use = "method moves the value of self and returns the modified value"]
     pub fn graph_type(mut self, graph_type: GraphType) -> Dataset<'a> {
         self.graph_type = graph_type;
         self
     }
 
-    pub fn style(mut self, style: Style) -> Dataset<'a> {
-        self.style = style;
+    /// Sets the style of this dataset
+    ///
+    /// The given style will be used to draw the legend and the data points. Currently the legend
+    /// will use the entire style whereas the data points will only use the foreground.
+    ///
+    /// `style` accepts any type that is convertible to [`Style`] (e.g. [`Style`], [`Color`], or
+    /// your own type that implements [`Into<Style>`]).
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn style<S: Into<Style>>(mut self, style: S) -> Dataset<'a> {
+        self.style = style.into();
         self
     }
 }
 
 /// A container that holds all the infos about where to display each elements of the chart (axis,
 /// labels, legend, ...).
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 struct ChartLayout {
     /// Location of the title of the x axis
     title_x: Option<(u16, u16)>,
@@ -143,7 +323,7 @@ struct ChartLayout {
     graph_area: Rect,
 }
 
-/// A "custom" chart, just a slightly tweaked [`tui::widgets::Chart`] from tui-rs, but with greater control over the
+/// A "custom" chart, just a slightly tweaked [`tui::widgets::Chart`] from ratatui, but with greater control over the
 /// legend, and built with the idea of drawing data points relative to a time-based x-axis.
 ///
 /// Main changes:
@@ -152,7 +332,7 @@ struct ChartLayout {
 /// - Automatic interpolation to points that fall *just* outside of the screen.
 ///
 /// TODO: Support for putting the legend on the left side.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct TimeChart<'a> {
     /// A block to display around the widget eventually
     block: Option<Block<'a>>,
@@ -164,70 +344,116 @@ pub struct TimeChart<'a> {
     datasets: Vec<Dataset<'a>>,
     /// The widget base style
     style: Style,
-    /// The legend's style
+    /// The legend's style.
     legend_style: Style,
     /// Constraints used to determine whether the legend should be shown or not
     hidden_legend_constraints: (Constraint, Constraint),
+    /// The position detnermine where the legenth is shown or hide regaurdless of
+    /// `hidden_legend_constraints`
+    legend_position: Option<LegendPosition>,
     /// The marker type.
     marker: Marker,
 }
 
-pub const DEFAULT_LEGEND_CONSTRAINTS: (Constraint, Constraint) =
-    (Constraint::Ratio(1, 4), Constraint::Length(4));
-
-#[allow(dead_code)]
 impl<'a> TimeChart<'a> {
-    /// Creates a new [`TimeChart`].
+    /// Creates a chart with the given [datasets](Dataset)
     ///
-    /// **Note:** `datasets` **must** be sorted!
+    /// A chart can render multiple datasets.
     pub fn new(datasets: Vec<Dataset<'a>>) -> TimeChart<'a> {
         TimeChart {
             block: None,
             x_axis: Axis::default(),
             y_axis: Axis::default(),
-            style: Default::default(),
-            legend_style: Default::default(),
+            style: Style::default(),
+            legend_style: Style::default(),
             datasets,
-            hidden_legend_constraints: DEFAULT_LEGEND_CONSTRAINTS,
+            hidden_legend_constraints: (Constraint::Ratio(1, 4), Constraint::Ratio(1, 4)),
+            legend_position: Some(LegendPosition::default()),
             marker: Marker::Braille,
         }
     }
 
+    /// Wraps the chart with the given [`Block`]
+    #[must_use = "method moves the value of self and returns the modified value"]
     pub fn block(mut self, block: Block<'a>) -> TimeChart<'a> {
         self.block = Some(block);
         self
     }
 
-    pub fn style(mut self, style: Style) -> TimeChart<'a> {
-        self.style = style;
+    /// Sets the style of the entire chart
+    ///
+    /// `style` accepts any type that is convertible to [`Style`] (e.g. [`Style`], [`Color`], or
+    /// your own type that implements [`Into<Style>`]).
+    ///
+    /// Styles of [`Axis`] and [`Dataset`] will have priority over this style.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn style<S: Into<Style>>(mut self, style: S) -> TimeChart<'a> {
+        self.style = style.into();
         self
     }
 
+    /// Sets the legend's style.
+    #[must_use = "method moves the value of self and returns the modified value"]
     pub fn legend_style(mut self, legend_style: Style) -> TimeChart<'a> {
         self.legend_style = legend_style;
         self
     }
 
+    /// Sets the X [`Axis`]
+    ///
+    /// The default is an empty [`Axis`], i.e. only a line.
+    #[must_use = "method moves the value of self and returns the modified value"]
     pub fn x_axis(mut self, axis: Axis<'a>) -> TimeChart<'a> {
         self.x_axis = axis;
         self
     }
 
+    /// Sets the Y [`Axis`]
+    ///
+    /// The default is an empty [`Axis`], i.e. only a line.
+    #[must_use = "method moves the value of self and returns the modified value"]
     pub fn y_axis(mut self, axis: Axis<'a>) -> TimeChart<'a> {
         self.y_axis = axis;
         self
     }
 
+    /// Sets the marker type.
+    #[must_use = "method moves the value of self and returns the modified value"]
     pub fn marker(mut self, marker: Marker) -> TimeChart<'a> {
         self.marker = marker;
         self
     }
 
-    /// Set the constraints used to determine whether the legend should be shown or not.
+    /// Sets the constraints used to determine whether the legend should be shown or not.
+    ///
+    /// The tuple's first constraint is used for the width and the second for the height. If the
+    /// legend takes more space than what is allowed by any constraint, the legend is hidden.
+    /// [`Constraint::Min`] is an exception and will always show the legend.
+    ///
+    /// If this is not set, the default behavior is to hide the legend if it is greater than 25% of
+    /// the chart, either horizontally or vertically.
+    #[must_use = "method moves the value of self and returns the modified value"]
     pub fn hidden_legend_constraints(
         mut self, constraints: (Constraint, Constraint),
     ) -> TimeChart<'a> {
         self.hidden_legend_constraints = constraints;
+        self
+    }
+
+    /// Sets the position of a legend or hide it
+    ///
+    /// The default is [`LegendPosition::TopRight`].
+    ///
+    /// If [`None`] is given, hide the legend even if [`hidden_legend_constraints`] determines it
+    /// should be shown. In contrast, if `Some(...)` is given, [`hidden_legend_constraints`] might
+    /// still decide whether to show the legend or not.
+    ///
+    /// See [`LegendPosition`] for all available positions.
+    ///
+    /// [`hidden_legend_constraints`]: Self::hidden_legend_constraints
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn legend_position(mut self, position: Option<LegendPosition>) -> TimeChart<'a> {
+        self.legend_position = position;
         self
     }
 
@@ -247,7 +473,7 @@ impl<'a> TimeChart<'a> {
         }
 
         layout.label_y = self.y_axis.labels.as_ref().and(Some(x));
-        x += self.max_width_of_labels_left_of_y_axis(area);
+        x += self.max_width_of_labels_left_of_y_axis(area, self.y_axis.labels.is_some());
 
         if self.x_axis.labels.is_some() && y > area.top() {
             layout.axis_x = Some(y);
@@ -277,120 +503,190 @@ impl<'a> TimeChart<'a> {
             }
         }
 
-        if let Some(inner_width) = self.datasets.iter().map(|d| d.name.width() as u16).max() {
-            let legend_width = inner_width + 2;
-            let legend_height = self.datasets.len() as u16 + 2;
-            let max_legend_width = self
-                .hidden_legend_constraints
-                .0
-                .apply(layout.graph_area.width);
-            let max_legend_height = self
-                .hidden_legend_constraints
-                .1
-                .apply(layout.graph_area.height);
-            if inner_width > 0
-                && legend_width < max_legend_width
-                && legend_height < max_legend_height
-            {
-                layout.legend_area = Some(Rect::new(
-                    layout.graph_area.right() - legend_width,
-                    layout.graph_area.top(),
-                    legend_width,
-                    legend_height,
-                ));
+        if let Some(legend_position) = self.legend_position {
+            let legends = self
+                .datasets
+                .iter()
+                .filter_map(|d| Some(d.name.as_ref()?.width() as u16));
+
+            if let Some(inner_width) = legends.clone().max() {
+                let legend_width = inner_width + 2;
+                let legend_height = legends.count() as u16 + 2;
+
+                let [max_legend_width] = Layout::horizontal([self.hidden_legend_constraints.0])
+                    .flex(Flex::Start)
+                    .areas(layout.graph_area);
+
+                let [max_legend_height] = Layout::vertical([self.hidden_legend_constraints.1])
+                    .flex(Flex::Start)
+                    .areas(layout.graph_area);
+
+                if inner_width > 0
+                    && legend_width <= max_legend_width.width
+                    && legend_height <= max_legend_height.height
+                {
+                    layout.legend_area = legend_position.layout(
+                        layout.graph_area,
+                        legend_width,
+                        legend_height,
+                        layout
+                            .title_x
+                            .and(self.x_axis.title.as_ref())
+                            .map(|t| t.width() as u16)
+                            .unwrap_or_default(),
+                        layout
+                            .title_y
+                            .and(self.y_axis.title.as_ref())
+                            .map(|t| t.width() as u16)
+                            .unwrap_or_default(),
+                    );
+                }
             }
         }
         layout
     }
 
-    fn max_width_of_labels_left_of_y_axis(&self, area: Rect) -> u16 {
+    fn max_width_of_labels_left_of_y_axis(&self, area: Rect, has_y_axis: bool) -> u16 {
         let mut max_width = self
             .y_axis
             .labels
             .as_ref()
             .map(|l| l.iter().map(Span::width).max().unwrap_or_default() as u16)
             .unwrap_or_default();
-        if let Some(ref x_labels) = self.x_axis.labels {
-            if !x_labels.is_empty() {
-                max_width = max(max_width, x_labels[0].content.width() as u16);
-            }
+
+        if let Some(first_x_label) = self
+            .x_axis
+            .labels
+            .as_ref()
+            .and_then(|labels| labels.first())
+        {
+            let first_label_width = first_x_label.content.width() as u16;
+            let width_left_of_y_axis = match self.x_axis.labels_alignment {
+                Alignment::Left => {
+                    // The last character of the label should be below the Y-Axis when it exists,
+                    // not on its left
+                    let y_axis_offset = u16::from(has_y_axis);
+                    first_label_width.saturating_sub(y_axis_offset)
+                }
+                Alignment::Center => first_label_width / 2,
+                Alignment::Right => 0,
+            };
+            max_width = max(max_width, width_left_of_y_axis);
         }
         // labels of y axis and first label of x axis can take at most 1/3rd of the total width
         max_width.min(area.width / 3)
     }
 
     fn render_x_labels(
-        &mut self, buf: &mut Buffer, layout: &ChartLayout, chart_area: Rect, graph_area: Rect,
+        &self, buf: &mut Buffer, layout: &ChartLayout, chart_area: Rect, graph_area: Rect,
     ) {
-        let y = match layout.label_x {
-            Some(y) => y,
-            None => return,
-        };
+        let Some(y) = layout.label_x else { return };
         let labels = self.x_axis.labels.as_ref().unwrap();
         let labels_len = labels.len() as u16;
         if labels_len < 2 {
             return;
         }
-        let width_between_ticks = graph_area.width / (labels_len - 1);
-        for (i, label) in labels.iter().enumerate() {
-            let label_width = label.width() as u16;
-            let label_width = if i == 0 {
-                // the first label is put between the left border of the chart and the y axis.
-                graph_area
-                    .left()
-                    .saturating_sub(chart_area.left())
-                    .min(label_width)
-            } else {
-                // other labels are put on the left of each tick on the x axis
-                width_between_ticks.min(label_width)
-            };
-            buf.set_span(
-                graph_area.left() + i as u16 * width_between_ticks - label_width,
-                y,
-                label,
-                label_width,
-            );
+
+        let width_between_ticks = graph_area.width / labels_len;
+
+        let label_area = self.first_x_label_area(
+            y,
+            labels.first().unwrap().width() as u16,
+            width_between_ticks,
+            chart_area,
+            graph_area,
+        );
+
+        let label_alignment = match self.x_axis.labels_alignment {
+            Alignment::Left => Alignment::Right,
+            Alignment::Center => Alignment::Center,
+            Alignment::Right => Alignment::Left,
+        };
+
+        Self::render_label(buf, labels.first().unwrap(), label_area, label_alignment);
+
+        for (i, label) in labels[1..labels.len() - 1].iter().enumerate() {
+            // We add 1 to x (and width-1 below) to leave at least one space before each
+            // intermediate labels
+            let x = graph_area.left() + (i + 1) as u16 * width_between_ticks + 1;
+            let label_area = Rect::new(x, y, width_between_ticks.saturating_sub(1), 1);
+
+            Self::render_label(buf, label, label_area, Alignment::Center);
         }
+
+        let x = graph_area.right() - width_between_ticks;
+        let label_area = Rect::new(x, y, width_between_ticks, 1);
+        // The last label should be aligned Right to be at the edge of the graph area
+        Self::render_label(buf, labels.last().unwrap(), label_area, Alignment::Right);
+    }
+
+    fn first_x_label_area(
+        &self, y: u16, label_width: u16, max_width_after_y_axis: u16, chart_area: Rect,
+        graph_area: Rect,
+    ) -> Rect {
+        let (min_x, max_x) = match self.x_axis.labels_alignment {
+            Alignment::Left => (chart_area.left(), graph_area.left()),
+            Alignment::Center => (
+                chart_area.left(),
+                graph_area.left() + max_width_after_y_axis.min(label_width),
+            ),
+            Alignment::Right => (
+                graph_area.left().saturating_sub(1),
+                graph_area.left() + max_width_after_y_axis,
+            ),
+        };
+
+        Rect::new(min_x, y, max_x - min_x, 1)
+    }
+
+    fn render_label(buf: &mut Buffer, label: &Span<'_>, label_area: Rect, alignment: Alignment) {
+        let label_width = label.width() as u16;
+        let bounded_label_width = label_area.width.min(label_width);
+
+        let x = match alignment {
+            Alignment::Left => label_area.left(),
+            Alignment::Center => label_area.left() + label_area.width / 2 - bounded_label_width / 2,
+            Alignment::Right => label_area.right() - bounded_label_width,
+        };
+
+        buf.set_span(x, label_area.top(), label, bounded_label_width);
     }
 
     fn render_y_labels(
-        &mut self, buf: &mut Buffer, layout: &ChartLayout, chart_area: Rect, graph_area: Rect,
+        &self, buf: &mut Buffer, layout: &ChartLayout, chart_area: Rect, graph_area: Rect,
     ) {
-        let x = match layout.label_y {
-            Some(x) => x,
-            None => return,
-        };
+        let Some(x) = layout.label_y else { return };
         let labels = self.y_axis.labels.as_ref().unwrap();
         let labels_len = labels.len() as u16;
-        let label_width = graph_area.left().saturating_sub(chart_area.left());
         for (i, label) in labels.iter().enumerate() {
             let dy = i as u16 * (graph_area.height - 1) / (labels_len - 1);
             if dy < graph_area.bottom() {
-                buf.set_span(x, graph_area.bottom() - 1 - dy, label, label_width);
+                let label_area = Rect::new(
+                    x,
+                    graph_area.bottom().saturating_sub(1) - dy,
+                    (graph_area.left() - chart_area.left()).saturating_sub(1),
+                    1,
+                );
+                Self::render_label(buf, label, label_area, self.y_axis.labels_alignment);
             }
         }
     }
 }
 
-impl<'a> Widget for TimeChart<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
-        if area.area() == 0 {
+impl Widget for TimeChart<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        buf.set_style(area, self.style);
+
+        self.block.render(area, buf);
+        let chart_area = self.block.inner_if_some(area);
+        if chart_area.is_empty() {
             return;
         }
-        buf.set_style(area, self.style);
+
         // Sample the style of the entire widget. This sample will be used to reset the style of
-        // the cells that are part of the components put on top of the graph area (i.e legend and
+        // the cells that are part of the components put on top of the grah area (i.e legend and
         // axis names).
         let original_style = buf.get(area.left(), area.top()).style();
-
-        let chart_area = match self.block.take() {
-            Some(b) => {
-                let inner_area = b.inner(area);
-                b.render(area, buf);
-                inner_area
-            }
-            None => area,
-        };
 
         let layout = self.layout(chart_area);
         let graph_area = layout.graph_area;
@@ -431,97 +727,45 @@ impl<'a> Widget for TimeChart<'a> {
             .y_bounds(self.y_axis.bounds)
             .marker(self.marker)
             .paint(|ctx| {
-                // Idea is to:
-                // - Go over all datasets, determine *where* a point will be drawn.
-                // - We take the topmost (last) point first.
-                // - After we determine all points, then we paint them all.
-                // This helps relieve the issue where normally, braille grids are painted via |=, when we want
-                // an exclusive replacement.
-
-                for dataset in &self.datasets {
-                    let color = dataset.style.fg.unwrap_or(Color::Reset);
-
-                    let start_bound = self.x_axis.bounds[0];
-                    let end_bound = self.x_axis.bounds[1];
-
-                    let (start_index, interpolate_start) = get_start(dataset, start_bound);
-                    let (end_index, interpolate_end) = get_end(dataset, end_bound);
-
-                    let data_slice = &dataset.data[start_index..end_index];
-
-                    if let Some(interpolate_start) = interpolate_start {
-                        if let (Some(older_point), Some(newer_point)) = (
-                            dataset.data.get(interpolate_start),
-                            dataset.data.get(interpolate_start + 1),
-                        ) {
-                            let interpolated_point = (
-                                self.x_axis.bounds[0],
-                                interpolate_point(older_point, newer_point, self.x_axis.bounds[0]),
-                            );
-
-                            if let GraphType::Line = dataset.graph_type {
-                                ctx.draw(&CanvasLine {
-                                    x1: interpolated_point.0,
-                                    y1: interpolated_point.1,
-                                    x2: newer_point.0,
-                                    y2: newer_point.1,
-                                    color,
-                                });
-                            } else {
-                                ctx.draw(&Points {
-                                    coords: &[interpolated_point],
-                                    color,
-                                });
-                            }
-                        }
-                    }
-
-                    if let GraphType::Line = dataset.graph_type {
-                        for data in data_slice.windows(2) {
-                            ctx.draw(&CanvasLine {
-                                x1: data[0].0,
-                                y1: data[0].1,
-                                x2: data[1].0,
-                                y2: data[1].1,
-                                color,
-                            });
-                        }
-                    } else {
-                        ctx.draw(&Points {
-                            coords: data_slice,
-                            color,
-                        });
-                    }
-
-                    if let Some(interpolate_end) = interpolate_end {
-                        if let (Some(older_point), Some(newer_point)) = (
-                            dataset.data.get(interpolate_end - 1),
-                            dataset.data.get(interpolate_end),
-                        ) {
-                            let interpolated_point = (
-                                self.x_axis.bounds[1],
-                                interpolate_point(older_point, newer_point, self.x_axis.bounds[1]),
-                            );
-
-                            if let GraphType::Line = dataset.graph_type {
-                                ctx.draw(&CanvasLine {
-                                    x1: older_point.0,
-                                    y1: older_point.1,
-                                    x2: interpolated_point.0,
-                                    y2: interpolated_point.1,
-                                    color,
-                                });
-                            } else {
-                                ctx.draw(&Points {
-                                    coords: &[interpolated_point],
-                                    color,
-                                });
-                            }
-                        }
-                    }
-                }
+                self.draw_points(ctx);
             })
             .render(graph_area, buf);
+
+        if let Some((x, y)) = layout.title_x {
+            let title = self.x_axis.title.as_ref().unwrap();
+            let width = graph_area
+                .right()
+                .saturating_sub(x)
+                .min(title.width() as u16);
+            buf.set_style(
+                Rect {
+                    x,
+                    y,
+                    width,
+                    height: 1,
+                },
+                original_style,
+            );
+            buf.set_line(x, y, title, width);
+        }
+
+        if let Some((x, y)) = layout.title_y {
+            let title = self.y_axis.title.as_ref().unwrap();
+            let width = graph_area
+                .right()
+                .saturating_sub(x)
+                .min(title.width() as u16);
+            buf.set_style(
+                Rect {
+                    x,
+                    y,
+                    width,
+                    height: 1,
+                },
+                original_style,
+            );
+            buf.set_line(x, y, title, width);
+        }
 
         if let Some(legend_area) = layout.legend_area {
             buf.set_style(legend_area, original_style);
@@ -529,147 +773,120 @@ impl<'a> Widget for TimeChart<'a> {
                 .borders(Borders::ALL)
                 .border_style(self.legend_style)
                 .render(legend_area, buf);
-            for (i, dataset) in self.datasets.iter().enumerate() {
-                buf.set_string(
-                    legend_area.x + 1,
-                    legend_area.y + 1 + i as u16,
-                    &dataset.name,
-                    dataset.style,
+
+            for (i, (dataset_name, dataset_style)) in self
+                .datasets
+                .iter()
+                .filter_map(|ds| Some((ds.name.as_ref()?, ds.style())))
+                .enumerate()
+            {
+                let name = dataset_name.clone().patch_style(dataset_style);
+                name.render(
+                    Rect {
+                        x: legend_area.x + 1,
+                        y: legend_area.y + 1 + i as u16,
+                        width: legend_area.width - 2,
+                        height: 1,
+                    },
+                    buf,
                 );
             }
         }
-
-        if let Some((x, y)) = layout.title_x {
-            let title = self.x_axis.title.unwrap();
-            let width = graph_area.right().saturating_sub(x);
-            buf.set_style(
-                Rect {
-                    x,
-                    y,
-                    width,
-                    height: 1,
-                },
-                original_style,
-            );
-            buf.set_line(x, y, &title, width);
-        }
-
-        if let Some((x, y)) = layout.title_y {
-            let title = self.y_axis.title.unwrap();
-            let width = graph_area.right().saturating_sub(x);
-            buf.set_style(
-                Rect {
-                    x,
-                    y,
-                    width,
-                    height: 1,
-                },
-                original_style,
-            );
-            buf.set_line(x, y, &title, width);
-        }
     }
 }
 
-/// Returns the start index and potential interpolation index given the start time and the dataset.
-fn get_start(dataset: &Dataset<'_>, start_bound: f64) -> (usize, Option<usize>) {
-    match dataset
-        .data
-        .binary_search_by(|(x, _y)| partial_ordering(x, &start_bound))
-    {
-        Ok(index) => (index, None),
-        Err(index) => (index, index.checked_sub(1)),
+impl<'a> Styled for Axis<'a> {
+    type Item = Axis<'a>;
+
+    fn style(&self) -> Style {
+        self.style
+    }
+
+    fn set_style<S: Into<Style>>(self, style: S) -> Self::Item {
+        self.style(style)
     }
 }
 
-/// Returns the end position and potential interpolation index given the end time and the dataset.
-fn get_end(dataset: &Dataset<'_>, end_bound: f64) -> (usize, Option<usize>) {
-    match dataset
-        .data
-        .binary_search_by(|(x, _y)| partial_ordering(x, &end_bound))
-    {
-        // In the success case, this means we found an index. Add one since we want to include this index and we
-        // expect to use the returned index as part of a (m..n) range.
-        Ok(index) => (index.saturating_add(1), None),
-        // In the fail case, this means we did not find an index, and the returned index is where one would *insert*
-        // the location. This index is where one would insert to fit inside the dataset - and since this is an end
-        // bound, index is, in a sense, already "+1" for our range later.
-        Err(index) => (index, {
-            let sum = index.checked_add(1);
-            match sum {
-                Some(s) if s < dataset.data.len() => sum,
-                _ => None,
-            }
-        }),
+impl<'a> Styled for Dataset<'a> {
+    type Item = Dataset<'a>;
+
+    fn style(&self) -> Style {
+        self.style
+    }
+
+    fn set_style<S: Into<Style>>(self, style: S) -> Self::Item {
+        self.style(style)
     }
 }
 
-/// Returns the y-axis value for a given `x`, given two points to draw a line between.
-fn interpolate_point(older_point: &Point, newer_point: &Point, x: f64) -> f64 {
-    let delta_x = newer_point.0 - older_point.0;
-    let delta_y = newer_point.1 - older_point.1;
-    let slope = delta_y / delta_x;
+impl<'a> Styled for TimeChart<'a> {
+    type Item = TimeChart<'a>;
 
-    (older_point.1 + (x - older_point.0) * slope).max(0.0)
+    fn style(&self) -> Style {
+        self.style
+    }
+
+    fn set_style<S: Into<Style>>(self, style: S) -> Self::Item {
+        self.style(style)
+    }
 }
 
+/// Tests taken from ratatui.
 #[cfg(test)]
-mod test {
+mod tests {
+    macro_rules! assert_buffer_eq {
+        ($actual_expr:expr, $expected_expr:expr) => {
+            match (&$actual_expr, &$expected_expr) {
+                (actual, expected) => {
+                    if actual.area != expected.area {
+                        panic!(
+                            indoc::indoc!(
+                                "
+                                buffer areas not equal
+                                expected:  {:?}
+                                actual:    {:?}"
+                            ),
+                            expected, actual
+                        );
+                    }
+                    let diff = expected.diff(&actual);
+                    if !diff.is_empty() {
+                        let nice_diff = diff
+                            .iter()
+                            .enumerate()
+                            .map(|(i, (x, y, cell))| {
+                                let expected_cell = expected.get(*x, *y);
+                                indoc::formatdoc! {"
+                                    {i}: at ({x}, {y})
+                                      expected: {expected_cell:?}
+                                      actual:   {cell:?}
+                                "}
+                            })
+                            .collect::<Vec<String>>()
+                            .join("\n");
+                        panic!(
+                            indoc::indoc!(
+                                "
+                                buffer contents not equal
+                                expected: {:?}
+                                actual: {:?}
+                                diff:
+                                {}"
+                            ),
+                            expected, actual, nice_diff
+                        );
+                    }
+                    // shouldn't get here, but this guards against future behavior
+                    // that changes equality but not area or content
+                    assert_eq!(actual, expected, "buffers not equal");
+                }
+            }
+        };
+    }
+
+    use tui::style::{Modifier, Stylize};
+
     use super::*;
-
-    #[test]
-    fn time_chart_test_interpolation() {
-        let data = [(-3.0, 8.0), (-1.0, 6.0), (0.0, 5.0)];
-
-        assert_eq!(interpolate_point(&data[1], &data[2], 0.0), 5.0);
-        assert_eq!(interpolate_point(&data[1], &data[2], -0.25), 5.25);
-        assert_eq!(interpolate_point(&data[1], &data[2], -0.5), 5.5);
-        assert_eq!(interpolate_point(&data[0], &data[1], -1.0), 6.0);
-        assert_eq!(interpolate_point(&data[0], &data[1], -1.5), 6.5);
-        assert_eq!(interpolate_point(&data[0], &data[1], -2.0), 7.0);
-        assert_eq!(interpolate_point(&data[0], &data[1], -2.5), 7.5);
-        assert_eq!(interpolate_point(&data[0], &data[1], -3.0), 8.0);
-    }
-
-    #[test]
-    fn time_chart_empty_dataset() {
-        let data = [];
-        let dataset = Dataset::default().data(&data);
-
-        assert_eq!(get_start(&dataset, -100.0), (0, None));
-        assert_eq!(get_start(&dataset, -3.0), (0, None));
-
-        assert_eq!(get_end(&dataset, 0.0), (0, None));
-        assert_eq!(get_end(&dataset, 100.0), (0, None));
-    }
-
-    #[test]
-    fn time_chart_test_data_trimming() {
-        let data = [
-            (-3.0, 8.0),
-            (-2.5, 15.0),
-            (-2.0, 9.0),
-            (-1.0, 6.0),
-            (0.0, 5.0),
-        ];
-        let dataset = Dataset::default().data(&data);
-
-        // Test start point cases (miss and hit)
-        assert_eq!(get_start(&dataset, -100.0), (0, None));
-        assert_eq!(get_start(&dataset, -3.0), (0, None));
-        assert_eq!(get_start(&dataset, -2.8), (1, Some(0)));
-        assert_eq!(get_start(&dataset, -2.5), (1, None));
-        assert_eq!(get_start(&dataset, -2.4), (2, Some(1)));
-
-        // Test end point cases (miss and hit)
-        assert_eq!(get_end(&dataset, -2.5), (2, None));
-        assert_eq!(get_end(&dataset, -2.4), (2, Some(3)));
-        assert_eq!(get_end(&dataset, -1.4), (3, Some(4)));
-        assert_eq!(get_end(&dataset, -1.0), (4, None));
-        assert_eq!(get_end(&dataset, 0.0), (5, None));
-        assert_eq!(get_end(&dataset, 1.0), (5, None));
-        assert_eq!(get_end(&dataset, 100.0), (5, None));
-    }
 
     struct LegendTestCase {
         chart_area: Rect,
@@ -677,7 +894,6 @@ mod test {
         legend_area: Option<Rect>,
     }
 
-    /// Test from the original tui-rs [`Chart`](tui::widgets::Chart).
     #[test]
     fn it_should_hide_the_legend() {
         let data = [(0.0, 5.0), (1.0, 6.0), (3.0, 7.0)];
@@ -707,5 +923,405 @@ mod test {
             let layout = chart.layout(case.chart_area);
             assert_eq!(layout.legend_area, case.legend_area);
         }
+    }
+
+    #[test]
+    fn axis_can_be_stylized() {
+        assert_eq!(
+            Axis::default().black().on_white().bold().not_dim().style,
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::White)
+                .add_modifier(Modifier::BOLD)
+                .remove_modifier(Modifier::DIM)
+        )
+    }
+
+    #[test]
+    fn dataset_can_be_stylized() {
+        assert_eq!(
+            Dataset::default().black().on_white().bold().not_dim().style,
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::White)
+                .add_modifier(Modifier::BOLD)
+                .remove_modifier(Modifier::DIM)
+        )
+    }
+
+    #[test]
+    fn chart_can_be_stylized() {
+        assert_eq!(
+            TimeChart::new(vec![])
+                .black()
+                .on_white()
+                .bold()
+                .not_dim()
+                .style,
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::White)
+                .add_modifier(Modifier::BOLD)
+                .remove_modifier(Modifier::DIM)
+        )
+    }
+
+    #[test]
+    fn graph_type_to_string() {
+        assert_eq!(GraphType::Scatter.to_string(), "Scatter");
+        assert_eq!(GraphType::Line.to_string(), "Line");
+    }
+
+    #[test]
+    fn graph_type_from_str() {
+        assert_eq!("Scatter".parse::<GraphType>(), Ok(GraphType::Scatter));
+        assert_eq!("Line".parse::<GraphType>(), Ok(GraphType::Line));
+        assert!("".parse::<GraphType>().is_err());
+    }
+
+    #[test]
+    fn it_does_not_panic_if_title_is_wider_than_buffer() {
+        let widget = TimeChart::default()
+            .y_axis(Axis::default().title("xxxxxxxxxxxxxxxx"))
+            .x_axis(Axis::default().title("xxxxxxxxxxxxxxxx"));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 4));
+        widget.render(buffer.area, &mut buffer);
+
+        assert_eq!(buffer, Buffer::with_lines(vec![" ".repeat(8); 4]))
+    }
+
+    #[test]
+    fn datasets_without_name_dont_contribute_to_legend_height() {
+        let data_named_1 = Dataset::default().name("data1"); // must occupy a row in legend
+        let data_named_2 = Dataset::default().name(""); // must occupy a row in legend, even if name is empty
+        let data_unnamed = Dataset::default(); // must not occupy a row in legend
+        let widget = TimeChart::new(vec![data_named_1, data_unnamed, data_named_2]);
+        let buffer = Buffer::empty(Rect::new(0, 0, 50, 25));
+        let layout = widget.layout(buffer.area);
+
+        assert!(layout.legend_area.is_some());
+        assert_eq!(layout.legend_area.unwrap().height, 4); // 2 for borders, 2 for rows
+    }
+
+    #[test]
+    fn no_legend_if_no_named_datasets() {
+        let dataset = Dataset::default();
+        let widget = TimeChart::new(vec![dataset; 3]);
+        let buffer = Buffer::empty(Rect::new(0, 0, 50, 25));
+        let layout = widget.layout(buffer.area);
+
+        assert!(layout.legend_area.is_none());
+    }
+
+    #[test]
+    fn dataset_legend_style_is_patched() {
+        let long_dataset_name = Dataset::default().name("Very long name");
+        let short_dataset =
+            Dataset::default().name(Line::from("Short name").alignment(Alignment::Right));
+        let widget = TimeChart::new(vec![long_dataset_name, short_dataset])
+            .hidden_legend_constraints((100.into(), 100.into()));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 20, 5));
+
+        widget.render(buffer.area, &mut buffer);
+
+        let expected = Buffer::with_lines(vec![
+            "    ┌──────────────┐",
+            "    │Very long name│",
+            "    │    Short name│",
+            "    └──────────────┘",
+            "                    ",
+        ]);
+        assert_buffer_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn test_chart_have_a_topleft_legend() {
+        let chart = TimeChart::new(vec![Dataset::default().name("Ds1")])
+            .legend_position(Some(LegendPosition::TopLeft));
+
+        let area = Rect::new(0, 0, 30, 20);
+        let mut buffer = Buffer::empty(area);
+
+        chart.render(buffer.area, &mut buffer);
+
+        let expected = Buffer::with_lines(vec![
+            "┌───┐                         ",
+            "│Ds1│                         ",
+            "└───┘                         ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+        ]);
+
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn test_chart_have_a_long_y_axis_title_overlapping_legend() {
+        let chart = TimeChart::new(vec![Dataset::default().name("Ds1")])
+            .y_axis(Axis::default().title("The title overlap a legend."));
+
+        let area = Rect::new(0, 0, 30, 20);
+        let mut buffer = Buffer::empty(area);
+
+        chart.render(buffer.area, &mut buffer);
+
+        let expected = Buffer::with_lines(vec![
+            "The title overlap a legend.   ",
+            "                         ┌───┐",
+            "                         │Ds1│",
+            "                         └───┘",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+            "                              ",
+        ]);
+
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn test_chart_have_overflowed_y_axis() {
+        let chart = TimeChart::new(vec![Dataset::default().name("Ds1")])
+            .y_axis(Axis::default().title("The title overlap a legend."));
+
+        let area = Rect::new(0, 0, 10, 10);
+        let mut buffer = Buffer::empty(area);
+
+        chart.render(buffer.area, &mut buffer);
+
+        let expected = Buffer::with_lines(vec![
+            "          ",
+            "          ",
+            "          ",
+            "          ",
+            "          ",
+            "          ",
+            "          ",
+            "          ",
+            "          ",
+            "          ",
+        ]);
+
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn test_legend_area_can_fit_same_chart_area() {
+        let name = "Data";
+        let chart = TimeChart::new(vec![Dataset::default().name(name)])
+            .hidden_legend_constraints((Constraint::Percentage(100), Constraint::Percentage(100)));
+
+        let area = Rect::new(0, 0, name.len() as u16 + 2, 3);
+        let mut buffer = Buffer::empty(area);
+
+        let expected = Buffer::with_lines(vec!["┌────┐", "│Data│", "└────┘"]);
+
+        [
+            LegendPosition::TopLeft,
+            LegendPosition::Top,
+            LegendPosition::TopRight,
+            LegendPosition::Left,
+            LegendPosition::Right,
+            LegendPosition::Bottom,
+            LegendPosition::BottomLeft,
+            LegendPosition::BottomRight,
+        ]
+        .iter()
+        .for_each(|&position| {
+            let chart = chart.clone().legend_position(Some(position));
+            buffer.reset();
+            chart.render(buffer.area, &mut buffer);
+            assert_eq!(buffer, expected);
+        });
+    }
+
+    #[test]
+    fn test_legend_of_chart_have_odd_margin_size() {
+        let name = "Data";
+        let base_chart = TimeChart::new(vec![Dataset::default().name(name)])
+            .hidden_legend_constraints((Constraint::Percentage(100), Constraint::Percentage(100)));
+
+        let area = Rect::new(0, 0, name.len() as u16 + 2 + 3, 3 + 3);
+        let mut buffer = Buffer::empty(area);
+
+        let chart = base_chart
+            .clone()
+            .legend_position(Some(LegendPosition::TopLeft));
+        buffer.reset();
+        chart.render(buffer.area, &mut buffer);
+        assert_eq!(
+            buffer,
+            Buffer::with_lines(vec![
+                "┌────┐   ",
+                "│Data│   ",
+                "└────┘   ",
+                "         ",
+                "         ",
+                "         ",
+            ])
+        );
+        buffer.reset();
+
+        let chart = base_chart
+            .clone()
+            .legend_position(Some(LegendPosition::Top));
+        buffer.reset();
+        chart.render(buffer.area, &mut buffer);
+        assert_eq!(
+            buffer,
+            Buffer::with_lines(vec![
+                " ┌────┐  ",
+                " │Data│  ",
+                " └────┘  ",
+                "         ",
+                "         ",
+                "         ",
+            ])
+        );
+
+        let chart = base_chart
+            .clone()
+            .legend_position(Some(LegendPosition::TopRight));
+        buffer.reset();
+        chart.render(buffer.area, &mut buffer);
+        assert_eq!(
+            buffer,
+            Buffer::with_lines(vec![
+                "   ┌────┐",
+                "   │Data│",
+                "   └────┘",
+                "         ",
+                "         ",
+                "         ",
+            ])
+        );
+
+        let chart = base_chart
+            .clone()
+            .legend_position(Some(LegendPosition::Left));
+        buffer.reset();
+        chart.render(buffer.area, &mut buffer);
+        assert_eq!(
+            buffer,
+            Buffer::with_lines(vec![
+                "         ",
+                "┌────┐   ",
+                "│Data│   ",
+                "└────┘   ",
+                "         ",
+                "         ",
+            ])
+        );
+        buffer.reset();
+
+        let chart = base_chart
+            .clone()
+            .legend_position(Some(LegendPosition::Right));
+        buffer.reset();
+        chart.render(buffer.area, &mut buffer);
+        assert_eq!(
+            buffer,
+            Buffer::with_lines(vec![
+                "         ",
+                "   ┌────┐",
+                "   │Data│",
+                "   └────┘",
+                "         ",
+                "         ",
+            ])
+        );
+
+        let chart = base_chart
+            .clone()
+            .legend_position(Some(LegendPosition::BottomLeft));
+        buffer.reset();
+        chart.render(buffer.area, &mut buffer);
+        assert_eq!(
+            buffer,
+            Buffer::with_lines(vec![
+                "         ",
+                "         ",
+                "         ",
+                "┌────┐   ",
+                "│Data│   ",
+                "└────┘   ",
+            ])
+        );
+
+        let chart = base_chart
+            .clone()
+            .legend_position(Some(LegendPosition::Bottom));
+        buffer.reset();
+        chart.render(buffer.area, &mut buffer);
+        assert_eq!(
+            buffer,
+            Buffer::with_lines(vec![
+                "         ",
+                "         ",
+                "         ",
+                " ┌────┐  ",
+                " │Data│  ",
+                " └────┘  ",
+            ])
+        );
+
+        let chart = base_chart
+            .clone()
+            .legend_position(Some(LegendPosition::BottomRight));
+        buffer.reset();
+        chart.render(buffer.area, &mut buffer);
+        assert_eq!(
+            buffer,
+            Buffer::with_lines(vec![
+                "         ",
+                "         ",
+                "         ",
+                "   ┌────┐",
+                "   │Data│",
+                "   └────┘",
+            ])
+        );
+
+        let chart = base_chart.clone().legend_position(None);
+        buffer.reset();
+        chart.render(buffer.area, &mut buffer);
+        assert_eq!(
+            buffer,
+            Buffer::with_lines(vec![
+                "         ",
+                "         ",
+                "         ",
+                "         ",
+                "         ",
+                "         ",
+            ])
+        );
     }
 }

--- a/src/canvas/components/tui_widget/time_chart/points.rs
+++ b/src/canvas/components/tui_widget/time_chart/points.rs
@@ -1,0 +1,206 @@
+use tui::{
+    style::Color,
+    widgets::{
+        canvas::{Line as CanvasLine, Points},
+        GraphType,
+    },
+};
+
+use crate::utils::general::partial_ordering;
+
+use super::{Context, Dataset, Point, TimeChart};
+
+impl TimeChart<'_> {
+    pub(crate) fn draw_points(&self, ctx: &mut Context<'_>) {
+        // Idea is to:
+        // - Go over all datasets, determine *where* a point will be drawn.
+        // - We take the topmost (last) point first.
+        // - After we determine all points, then we paint them all.
+        // This helps relieve the issue where normally, braille grids are painted via |=, when we want
+        // an exclusive replacement.
+
+        for dataset in &self.datasets {
+            let color = dataset.style.fg.unwrap_or(Color::Reset);
+
+            let start_bound = self.x_axis.bounds[0];
+            let end_bound = self.x_axis.bounds[1];
+
+            let (start_index, interpolate_start) = get_start(dataset, start_bound);
+            let (end_index, interpolate_end) = get_end(dataset, end_bound);
+
+            let data_slice = &dataset.data[start_index..end_index];
+
+            if let Some(interpolate_start) = interpolate_start {
+                if let (Some(older_point), Some(newer_point)) = (
+                    dataset.data.get(interpolate_start),
+                    dataset.data.get(interpolate_start + 1),
+                ) {
+                    let interpolated_point = (
+                        self.x_axis.bounds[0],
+                        interpolate_point(older_point, newer_point, self.x_axis.bounds[0]),
+                    );
+
+                    if let GraphType::Line = dataset.graph_type {
+                        ctx.draw(&CanvasLine {
+                            x1: interpolated_point.0,
+                            y1: interpolated_point.1,
+                            x2: newer_point.0,
+                            y2: newer_point.1,
+                            color,
+                        });
+                    } else {
+                        ctx.draw(&Points {
+                            coords: &[interpolated_point],
+                            color,
+                        });
+                    }
+                }
+            }
+
+            if let GraphType::Line = dataset.graph_type {
+                for data in data_slice.windows(2) {
+                    ctx.draw(&CanvasLine {
+                        x1: data[0].0,
+                        y1: data[0].1,
+                        x2: data[1].0,
+                        y2: data[1].1,
+                        color,
+                    });
+                }
+            } else {
+                ctx.draw(&Points {
+                    coords: data_slice,
+                    color,
+                });
+            }
+
+            if let Some(interpolate_end) = interpolate_end {
+                if let (Some(older_point), Some(newer_point)) = (
+                    dataset.data.get(interpolate_end - 1),
+                    dataset.data.get(interpolate_end),
+                ) {
+                    let interpolated_point = (
+                        self.x_axis.bounds[1],
+                        interpolate_point(older_point, newer_point, self.x_axis.bounds[1]),
+                    );
+
+                    if let GraphType::Line = dataset.graph_type {
+                        ctx.draw(&CanvasLine {
+                            x1: older_point.0,
+                            y1: older_point.1,
+                            x2: interpolated_point.0,
+                            y2: interpolated_point.1,
+                            color,
+                        });
+                    } else {
+                        ctx.draw(&Points {
+                            coords: &[interpolated_point],
+                            color,
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Returns the start index and potential interpolation index given the start time and the dataset.
+fn get_start(dataset: &Dataset<'_>, start_bound: f64) -> (usize, Option<usize>) {
+    match dataset
+        .data
+        .binary_search_by(|(x, _y)| partial_ordering(x, &start_bound))
+    {
+        Ok(index) => (index, None),
+        Err(index) => (index, index.checked_sub(1)),
+    }
+}
+
+/// Returns the end position and potential interpolation index given the end time and the dataset.
+fn get_end(dataset: &Dataset<'_>, end_bound: f64) -> (usize, Option<usize>) {
+    match dataset
+        .data
+        .binary_search_by(|(x, _y)| partial_ordering(x, &end_bound))
+    {
+        // In the success case, this means we found an index. Add one since we want to include this index and we
+        // expect to use the returned index as part of a (m..n) range.
+        Ok(index) => (index.saturating_add(1), None),
+        // In the fail case, this means we did not find an index, and the returned index is where one would *insert*
+        // the location. This index is where one would insert to fit inside the dataset - and since this is an end
+        // bound, index is, in a sense, already "+1" for our range later.
+        Err(index) => (index, {
+            let sum = index.checked_add(1);
+            match sum {
+                Some(s) if s < dataset.data.len() => sum,
+                _ => None,
+            }
+        }),
+    }
+}
+
+/// Returns the y-axis value for a given `x`, given two points to draw a line between.
+fn interpolate_point(older_point: &Point, newer_point: &Point, x: f64) -> f64 {
+    let delta_x = newer_point.0 - older_point.0;
+    let delta_y = newer_point.1 - older_point.1;
+    let slope = delta_y / delta_x;
+
+    (older_point.1 + (x - older_point.0) * slope).max(0.0)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn time_chart_test_interpolation() {
+        let data = [(-3.0, 8.0), (-1.0, 6.0), (0.0, 5.0)];
+
+        assert_eq!(interpolate_point(&data[1], &data[2], 0.0), 5.0);
+        assert_eq!(interpolate_point(&data[1], &data[2], -0.25), 5.25);
+        assert_eq!(interpolate_point(&data[1], &data[2], -0.5), 5.5);
+        assert_eq!(interpolate_point(&data[0], &data[1], -1.0), 6.0);
+        assert_eq!(interpolate_point(&data[0], &data[1], -1.5), 6.5);
+        assert_eq!(interpolate_point(&data[0], &data[1], -2.0), 7.0);
+        assert_eq!(interpolate_point(&data[0], &data[1], -2.5), 7.5);
+        assert_eq!(interpolate_point(&data[0], &data[1], -3.0), 8.0);
+    }
+
+    #[test]
+    fn time_chart_empty_dataset() {
+        let data = [];
+        let dataset = Dataset::default().data(&data);
+
+        assert_eq!(get_start(&dataset, -100.0), (0, None));
+        assert_eq!(get_start(&dataset, -3.0), (0, None));
+
+        assert_eq!(get_end(&dataset, 0.0), (0, None));
+        assert_eq!(get_end(&dataset, 100.0), (0, None));
+    }
+
+    #[test]
+    fn time_chart_test_data_trimming() {
+        let data = [
+            (-3.0, 8.0),
+            (-2.5, 15.0),
+            (-2.0, 9.0),
+            (-1.0, 6.0),
+            (0.0, 5.0),
+        ];
+        let dataset = Dataset::default().data(&data);
+
+        // Test start point cases (miss and hit)
+        assert_eq!(get_start(&dataset, -100.0), (0, None));
+        assert_eq!(get_start(&dataset, -3.0), (0, None));
+        assert_eq!(get_start(&dataset, -2.8), (1, Some(0)));
+        assert_eq!(get_start(&dataset, -2.5), (1, None));
+        assert_eq!(get_start(&dataset, -2.4), (2, Some(1)));
+
+        // Test end point cases (miss and hit)
+        assert_eq!(get_end(&dataset, -2.5), (2, None));
+        assert_eq!(get_end(&dataset, -2.4), (2, Some(3)));
+        assert_eq!(get_end(&dataset, -1.4), (3, Some(4)));
+        assert_eq!(get_end(&dataset, -1.0), (4, None));
+        assert_eq!(get_end(&dataset, 0.0), (5, None));
+        assert_eq!(get_end(&dataset, 1.0), (5, None));
+        assert_eq!(get_end(&dataset, 100.0), (5, None));
+    }
+}

--- a/src/canvas/components/tui_widget/time_chart/points.rs
+++ b/src/canvas/components/tui_widget/time_chart/points.rs
@@ -14,10 +14,19 @@ impl TimeChart<'_> {
     pub(crate) fn draw_points(&self, ctx: &mut Context<'_>) {
         // Idea is to:
         // - Go over all datasets, determine *where* a point will be drawn.
-        // - We take the topmost (last) point first.
-        // - After we determine all points, then we paint them all.
-        // This helps relieve the issue where normally, braille grids are painted via |=, when we want
-        // an exclusive replacement.
+        // - Last point wins for what gets drawn.
+        // - We set _all_ points for all datasets before actually rendering.
+        //
+        // By doing this, it's a bit more efficient from my experience than looping
+        // over each dataset and rendering a new layer each time.
+        //
+        // See <https://github.com/ClementTsang/bottom/pull/918> and <https://github.com/ClementTsang/bottom/pull/937>
+        // for the original motivation.
+        //
+        // We also additionally do some interpolation logic because we may get caught missing some points
+        // when drawing, but we generally want to avoid jarring gaps between the edges when there's
+        // a point that is off screen and so a line isn't drawn (right edge generally won't have this issue
+        // issue but it can happen in some cases).
 
         for dataset in &self.datasets {
             let color = dataset.style.fg.unwrap_or(Color::Reset);

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -345,8 +345,8 @@ fn adjust_network_data_point(
     // So for example, let's say I use 390 Mb/s.  If I drew 4 segments, it would be 97.5, 195, 292.5, 390, and
     // probably something like 438.75?
     //
-    // So, how do we do this in tui-rs?  Well, if we  are using intervals that tie in perfectly to the max
-    // value we want... then it's actually not that hard.  Since tui-rs accepts a vector as labels and will
+    // So, how do we do this in ratatui?  Well, if we  are using intervals that tie in perfectly to the max
+    // value we want... then it's actually not that hard.  Since ratatui accepts a vector as labels and will
     // properly space them all out... we just work with that and space it out properly.
     //
     // Dynamic chart idea based off of FreeNAS's chart design.

--- a/src/utils/general.rs
+++ b/src/utils/general.rs
@@ -1,6 +1,9 @@
 use std::{cmp::Ordering, num::NonZeroUsize};
 
-use tui::text::{Line, Span, Text};
+use tui::{
+    style::Style,
+    text::{Line, Span, Text},
+};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
@@ -64,6 +67,8 @@ pub fn get_decimal_prefix(quantity: u64, unit: &str) -> (f64, String) {
 pub fn truncate_to_text<'a, U: Into<usize>>(content: &str, width: U) -> Text<'a> {
     Text {
         lines: vec![Line::from(vec![Span::raw(truncate_str(content, width))])],
+        style: Style::default(),
+        alignment: None,
     }
 }
 

--- a/src/widgets/cpu_graph.rs
+++ b/src/widgets/cpu_graph.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, time::Instant};
+use std::{borrow::Cow, num::NonZeroU16, time::Instant};
 
 use concat_string::concat_string;
 use tui::{style::Style, text::Text, widgets::Row};
@@ -81,8 +81,10 @@ impl CpuWidgetTableData {
 }
 
 impl DataToCell<CpuWidgetColumn> for CpuWidgetTableData {
-    fn to_cell(&self, column: &CpuWidgetColumn, calculated_width: u16) -> Option<Text<'_>> {
+    fn to_cell(&self, column: &CpuWidgetColumn, calculated_width: NonZeroU16) -> Option<Text<'_>> {
         const CPU_TRUNCATE_BREAKPOINT: u16 = 5;
+
+        let calculated_width = calculated_width.get();
 
         // This is a bit of a hack, but apparently we can avoid having to do any fancy checks
         // of showing the "All" on a specific column if the other is hidden by just always

--- a/src/widgets/disk_table.rs
+++ b/src/widgets/disk_table.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, cmp::max};
+use std::{borrow::Cow, cmp::max, num::NonZeroU16};
 
 use kstring::KString;
 use tui::text::Text;
@@ -128,11 +128,8 @@ impl ColumnHeader for DiskWidgetColumn {
 }
 
 impl DataToCell<DiskWidgetColumn> for DiskWidgetData {
-    fn to_cell(&self, column: &DiskWidgetColumn, calculated_width: u16) -> Option<Text<'_>> {
-        if calculated_width == 0 {
-            return None;
-        }
-
+    fn to_cell(&self, column: &DiskWidgetColumn, calculated_width: NonZeroU16) -> Option<Text<'_>> {
+        let calculated_width = calculated_width.get();
         let text = match column {
             DiskWidgetColumn::Disk => truncate_to_text(&self.name, calculated_width),
             DiskWidgetColumn::Mount => truncate_to_text(&self.mount_point, calculated_width),

--- a/src/widgets/process_table.rs
+++ b/src/widgets/process_table.rs
@@ -89,7 +89,7 @@ fn make_column(column: ProcColumn) -> SortColumn<ProcColumn> {
         TotalRead => SortColumn::hard(TotalRead, 8).default_descending(),
         TotalWrite => SortColumn::hard(TotalWrite, 8).default_descending(),
         User => SortColumn::soft(User, Some(0.05)),
-        State => SortColumn::hard(State, 7),
+        State => SortColumn::hard(State, 9),
         Time => SortColumn::new(Time),
         #[cfg(feature = "gpu")]
         GpuMem => SortColumn::new(GpuMem).default_descending(),

--- a/src/widgets/process_table/proc_widget_data.rs
+++ b/src/widgets/process_table/proc_widget_data.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::{max, Ordering},
     fmt::Display,
+    num::NonZeroU16,
     time::Duration,
 };
 
@@ -299,10 +300,8 @@ impl ProcWidgetData {
 }
 
 impl DataToCell<ProcColumn> for ProcWidgetData {
-    fn to_cell(&self, column: &ProcColumn, calculated_width: u16) -> Option<Text<'_>> {
-        if calculated_width == 0 {
-            return None;
-        }
+    fn to_cell(&self, column: &ProcColumn, calculated_width: NonZeroU16) -> Option<Text<'_>> {
+        let calculated_width = calculated_width.get();
 
         // TODO: Optimize the string allocations here...
         // TODO: Also maybe just pull in the to_string call but add a variable for the differences.

--- a/src/widgets/process_table/sort_table.rs
+++ b/src/widgets/process_table/sort_table.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, num::NonZeroU16};
 
 use tui::text::Text;
 
@@ -16,12 +16,8 @@ impl ColumnHeader for SortTableColumn {
 }
 
 impl DataToCell<SortTableColumn> for &'static str {
-    fn to_cell(&self, _column: &SortTableColumn, calculated_width: u16) -> Option<Text<'_>> {
-        if calculated_width == 0 {
-            return None;
-        }
-
-        Some(truncate_to_text(self, calculated_width))
+    fn to_cell(&self, _column: &SortTableColumn, calculated_width: NonZeroU16) -> Option<Text<'_>> {
+        Some(truncate_to_text(self, calculated_width.get()))
     }
 
     fn column_widths<C: DataTableColumn<SortTableColumn>>(data: &[Self], _columns: &[C]) -> Vec<u16>
@@ -33,12 +29,8 @@ impl DataToCell<SortTableColumn> for &'static str {
 }
 
 impl DataToCell<SortTableColumn> for Cow<'static, str> {
-    fn to_cell(&self, _column: &SortTableColumn, calculated_width: u16) -> Option<Text<'_>> {
-        if calculated_width == 0 {
-            return None;
-        }
-
-        Some(truncate_to_text(self, calculated_width))
+    fn to_cell(&self, _column: &SortTableColumn, calculated_width: NonZeroU16) -> Option<Text<'_>> {
+        Some(truncate_to_text(self, calculated_width.get()))
     }
 
     fn column_widths<C: DataTableColumn<SortTableColumn>>(data: &[Self], _columns: &[C]) -> Vec<u16>

--- a/src/widgets/temperature_table.rs
+++ b/src/widgets/temperature_table.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, cmp::max};
+use std::{borrow::Cow, cmp::max, num::NonZeroU16};
 
 use concat_string::concat_string;
 use kstring::KString;
@@ -55,14 +55,10 @@ impl TempWidgetData {
 }
 
 impl DataToCell<TempWidgetColumn> for TempWidgetData {
-    fn to_cell(&self, column: &TempWidgetColumn, calculated_width: u16) -> Option<Text<'_>> {
-        if calculated_width == 0 {
-            return None;
-        }
-
+    fn to_cell(&self, column: &TempWidgetColumn, calculated_width: NonZeroU16) -> Option<Text<'_>> {
         Some(match column {
-            TempWidgetColumn::Sensor => truncate_to_text(&self.sensor, calculated_width),
-            TempWidgetColumn::Temp => truncate_to_text(&self.temperature(), calculated_width),
+            TempWidgetColumn::Sensor => truncate_to_text(&self.sensor, calculated_width.get()),
+            TempWidgetColumn::Temp => truncate_to_text(&self.temperature(), calculated_width.get()),
         })
     }
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Bumps to 0.26. Followed the guide for breaking changes from 0.26: https://github.com/ratatui-org/ratatui/blob/main/BREAKING-CHANGES.md#v0260

Changes:
- The only real thing I think I needed to update was some code around the fields for `Text` and some column spacing code for drawing tables.
- Optimized some cases of non-zero u16s out since we were always just filtering them out anyway when doing column spacing.
- Also took advantage of this version update to refactor/update `TimeChart` and some `canvas.rs` code.

Another thing to check in a separate PR is to see if I can skip how I currently manually calculate widths for spacing (see https://github.com/ClementTsang/bottom/pull/916 and https://github.com/ClementTsang/bottom/issues/896 for the original problem).



## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [x] _Windows_
- [x] _macOS_
- [x] _Linux_

Note: test this on all 3 main platforms! It should be fine if it works on Linux but eh, might as well be sure.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
