### PR TITLE
ci: bump cargo-deb version to 2.1.0

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -364,7 +364,7 @@ jobs:
         env:
           BTM_GENERATE: true
         run: |
-          cargo install cargo-deb --version 1.41.3 --locked
+          cargo install cargo-deb --version 2.1.0 --locked
           cargo deb --no-build --target ${{ matrix.info.target }}
           cp ./target/${{ matrix.info.target }}/debian/bottom_*.deb .
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

The ARM versions are going to be handled by updating the images (see https://github.com/ClementTsang/cargo-deb-arm/pull/15).

Of note, technical breaking change as per the upstream `cargo-deb` repo:

> Note Since v2.0.0 the deb package version will have a "-1" suffix. You can disable this by adding --deb-revision="" flag or revision = "" in Cargo metadata. The default suffix is for compliance with Debian's packaging standard.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Mock nightly build: https://github.com/ClementTsang/bottom/actions/runs/8216472368

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
