### PR TITLE
fix: avg cpu row incorrect height

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -356,8 +356,12 @@ impl Painter {
                 // This fixes #397, apparently if the height is 1, it can't render the CPU
                 // bars...
                 let cpu_height = {
-                    let c =
-                        (actual_cpu_data_len / 4) as u16 + u16::from(actual_cpu_data_len % 4 != 0);
+                    let c = (actual_cpu_data_len / 4) as u16
+                        + u16::from(actual_cpu_data_len % 4 != 0)
+                        + u16::from(
+                            app_state.app_config_fields.dedicated_average_row
+                                && actual_cpu_data_len.saturating_sub(1) % 4 != 0,
+                        );
 
                     if c <= 1 {
                         1


### PR DESCRIPTION
## Description

With the new average CPU row there's a bug where the widget wouldn't fix the height accordingly if the average gauge wasn't already on a new line, causing cores on any system core count isn't divisible by 4 to be cut off.

This is a screenshot of my 14c Macbook Pro having cores cut off before the fix.
<img width="744" alt="image" src="https://github.com/user-attachments/assets/cc1f5a17-1fa2-455e-8cbd-0d3b24be2cd0">

And here's after the fix on a 16c32t system and the same 14c mac
<img width="1497" alt="image" src="https://github.com/user-attachments/assets/387f5f81-51d1-4c79-bf84-6e4fd4f71004">

## Testing

Tested by enabling `average_cpu_row` on a system where the core count wasn't divisible by 4 to the UI bug was fixed and by doing the same on a system where the core count is divisible by 4 to ensure there's no breakage. 

- [x] _Windows_
- [x] _macOS_
- [x] _Linux_

## Checklist

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [x] _If relevant, new tests were added (don't worry too much about coverage)_
