### PR TITLE
change: make table headers bold by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1499](https://github.com/ClementTsang/bottom/pull/1499): Redesign how styling is configured.
 - [#1499](https://github.com/ClementTsang/bottom/pull/1499): The following arguments have changed names:
   - `--colors` is now `--theme`
+- [#1513](https://github.com/ClementTsang/bottom/pull/1513): Table headers are now bold by default.
 
 ### Bug Fixes
 

--- a/sample_configs/default_config.toml
+++ b/sample_configs/default_config.toml
@@ -138,7 +138,7 @@
 # - "nord-light".
 #
 # This will have the lowest precedence if a custom colour palette is set,
-# or overriden if the command-line flag for a built-in theme is set.
+# or overridden if the command-line flag for a built-in theme is set.
 #theme = "default"
 
 #[styles.cpu]
@@ -165,7 +165,7 @@
 #low_battery_color = "red"
 
 #[styles.tables]
-#headers = {color = "light blue"}
+#headers = {color = "light blue", bold = true}
 
 #[styles.graphs]
 #graph_color = "gray"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -402,7 +402,7 @@ pub const CONFIG_TEXT: &str = r#"# This is a default config file for bottom.  Al
 # - "nord-light".
 #
 # This will have the lowest precedence if a custom colour palette is set,
-# or overriden if the command-line flag for a built-in theme is set.
+# or overridden if the command-line flag for a built-in theme is set.
 #theme = "default"
 
 #[styles.cpu]
@@ -429,7 +429,7 @@ pub const CONFIG_TEXT: &str = r#"# This is a default config file for bottom.  Al
 #low_battery_color = "red"
 
 #[styles.tables]
-#headers = {color = "light blue"}
+#headers = {color = "light blue", bold = true}
 
 #[styles.graphs]
 #graph_color = "gray"

--- a/src/options/config/style/themes/default.rs
+++ b/src/options/config/style/themes/default.rs
@@ -1,4 +1,4 @@
-use tui::style::{Color, Style};
+use tui::style::{Color, Modifier, Style};
 
 use crate::options::config::style::ColourPalette;
 
@@ -22,7 +22,7 @@ impl ColourPalette {
 
         Self {
             selected_text_style: DEFAULT_SELECTED_TEXT_STYLE,
-            table_header_style: color!(HIGHLIGHT_COLOUR),
+            table_header_style: color!(HIGHLIGHT_COLOUR).add_modifier(Modifier::BOLD),
             ram_style: color!(FIRST_COLOUR),
             #[cfg(not(target_os = "windows"))]
             cache_style: color!(FIFTH_COLOUR),
@@ -70,7 +70,7 @@ impl ColourPalette {
     pub fn default_light_mode() -> Self {
         Self {
             selected_text_style: color!(Color::White),
-            table_header_style: color!(Color::Black),
+            table_header_style: color!(Color::Black).add_modifier(Modifier::BOLD),
             ram_style: color!(Color::Blue),
             #[cfg(not(target_os = "windows"))]
             cache_style: color!(Color::LightRed),

--- a/src/options/config/style/themes/gruvbox.rs
+++ b/src/options/config/style/themes/gruvbox.rs
@@ -1,4 +1,4 @@
-use tui::style::Color;
+use tui::style::{Color, Modifier};
 
 use crate::options::config::style::{utils::convert_hex_to_color, ColourPalette};
 
@@ -8,7 +8,7 @@ impl ColourPalette {
     pub(crate) fn gruvbox_palette() -> Self {
         Self {
             selected_text_style: hex!("#1d2021").bg(convert_hex_to_color("#ebdbb2").unwrap()),
-            table_header_style: hex!("#83a598"),
+            table_header_style: hex!("#83a598").add_modifier(Modifier::BOLD),
             ram_style: hex!("#8ec07c"),
             #[cfg(not(target_os = "windows"))]
             cache_style: hex!("#b16286"),
@@ -68,7 +68,7 @@ impl ColourPalette {
     pub(crate) fn gruvbox_light_palette() -> Self {
         Self {
             selected_text_style: hex!("#ebdbb2").bg(convert_hex_to_color("#3c3836").unwrap()),
-            table_header_style: hex!("#076678"),
+            table_header_style: hex!("#076678").add_modifier(Modifier::BOLD),
             ram_style: hex!("#427b58"),
             #[cfg(not(target_os = "windows"))]
             cache_style: hex!("#d79921"),

--- a/src/options/config/style/themes/nord.rs
+++ b/src/options/config/style/themes/nord.rs
@@ -1,4 +1,4 @@
-use tui::style::Color;
+use tui::style::{Color, Modifier};
 
 use crate::options::config::style::{utils::convert_hex_to_color, ColourPalette};
 
@@ -8,7 +8,7 @@ impl ColourPalette {
     pub(crate) fn nord_palette() -> Self {
         Self {
             selected_text_style: hex!("#2e3440").bg(convert_hex_to_color("#88c0d0").unwrap()),
-            table_header_style: hex!("#81a1c1"),
+            table_header_style: hex!("#81a1c1").add_modifier(Modifier::BOLD),
             ram_style: hex!("#88c0d0"),
             #[cfg(not(target_os = "windows"))]
             cache_style: hex!("#d8dee9"),
@@ -56,7 +56,7 @@ impl ColourPalette {
     pub(crate) fn nord_light_palette() -> Self {
         Self {
             selected_text_style: hex!("#f5f5f5").bg(convert_hex_to_color("#5e81ac").unwrap()),
-            table_header_style: hex!("#5e81ac"),
+            table_header_style: hex!("#5e81ac").add_modifier(Modifier::BOLD),
             ram_style: hex!("#81a1c1"),
             #[cfg(not(target_os = "windows"))]
             cache_style: hex!("#4c566a"),


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Makes table headers bold by default. For example:

![image](https://github.com/user-attachments/assets/3fa53688-23e8-4d88-bed6-b873bf412495)


## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
