### PR TITLE
bug: fix -V not working and causing Cirrus CI to fail

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install cargo-llvm-cov
         run: |
           rustup component add llvm-tools-preview
-          cargo install cargo-llvm-cov --version 0.5.37 --locked
+          cargo install cargo-llvm-cov --version 0.6.10 --locked
 
       - name: Generate code coverage
         run: |
@@ -72,7 +72,7 @@ jobs:
 
       # The token is generally not needed, but sometimes the default shared token hits limits.
       - name: Upload to codecov.io
-        uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+        uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
         with:
           action: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # 3.1.4
           with: |

--- a/src/options/args.rs
+++ b/src/options/args.rs
@@ -564,7 +564,7 @@ pub struct OtherArgs {
     #[arg(short = 'h', long, action = ArgAction::Help, help = "Prints help info (for more details use `--help`.")]
     help: (),
 
-    #[arg(short = 'v', long, action = ArgAction::Version, help = "Prints version information.")]
+    #[arg(short = 'V', long, action = ArgAction::Version, help = "Prints version information.")]
     version: (),
 }
 
@@ -586,6 +586,18 @@ mod test {
     #[test]
     fn verify_cli() {
         build_cmd().debug_assert();
+    }
+
+    #[test]
+    fn test_version() {
+        BottomArgs::parse_from(["btm", "--version"]);
+        BottomArgs::parse_from(["btm", "-V"]);
+    }
+
+    #[test]
+    fn test_help() {
+        BottomArgs::parse_from(["btm", "--help"]);
+        BottomArgs::parse_from(["btm", "-h"]);
     }
 
     #[test]

--- a/src/options/args.rs
+++ b/src/options/args.rs
@@ -588,6 +588,7 @@ mod test {
         build_cmd().debug_assert();
     }
 
+    /// Sanity test due to <https://github.com/ClementTsang/bottom/pull/1478>.
     #[test]
     fn test_version() {
         BottomArgs::parse_from(["btm", "--version"]);

--- a/src/options/args.rs
+++ b/src/options/args.rs
@@ -588,19 +588,6 @@ mod test {
         build_cmd().debug_assert();
     }
 
-    /// Sanity test due to <https://github.com/ClementTsang/bottom/pull/1478>.
-    #[test]
-    fn test_version() {
-        BottomArgs::parse_from(["btm", "--version"]);
-        BottomArgs::parse_from(["btm", "-V"]);
-    }
-
-    #[test]
-    fn test_help() {
-        BottomArgs::parse_from(["btm", "--help"]);
-        BottomArgs::parse_from(["btm", "-h"]);
-    }
-
     #[test]
     fn no_default_help_heading() {
         let mut cmd = build_cmd();

--- a/tests/integration/arg_tests.rs
+++ b/tests/integration/arg_tests.rs
@@ -161,3 +161,17 @@ fn test_gpu_flag() {
             "unexpected argument '--enable_gpu' found",
         ));
 }
+
+/// Sanity test due to <https://github.com/ClementTsang/bottom/pull/1478>.
+#[test]
+fn test_version() {
+    btm_command(&["--version"]).assert().success();
+    btm_command(&["-V"]).assert().success();
+}
+
+/// Sanity test due to <https://github.com/ClementTsang/bottom/pull/1478>.
+#[test]
+fn test_help() {
+    btm_command(&["--help"]).assert().success();
+    btm_command(&["-h"]).assert().success();
+}


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

I used the wrong flag casing (`-V` vs `-v`) which broke Cirrus CI, which expected to run `btm -V` as a sanity check.

This fixes it and adds a test to catch it in the future.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
