### PR TITLE
docs: fix broken link to config documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ You can find more information on usage in the [documentation](https://clementtsa
 bottom accepts a number of command-line arguments to change the behaviour of the application as desired. Additionally, bottom will automatically
 generate a configuration file on the first launch, which one can change as appropriate.
 
-More details on configuration can be found [in the documentation](https://clementtsang.github.io/bottom/nightly/configuration/config-file/default-config/).
+More details on configuration can be found [in the documentation](https://clementtsang.github.io/bottom/nightly/configuration/config-file/).
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Fixes a broken link to configuration documentation in the `README`. 

Previous link:
<img width="500" alt="Screenshot 2024-02-19 at 17 21 47" src="https://github.com/ClementTsang/bottom/assets/66440371/2111e29f-d0a1-46c6-bd5b-b0a9c27ed901">

New link (one level up):
<img width="500" alt="Screenshot 2024-02-19 at 17 22 19" src="https://github.com/ClementTsang/bottom/assets/66440371/fdcc3747-d7ce-42e5-97ff-4135f3516c4d">

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
