### PR TITLE
docs: Which table goes "flags" under?

### DIFF
--- a/docs/content/configuration/config-file/flags.md
+++ b/docs/content/configuration/config-file/flags.md
@@ -4,6 +4,13 @@
 
     This section is in progress, and is just copied from the old documentation.
 
+You can configure flags by putting them in `[flags]` table. Example:
+
+```toml
+[flags]
+color = "nord-light"
+```
+
 Most of the [command line flags](../command-line-options.md) have config file equivalents to avoid having to type them out
 each time:
 


### PR DESCRIPTION
## Description

- There is currently no indication under which [table](https://toml.io/en/v1.0.0#table) do "flags" go in the config file.
- I think having that being explicitly spelled out & having an example saves quite a bit of people's time. Would for me 🙃

## Issue

- N/A, I just created a PR directly on GitHub, can spin up one if you want though.

## Testing

- N/A

## Checklist

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
