### PR TITLE
refactor: rename `flags.enable_gpu` to `flags.disable_gpu` (`false` by default)

### DIFF
--- a/schema/nightly/bottom.json
+++ b/schema/nightly/bottom.json
@@ -330,7 +330,7 @@
             "null"
           ]
         },
-        "enable_gpu": {
+        "disable_gpu": {
           "type": [
             "boolean",
             "null"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -330,8 +330,8 @@ pub(crate) const CONFIG_TEXT: &str = r#"# This is a default config file for bott
 #network_use_log = false
 # Hides advanced options to stop a process on Unix-like systems.
 #disable_advanced_kill = false
-# Shows GPU(s) information
-#enable_gpu = false
+# Hide GPU(s) information
+#disable_gpu = false
 # Shows cache and buffer memory
 #enable_cache_memory = false
 # How much data is stored at once in terms of time.

--- a/src/options.rs
+++ b/src/options.rs
@@ -806,19 +806,20 @@ fn get_use_battery(args: &BottomArgs, config: &Config) -> bool {
     false
 }
 
-#[allow(unused_variables)]
+#[cfg(feature = "gpu")]
 fn get_enable_gpu(args: &BottomArgs, config: &Config) -> bool {
-    #[cfg(feature = "gpu")]
-    {
-        if args.gpu.enable_gpu {
-            return true;
-        } else if let Some(flags) = &config.flags {
-            if let Some(enable_gpu) = flags.enable_gpu {
-                return enable_gpu;
-            }
-        }
+    if args.gpu.disable_gpu {
+        return false;
     }
+    !config
+        .flags
+        .as_ref()
+        .and_then(|f| f.disable_gpu)
+        .unwrap_or(false)
+}
 
+#[cfg(not(feature = "gpu"))]
+fn get_enable_gpu(_: &BottomArgs, _: &Config) -> bool {
     false
 }
 

--- a/src/options/args.rs
+++ b/src/options/args.rs
@@ -520,8 +520,8 @@ pub struct BatteryArgs {
 #[derive(Args, Clone, Debug, Default)]
 #[command(next_help_heading = "GPU Options", rename_all = "snake_case")]
 pub struct GpuArgs {
-    #[arg(long, action = ArgAction::SetTrue, help = "Enable collecting and displaying GPU usage.")]
-    pub enable_gpu: bool,
+    #[arg(long, action = ArgAction::SetTrue, help = "Disable collecting and displaying GPU usage.")]
+    pub disable_gpu: bool,
 }
 
 /// Style arguments/config options.

--- a/src/options/config/flags.rs
+++ b/src/options/config/flags.rs
@@ -40,7 +40,7 @@ pub(crate) struct FlagConfig {
     pub(crate) network_use_bytes: Option<bool>,
     pub(crate) network_use_log: Option<bool>,
     pub(crate) network_use_binary_prefix: Option<bool>,
-    pub(crate) enable_gpu: Option<bool>,
+    pub(crate) disable_gpu: Option<bool>,
     pub(crate) enable_cache_memory: Option<bool>,
     pub(crate) retention: Option<StringOrNum>,
     pub(crate) average_cpu_row: Option<bool>,

--- a/tests/integration/arg_tests.rs
+++ b/tests/integration/arg_tests.rs
@@ -157,11 +157,11 @@ fn test_battery_flag() {
 #[cfg_attr(feature = "gpu", ignore)]
 fn test_gpu_flag() {
     no_cfg_btm_command()
-        .arg("--enable_gpu")
+        .arg("--disable_gpu")
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "unexpected argument '--enable_gpu' found",
+            "unexpected argument '--disable_gpu' found",
         ));
 }
 


### PR DESCRIPTION
## Description

Rename `flags.enable_gpu` to `flags.disable_gpu` and make it `false` by default

Closes: #1554
