### PR TITLE
Battery table_gap patch

### DIFF
--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -196,7 +196,7 @@ impl Painter {
                 )]));
 
                 let mut battery_rows = Vec::with_capacity(3);
-                battery_rows.push(Row::new([""]).bottom_margin(table_gap * 2));
+                battery_rows.push(Row::new([""]).bottom_margin(table_gap + 1));
                 battery_rows.push(
                     Row::new(["Rate", &battery_details.watt_consumption])
                         .style(self.colours.text_style),


### PR DESCRIPTION
## Description

This changes the behavior of the battery widget when paired with the `skip_table_gap`.

## Issue

Closes: #1457

## Testing

Tested with and without the `skip_table_gap` argument, both times works as expected. I only have access to a macOS laptop so I cannot test on Windows or Linux. I'm not proficient in Rust, so I'm open to feedback. 

- [ ] _Windows_
- [x] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
