### PR TITLE
bug: fix occasionally wrong run time reported by sysinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - [#1541](https://github.com/ClementTsang/bottom/pull/1541): Fix some process details not updating for macOS and Windows.
+- [#1542](https://github.com/ClementTsang/bottom/pull/1542): Fix confusing process run times being reported on macOS.
 - [#1543](https://github.com/ClementTsang/bottom/pull/1543): Fix the `--default_cpu_entry` argument not being checked.
 
 ## [0.10.1] - 2024-08-01

--- a/src/data_collection/processes/unix/process_ext.rs
+++ b/src/data_collection/processes/unix/process_ext.rs
@@ -90,7 +90,16 @@ pub(crate) trait UnixProcessExt {
                             .ok()
                     })
                     .unwrap_or_else(|| "N/A".into()),
-                time: Duration::from_secs(process_val.run_time()),
+                time: if process_val.start_time() == 0 {
+                    // Workaround for sysinfo occasionally returning a start time equal to UNIX
+                    // epoch, giving a run time in the range of 50+ years. We just
+                    // return a time of zero in this case for simplicity.
+                    //
+                    // TODO: Maybe return an option instead?
+                    Duration::ZERO
+                } else {
+                    Duration::from_secs(process_val.run_time())
+                },
                 #[cfg(feature = "gpu")]
                 gpu_mem: 0,
                 #[cfg(feature = "gpu")]

--- a/src/data_collection/processes/windows.rs
+++ b/src/data_collection/processes/windows.rs
@@ -104,9 +104,11 @@ pub fn sysinfo_process_data(
                 .and_then(|uid| users.get_user_by_id(uid))
                 .map_or_else(|| "N/A".into(), |user| user.name().to_owned().into()),
             time: if process_val.start_time() == 0 {
-                // Workaround for Windows occasionally returning a start time equal to UNIX
+                // Workaround for sysinfo occasionally returning a start time equal to UNIX
                 // epoch, giving a run time in the range of 50+ years. We just
                 // return a time of zero in this case for simplicity.
+                //
+                // TODO: Maybe return an option instead?
                 Duration::ZERO
             } else {
                 Duration::from_secs(process_val.run_time())


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Seems like on other platforms, sysinfo will sometimes report a run time that starts from UNIX epoch - this gives a non-sensical value of 19000+ days, and it at least looks a little more reasonable to just return 0 in this case. I guess we can also make it return N/A in the future but this is a quick fix for now.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [x] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
