### PR TITLE
refactor: Add the config path to the error message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use std::{
     boxed::Box,
     io::{stderr, stdout, Write},
     panic::{self, PanicInfo},
+    path::Path,
     sync::{
         mpsc::{self, Receiver, Sender},
         Arc, Condvar, Mutex,
@@ -331,8 +332,15 @@ fn main() -> anyhow::Result<()> {
     // Read from config file.
     let config = {
         let config_path = get_config_path(args.general.config_location.as_deref());
-        get_or_create_config(config_path.as_deref())
-            .context("Unable to parse or create the config file.")?
+        get_or_create_config(config_path.as_deref()).with_context(|| {
+            format!(
+                "Unable to parse or create the config file at: {}",
+                config_path
+                    .as_deref()
+                    .unwrap_or_else(|| Path::new("<failed locating>"))
+                    .display()
+            )
+        })?
     };
 
     // Create the "app" and initialize a bunch of stuff.


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Adds the resolved config path to the error message returned from failed to get or create the config file. E.g.

```console
$ rm -rf ~/.config/bottom

$ chmod -w ~/.config

$ c r
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/btm`
Error: Unable to parse or create the config file at: /home/cosmic/.config/bottom/bottom.toml

Caused by:
    Error with the config file or the arguments: Permission denied (os error 13)
```

The motivation was that I was showing `btm` to a friend, but it was failing to run on their computer due to some cursed issues on their home folder: however, the specific path that is causing an issue is missing from the message making things harder to debug

## Issue

_If applicable, what issue does this address?_

I couldn't find any existing relevant issues

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Tested using the commands listed in the description (which does wipe your existing bottom folder)

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_ **skipped**
- [x] _The pull request passes the provided CI pipeline_ **only fails from coverage which I' m counting as a pass**
- [x] _There are no merge conflicts_
- [x] _If relevant, new tests were added (don't worry too much about coverage)_ **skipped**
