### PR TITLE
fix: missing parent section names in TOML

### DIFF
--- a/sample_configs/default_config.toml
+++ b/sample_configs/default_config.toml
@@ -93,14 +93,14 @@
 
 # Disk widget configuration
 #[disk]
-#[name_filter]
+#[disk.name_filter]
 #is_list_ignored = true
 #list = ["/dev/sda\\d+", "/dev/nvme0n1p2"]
 #regex = true
 #case_sensitive = false
 #whole_word = false
 
-#[mount_filter]
+#[disk.mount_filter]
 #is_list_ignored = true
 #list = ["/mnt/.*", "/boot"]
 #regex = true
@@ -109,7 +109,7 @@
 
 # Temperature widget configuration
 #[temperature]
-#[sensor_filter]
+#[temperature.sensor_filter]
 #is_list_ignored = true
 #list = ["cpu", "wifi"]
 #regex = false
@@ -118,7 +118,7 @@
 
 # Network widget configuration
 #[network]
-#[interface_filter]
+#[network.interface_filter]
 #is_list_ignored = true
 #list = ["virbr0.*"]
 #regex = true

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -357,14 +357,14 @@ pub const CONFIG_TEXT: &str = r#"# This is a default config file for bottom.  Al
 
 # Disk widget configuration
 #[disk]
-#[name_filter]
+#[disk.name_filter]
 #is_list_ignored = true
 #list = ["/dev/sda\\d+", "/dev/nvme0n1p2"]
 #regex = true
 #case_sensitive = false
 #whole_word = false
 
-#[mount_filter]
+#[disk.mount_filter]
 #is_list_ignored = true
 #list = ["/mnt/.*", "/boot"]
 #regex = true
@@ -373,7 +373,7 @@ pub const CONFIG_TEXT: &str = r#"# This is a default config file for bottom.  Al
 
 # Temperature widget configuration
 #[temperature]
-#[sensor_filter]
+#[temperature.sensor_filter]
 #is_list_ignored = true
 #list = ["cpu", "wifi"]
 #regex = false
@@ -382,7 +382,7 @@ pub const CONFIG_TEXT: &str = r#"# This is a default config file for bottom.  Al
 
 # Network widget configuration
 #[network]
-#[interface_filter]
+#[network.interface_filter]
 #is_list_ignored = true
 #list = ["virbr0.*"]
 #regex = true

--- a/tests/valid_configs/filtering.toml
+++ b/tests/valid_configs/filtering.toml
@@ -1,12 +1,12 @@
 [disk]
-[name_filter]
+[disk.name_filter]
 is_list_ignored = true
 list = ["/dev/sda\\d+", "/dev/nvme0n1p2"]
 regex = true
 case_sensitive = false
 whole_word = false
 
-[mount_filter]
+[disk.mount_filter]
 is_list_ignored = true
 list = ["/mnt/.*", "/boot"]
 regex = true
@@ -14,7 +14,7 @@ case_sensitive = false
 whole_word = false
 
 [temperature]
-[sensor_filter]
+[temperature.sensor_filter]
 is_list_ignored = true
 list = ["cpu", "wifi"]
 regex = false
@@ -22,7 +22,7 @@ case_sensitive = false
 whole_word = false
 
 [network]
-[interface_filter]
+[network.interface_filter]
 is_list_ignored = true
 list = ["virbr0.*"]
 regex = true


### PR DESCRIPTION
## Description

The filters didn't have their parent section names, and were parsed as top-level items.

## Issue

Filters not working.

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
