### PR TITLE
bug: fix using clap macro incorrectly, causing broken long help name

### DIFF
--- a/src/options/args.rs
+++ b/src/options/args.rs
@@ -95,7 +95,7 @@ pub struct GeneralArgs {
         long,
         action = ArgAction::SetTrue,
         help = "Temporarily shows the time scale in graphs.",
-        long = "Automatically hides the time scale in graphs after being shown for a brief moment when zoomed \
+        long_help = "Automatically hides the time scale in graphs after being shown for a brief moment when zoomed \
                 in/out. If time is disabled using --hide_time then this will have no effect."
     )]
     pub autohide_time: bool,


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Basically, I did:

```
long = "blah blah blah"
```

but it should have been:

```
long,
long_help = "blah blah blah"
```

The former makes the _long help flag_ the description which... well, isn't right.

## Issue

_If applicable, what issue does this address?_

Closes: #1525

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
