### PR TITLE
change: default config location on macOS considers `$XDG_CONFIG_HOME`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ That said, these are more guidelines rather than hardset rules, though the proje
 ### Changes
 
 - [#1559](https://github.com/ClementTsang/bottom/pull/1559): Rename `--enable_gpu` to `--disable_gpu`, and make GPU features enabled by default.
+- [#1570](https://github.com/ClementTsang/bottom/pull/1570): Consider `$XDG_CONFIG_HOME` on macOS when looking for a default config path in a
+  backwards-compatible fashion.
 
 ## [0.10.2] - 2024-08-05
 

--- a/docs/content/configuration/config-file/index.md
+++ b/docs/content/configuration/config-file/index.md
@@ -6,11 +6,11 @@ For persistent configuration, and for certain configuration options, bottom supp
 
 If no config file argument is given, it will automatically look for a config file at these locations:
 
-| OS      | Default Config Location                                                                                                                |
-| ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| macOS   | `$HOME/Library/Application Support/bottom/bottom.toml`<br/> `~/.config/bottom/bottom.toml` <br/> `$XDG_CONFIG_HOME/bottom/bottom.toml` |
-| Linux   | `~/.config/bottom/bottom.toml` <br/> `$XDG_CONFIG_HOME/bottom/bottom.toml`                                                             |
-| Windows | `C:\Users\<USER>\AppData\Roaming\bottom\bottom.toml`                                                                                   |
+| OS      | Default Config Location                                                                                                                    |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| macOS   | `$HOME/Library/Application Support/bottom/bottom.toml`<br/> `$HOME/.config/bottom/bottom.toml` <br/> `$XDG_CONFIG_HOME/bottom/bottom.toml` |
+| Linux   | `$HOME/.config/bottom/bottom.toml` <br/> `$XDG_CONFIG_HOME/bottom/bottom.toml`                                                             |
+| Windows | `C:\Users\<USER>\AppData\Roaming\bottom\bottom.toml`                                                                                       |
 
 If the config file doesn't exist at the path, bottom will automatically try to create a new config file at the location
 with default values.

--- a/src/options.rs
+++ b/src/options.rs
@@ -1219,7 +1219,10 @@ mod test {
         use std::path::PathBuf;
 
         // Case three: no previous config, no XDG var.
-        std::env::set_var("XDG_CONFIG_HOME", "");
+        // SAFETY: this is the only test that does this
+        unsafe {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
 
         let case_1 = dirs::config_dir()
             .map(|mut path| {
@@ -1236,11 +1239,10 @@ mod test {
         case_2.push("/tmp");
         case_2.push(DEFAULT_CONFIG_FILE_PATH);
 
-        assert_eq!(get_config_path(None), Some(case_2.clone()));
+        assert_eq!(get_config_path(None), Some(case_2));
 
-        // Case one: old non-XDG exists already
-        std::env::set_var("XDG_CONFIG_HOME", "");
-        let case_3 = case_2;
-        assert_eq!(get_config_path(None), Some(case_3));
+        // Case one: old non-XDG exists already, XDG var exists.
+        // let case_3 = case_1;
+        // assert_eq!(get_config_path(None), Some(case_1));
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -1232,7 +1232,7 @@ mod test {
 
         let case_1 = dirs::config_dir()
             .map(|mut path| {
-                path.push(DEFAULT_CONFIG_FILE_PATH);
+                path.push(DEFAULT_CONFIG_FILE_LOCATION);
                 path
             })
             .unwrap();
@@ -1246,7 +1246,7 @@ mod test {
         std::env::set_var("XDG_CONFIG_HOME", "/tmp");
         let mut case_2 = PathBuf::new();
         case_2.push("/tmp");
-        case_2.push(DEFAULT_CONFIG_FILE_PATH);
+        case_2.push(DEFAULT_CONFIG_FILE_LOCATION);
 
         // Skip this test if the file already exists.
         if !case_2.exists() {

--- a/src/options/config/style.rs
+++ b/src/options/config/style.rs
@@ -231,7 +231,6 @@ mod test {
     #[test]
     fn default_selected_colour_works() {
         let mut colours = ColourPalette::default();
-        println!("colours: {colours:?}");
         let original_selected_text_colour = ColourPalette::default_palette()
             .selected_text_style
             .fg


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Actually support `$XDG_CONFIG_HOME` on macOS. Apparently in our docs we also say we do, but we, uh, don't, because `dirs` doesn't.

Note this is backwards-compatible, in that if a config file exists in the old default locations, we will check those first.

## Issue

_If applicable, what issue does this address?_

Closes: #1569 

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
