### PR TITLE
ci: migrate macOS ARM builds to use GHA

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-# Configuration for CirrusCI. This is primarily used for testing and building FreeBSD and macOS M1, since other
-# CI platforms don't seem to support these platforms as of writing (GH may support M1 soon though).
+# Configuration for CirrusCI. This is primarily used for testing and building FreeBSD and old versions of Linux,
+# since other CI platforms don't support build jobs for these configurations.
 #
 # Note that we set the YAML directive above to prevent some linting errors around the templates.
 
@@ -50,10 +50,7 @@ test_task:
         image_family: freebsd-14-0
     - name: "FreeBSD 13 Test"
       freebsd_instance:
-        image_family: freebsd-13-2
-    - name: "macOS M1 Test"
-      macos_instance:
-        image: ghcr.io/cirruslabs/macos-monterey-base:latest
+        image_family: freebsd-13-3
   <<: *SETUP_TEMPLATE
   <<: *CACHE_TEMPLATE
   test_no_feature_script:
@@ -88,12 +85,12 @@ build_task:
         TARGET: "x86_64-unknown-freebsd"
         NAME: "x86_64-unknown-freebsd-14-0"
     - name: "FreeBSD 13 Build"
-      alias: "freebsd_13_2_build"
+      alias: "freebsd_13_3_build"
       freebsd_instance:
-        image_family: freebsd-13-2
+        image_family: freebsd-13-3
       env:
         TARGET: "x86_64-unknown-freebsd"
-        NAME: "x86_64-unknown-freebsd-13-2"
+        NAME: "x86_64-unknown-freebsd-13-3"
     - name: "Legacy Linux (2.17)"
       alias: "linux_2_17_build"
       container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -94,13 +94,6 @@ build_task:
       env:
         TARGET: "x86_64-unknown-freebsd"
         NAME: "x86_64-unknown-freebsd-13-2"
-    - name: "macOS M1 Build"
-      alias: "macos_build"
-      macos_instance:
-        image: ghcr.io/cirruslabs/macos-monterey-base:latest
-      env:
-        TARGET: "aarch64-apple-darwin"
-        NAME: "aarch64-apple-darwin"
     - name: "Legacy Linux (2.17)"
       alias: "linux_2_17_build"
       container:

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         info:
           # ======= Supported targets =======
-          # Linux (x64, x86, aarch64)
+          # Linux (x86-64, x86, aarch64)
           - {
               os: "ubuntu-20.04",
               target: "x86_64-unknown-linux-gnu",
@@ -72,10 +72,11 @@ jobs:
               cross: true,
             }
 
-          # macOS (x64), M1 is built via CirrusCI.
+          # macOS (x86-64 and aarch64)
           - { os: "macos-12", target: "x86_64-apple-darwin", cross: false }
+          - { os: "macos-14", target: "aarch64-apple-darwin", cross: false }
 
-          # Windows (x64, x86)
+          # Windows (x86-64, x86)
           - {
               os: "windows-2019",
               target: "x86_64-pc-windows-msvc",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
               cross: true,
             }
           - { os: "macos-12", target: "x86_64-apple-darwin", cross: false }
+          - { os: "macos-14", target: "aarch64-apple-darwin", cross: false }
           - {
               os: "windows-2019",
               target: "x86_64-pc-windows-msvc",

--- a/scripts/cirrus/build.py
+++ b/scripts/cirrus/build.py
@@ -22,7 +22,6 @@ from urllib.request import Request, urlopen, urlretrieve
 TASKS: List[Tuple[str, str]] = [
     ("freebsd_13_2_build", "bottom_x86_64-unknown-freebsd-13-2.tar.gz"),
     ("freebsd_14_0_build", "bottom_x86_64-unknown-freebsd-14-0.tar.gz"),
-    ("macos_build", "bottom_aarch64-apple-darwin.tar.gz"),
     ("linux_2_17_build", "bottom_x86_64-unknown-linux-gnu-2-17.tar.gz"),
 ]
 URL = "https://api.cirrus-ci.com/graphql"

--- a/scripts/cirrus/build.py
+++ b/scripts/cirrus/build.py
@@ -20,7 +20,7 @@ from urllib.request import Request, urlopen, urlretrieve
 
 # Form of each task is (TASK_ALIAS, FILE_NAME).
 TASKS: List[Tuple[str, str]] = [
-    ("freebsd_13_2_build", "bottom_x86_64-unknown-freebsd-13-2.tar.gz"),
+    ("freebsd_13_3_build", "bottom_x86_64-unknown-freebsd-13-3.tar.gz"),
     ("freebsd_14_0_build", "bottom_x86_64-unknown-freebsd-14-0.tar.gz"),
     ("linux_2_17_build", "bottom_x86_64-unknown-linux-gnu-2-17.tar.gz"),
 ]


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

M1 macOS runners are now available on GHA, so we can use it instead of CirrusCI for builds/CI. This should hopefully be faster and better integrated than Cirrus is.

(More info: <https://github.com/orgs/community/discussions/102846>)

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Mock nightly run: https://github.com/ClementTsang/bottom/actions/runs/8128068411

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
