### PR TITLE
bug: fix not updating sysinfo processes correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1487](https://github.com/ClementTsang/bottom/pull/1487): Add option to move the AVG CPU bar to another row in basic mode.
 
+### Bug Fixes
+
+- [#1541](https://github.com/ClementTsang/bottom/pull/1541): Fix some process details not updating for macOS and Windows.
+
 ## [0.10.1] - 2024-08-01
 
 ### Bug Fixes

--- a/src/data_collection.rs
+++ b/src/data_collection.rs
@@ -174,6 +174,10 @@ pub struct DataCollector {
 
 impl DataCollector {
     pub fn new(filters: DataFilters) -> Self {
+        // Initialize it to the past to force it to load on initialization.
+        let now = Instant::now();
+        let last_collection_time = now.checked_sub(Duration::from_secs(600)).unwrap_or(now);
+
         DataCollector {
             data: Data::default(),
             sys: SysinfoSource::default(),
@@ -186,7 +190,7 @@ impl DataCollector {
             temperature_type: TemperatureType::Celsius,
             use_current_cpu_total: false,
             unnormalized_cpu: false,
-            last_collection_time: Instant::now() - Duration::from_secs(600), /* Initialize it to the past to force it to load on initialization. */
+            last_collection_time,
             total_rx: 0,
             total_tx: 0,
             show_average_cpu: false,

--- a/src/data_collection.rs
+++ b/src/data_collection.rs
@@ -123,6 +123,7 @@ pub struct SysinfoSource {
 impl Default for SysinfoSource {
     fn default() -> Self {
         use sysinfo::*;
+
         Self {
             system: System::new_with_specifics(RefreshKind::new()),
             network: Networks::new(),
@@ -284,7 +285,12 @@ impl DataCollector {
         #[cfg(not(target_os = "linux"))]
         {
             if self.widgets_to_harvest.use_proc {
-                self.sys.system.refresh_processes();
+                self.sys.system.refresh_processes_specifics(
+                    sysinfo::ProcessRefreshKind::everything()
+                        .without_environ()
+                        .without_cwd()
+                        .without_root(),
+                );
 
                 // For Windows, sysinfo also handles the users list.
                 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Looks like I wasn't updating processes correctly for sysinfo sources. This impacted macOS and Windows at the very least.

## Issue

_If applicable, what issue does this address?_

Closes: #1538

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [x] _Windows_
- [x] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
