### PR TITLE
ci: try using GHA instead of Cirrus for FreeBSD in basic CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,35 +39,6 @@ env:
   CARGO_PROFILE_DEV_DEBUG: "0"
   CARGO_HUSKY_DONT_INSTALL_HOOKS: "true"
 
-test_task:
-  auto_cancellation: "false" # We set this to false to prevent nightly builds from affecting this
-  only_if: $CIRRUS_BUILD_SOURCE != "api" && ($CIRRUS_BRANCH == "main" || $CIRRUS_PR != "")
-  timeout_in: "15m"
-  skip: "!changesInclude('.cargo/**', 'sample_configs/**', 'scripts/cirrus/**', 'src/**', 'tests/**', '.cirrus.yml', 'build.rs', 'Cargo.lock', 'Cargo.toml', 'clippy.toml', 'rustfmt.toml')"
-  matrix:
-    - name: "FreeBSD 14 Test"
-      freebsd_instance:
-        image_family: freebsd-14-0
-
-    - name: "FreeBSD 13 Test"
-      freebsd_instance:
-        image_family: freebsd-13-3
-  <<: *SETUP_TEMPLATE
-  <<: *CACHE_TEMPLATE
-  test_no_feature_script:
-    - . $HOME/.cargo/env
-    - cargo fmt --all -- --check
-    - cargo test --no-run --locked --no-default-features
-    - cargo test --no-fail-fast --no-default-features -- --nocapture --quiet
-    - cargo clippy --all-targets --workspace --no-default-features -- -D warnings
-  test_all_feature_script:
-    - . $HOME/.cargo/env
-    - cargo fmt --all -- --check
-    - cargo test --no-run --locked --all-features
-    - cargo test --no-fail-fast --all-features -- --nocapture --quiet
-    - cargo clippy --all-targets --workspace --all-features -- -D warnings
-  <<: *CLEANUP_TEMPLATE
-
 release_task:
   auto_cancellation: "false"
   only_if: $CIRRUS_BUILD_SOURCE == "api" && $BTM_BUILD_RELEASE_CALLER == "ci"

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -123,7 +123,7 @@ jobs:
 
           # FreeBSD 13
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-latest",
               target: "x86_64-unknown-freebsd",
               cross: true,
             }

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -120,6 +120,13 @@ jobs:
               target: "riscv64gc-unknown-linux-gnu",
               cross: true,
             }
+
+          # FreeBSD 13
+          - {
+              os: "ubuntu-20.04",
+              target: "x86_64-unknown-freebsd",
+              cross: true,
+            }
     steps:
       - name: Checkout repository
         if: matrix.info.container == ''
@@ -271,6 +278,30 @@ jobs:
           retention-days: 3
           name: "release-build-msi"
           path: release
+
+  # build-vm:
+  #   name: "Build using VMs"
+  #   runs-on: "ubuntu-latest"
+  #   timeout-minutes: 30
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       info:
+  #         - {
+  #             type: "freebsd",
+  #             os_release: "14.1",
+  #             target: "x86_64-unknown-freebsd",
+  #           }
+  #         - {
+  #             type: "freebsd",
+  #             os_release: "13.3",
+  #             target: "x86_64-unknown-freebsd",
+  #           }
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+  #       with:
+  #         fetch-depth: 1
 
   build-cirrus:
     name: "Build using Cirrus CI"

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -121,12 +121,9 @@ jobs:
               cross: true,
             }
 
-          # FreeBSD 13
-          - {
-              os: "ubuntu-latest",
-              target: "x86_64-unknown-freebsd",
-              cross: true,
-            }
+          # Seems like cross' FreeBSD image is a bit broken? I
+          # get build errors, may be related to this issue:
+          # https://github.com/cross-rs/cross/issues/1291
     steps:
       - name: Checkout repository
         if: matrix.info.container == ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,24 @@ jobs:
           key: ${{ matrix.info.target }}
           cache-all-crates: true
 
+      - name: Test (default features)
+        uses: ClementTsang/cargo-action@v0.0.5
+        if: ${{ matrix.info.no-default-features != true }}
+        with:
+          command: test
+          args: --all-targets --workspace --target=${{ matrix.info.target }} --locked
+          use-cross: ${{ matrix.info.cross }}
+          cross-version: ${{ matrix.info.cross-version || '0.2.5' }}
+
+      - name: Test (no features enabled)
+        uses: ClementTsang/cargo-action@v0.0.5
+        if: ${{ matrix.info.no-default-features == true  }}
+        with:
+          command: test
+          args: --all-targets --workspace --target=${{ matrix.info.target }} --locked --no-default-features
+          use-cross: ${{ matrix.info.cross }}
+          cross-version: ${{ matrix.info.cross-version || '0.2.5' }}
+
       - name: Check (default features)
         uses: ClementTsang/cargo-action@v0.0.5
         if: ${{ matrix.info.no-default-features != true }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,17 +309,17 @@ jobs:
 
       - name: Test FreeBSD
         if: ${{ matrix.info.type == 'freebsd' }}
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@v1.0.8
         with:
           release: "${{ matrix.info.os_release }}"
           envs: "CARGO_INCREMENTAL CARGO_PROFILE_DEV_DEBUG CARGO_HUSKY_DONT_INSTALL_HOOKS"
+          usesh: true
           prepare: |
             pkg install -y curl bash
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup.sh
             sh rustup.sh --default-toolchain stable -y
           run: |
-            chsh -s /usr/local/bin/bash
-            . $HOME/.cargo/env
+            . "$HOME/.cargo/env"
             cargo clippy --all-targets --workspace -- -D warnings
 
   completion:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,8 +304,9 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           release: "${{ matrix.info.os_release }}"
+          envs: "CARGO_INCREMENTAL CARGO_PROFILE_DEV_DEBUG CARGO_HUSKY_DONT_INSTALL_HOOKS"
           prepare: |
-            pkg install curl -y
+            pkg install -y curl
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup.sh
             sh rustup.sh --default-toolchain stable -y
           run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
         uses: Swatinem/rust-cache@9bdad043e88c75890e36ad3bbc8d27f0090dd609 # 2.7.3
         if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }} # If it is a PR, only if not a fork
         with:
-          key: ${{ matrix.info.target }}
+          key: ${{ matrix.info.target }}-${{ matrix.info.os_release }}
           cache-all-crates: true
 
       - name: Test FreeBSD

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,7 @@ jobs:
               cross: true,
               cross-version: "git:cabfc3b02d1edec03869fabdabf6a7f8b0519160",
               no-default-features: true,
+              no-clippy: true,
             }
 
           # Seems like cross' FreeBSD image is a bit broken? I
@@ -253,11 +254,23 @@ jobs:
 
       - name: Run clippy
         uses: ClementTsang/cargo-action@v0.0.5
+        if: matrix.info.no-clippy != 'true'
         with:
           command: clippy
-          args: ${{ matrix.features }} --all-targets --workspace --target=${{ matrix.info.target }} -- -D warnings
+          args: ${{ matrix.features }} --all-targets --workspace --target=${{ matrix.info.target }} --locked
           use-cross: ${{ matrix.info.cross }}
-          cross-version: 0.2.5
+          cross-version: ${{ matrix.info.cross-version || '0.2.5' }}
+        env:
+          RUST_BACKTRACE: full
+
+      - name: Try building with only default features enabled
+        uses: ClementTsang/cargo-action@v0.0.5
+        if: matrix.info.no-clippy == 'true'
+        with:
+          command: build
+          args: ${{ matrix.features }} --all-targets --verbose --target=${{ matrix.info.target }} --locked
+          use-cross: ${{ matrix.info.cross }}
+          cross-version: ${{ matrix.info.cross-version || '0.2.5' }}
         env:
           RUST_BACKTRACE: full
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,17 +150,17 @@ jobs:
         info:
           # x86 or x86-64
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-latest",
               target: "i686-unknown-linux-gnu",
               cross: true,
             }
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-latest",
               target: "x86_64-unknown-linux-musl",
               cross: false,
             }
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-latest",
               target: "i686-unknown-linux-musl",
               cross: true,
             }
@@ -174,7 +174,7 @@ jobs:
 
           # Beta
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-latest",
               target: "x86_64-unknown-linux-gnu",
               cross: false,
               rust: "beta",
@@ -194,35 +194,35 @@ jobs:
 
           # armv7
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-latest",
               target: "armv7-unknown-linux-gnueabihf",
               cross: true,
             }
 
           # armv6
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-latest",
               target: "arm-unknown-linux-gnueabihf",
               cross: true,
             }
 
           # PowerPC 64 LE
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-latest",
               target: "powerpc64le-unknown-linux-gnu",
               cross: true,
             }
 
           # Risc-V 64gc
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-latest",
               target: "riscv64gc-unknown-linux-gnu",
               cross: true,
             }
 
           # Android ARM64
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-latest",
               target: "aarch64-linux-android",
               cross: true,
               cross-version: "git:cabfc3b02d1edec03869fabdabf6a7f8b0519160",
@@ -231,7 +231,7 @@ jobs:
 
           # FreeBSD 13
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-latest",
               target: "x86_64-unknown-freebsd",
               cross: true,
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,17 +150,17 @@ jobs:
         info:
           # x86 or x86-64
           - {
-              os: "ubuntu-latest",
+              os: "ubuntu-20.04",
               target: "i686-unknown-linux-gnu",
               cross: true,
             }
           - {
-              os: "ubuntu-latest",
+              os: "ubuntu-20.04",
               target: "x86_64-unknown-linux-musl",
               cross: false,
             }
           - {
-              os: "ubuntu-latest",
+              os: "ubuntu-20.04",
               target: "i686-unknown-linux-musl",
               cross: true,
             }
@@ -174,7 +174,7 @@ jobs:
 
           # Beta
           - {
-              os: "ubuntu-latest",
+              os: "ubuntu-20.04",
               target: "x86_64-unknown-linux-gnu",
               cross: false,
               rust: "beta",
@@ -194,41 +194,47 @@ jobs:
 
           # armv7
           - {
-              os: "ubuntu-latest",
+              os: "ubuntu-20.04",
               target: "armv7-unknown-linux-gnueabihf",
               cross: true,
             }
 
           # armv6
           - {
-              os: "ubuntu-latest",
+              os: "ubuntu-20.04",
               target: "arm-unknown-linux-gnueabihf",
               cross: true,
             }
 
           # PowerPC 64 LE
           - {
-              os: "ubuntu-latest",
+              os: "ubuntu-20.04",
               target: "powerpc64le-unknown-linux-gnu",
               cross: true,
             }
 
           # Risc-V 64gc
           - {
-              os: "ubuntu-latest",
+              os: "ubuntu-20.04",
               target: "riscv64gc-unknown-linux-gnu",
               cross: true,
             }
 
           # Android ARM64
           - {
-              os: "ubuntu-latest",
+              os: "ubuntu-20.04",
               target: "aarch64-linux-android",
               cross: true,
               cross-version: "git:cabfc3b02d1edec03869fabdabf6a7f8b0519160",
               no-default-features: true,
             }
 
+          # FreeBSD 13
+          - {
+              os: "ubuntu-20.04",
+              target: "x86_64-unknown-freebsd",
+              cross: true,
+            }
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,7 @@ jobs:
           # Seems like cross' FreeBSD image is a bit broken? I
           # get build errors, may be related to this issue:
           # https://github.com/cross-rs/cross/issues/1291
+        features: ["--all-features", "--no-default-features"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -249,27 +250,79 @@ jobs:
           key: ${{ matrix.info.target }}
           cache-all-crates: true
 
-      - name: Try building with only default features enabled
+      - name: Run clippy
         uses: ClementTsang/cargo-action@v0.0.5
-        if: ${{ matrix.info.no-default-features != true }}
         with:
-          command: build
-          args: --all-targets --verbose --target=${{ matrix.info.target }} --locked
+          command: clippy
+          args: ${{ matrix.features }} --all-targets --workspace --target=${{ matrix.info.target }} -- -D warnings
           use-cross: ${{ matrix.info.cross }}
-          cross-version: ${{ matrix.info.cross-version || '0.2.5' }}
+          cross-version: 0.2.5
+        env:
+          RUST_BACKTRACE: full
 
-      - name: Try building with no features enabled
-        uses: ClementTsang/cargo-action@v0.0.5
-        if: ${{ matrix.info.no-default-features == true  }}
+  vm-check:
+    name: "Test using VMs"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        info:
+          - {
+              type: "freebsd",
+              os_release: "14.1",
+              target: "x86_64-unknown-freebsd",
+            }
+          - {
+              type: "freebsd",
+              os_release: "13.3",
+              target: "x86_64-unknown-freebsd",
+            }
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-          command: build
-          args: --all-targets --verbose --target=${{ matrix.info.target }} --locked --no-default-features
-          use-cross: ${{ matrix.info.cross }}
-          cross-version: ${{ matrix.info.cross-version || '0.2.5' }}
+          fetch-depth: 1
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@21dc36fb71dd22e3317045c0c31a3f4249868b17
+        with:
+          toolchain: ${{ matrix.info.rust || 'stable' }}
+          target: ${{ matrix.info.target }}
+
+      - name: Enable Rust cache
+        uses: Swatinem/rust-cache@9bdad043e88c75890e36ad3bbc8d27f0090dd609 # 2.7.3
+        if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }} # If it is a PR, only if not a fork
+        with:
+          key: ${{ matrix.info.target }}
+          cache-all-crates: true
+
+      - name: Test FreeBSD
+        if: ${{ matrix.info.type == 'freebsd' }}
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: "${{ matrix.info.os_release }}"
+          prepare: |
+            pkg install curl -y
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup.sh
+            sh rustup.sh --default-toolchain stable -y
+          run: |
+            . $HOME/.cargo/env
+            cargo fmt --all -- --check
+
+            # Test with default features
+            cargo test --no-run --locked
+            cargo test --no-fail-fast -- --nocapture --quiet
+            cargo clippy --all-targets --workspace -- -D warnings
+
+            # Test with no default features
+            cargo test --no-run --locked --no-default-features
+            cargo test --no-fail-fast --no-default-features -- --nocapture --quiet
+            cargo clippy --all-targets --workspace --no-default-features -- -D warnings
 
   completion:
     name: "CI Pass Check"
-    needs: [supported, other-check]
+    needs: [supported, other-check, vm-check]
     if: ${{ always() }}
     runs-on: "ubuntu-latest"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,6 @@ jobs:
           # Seems like cross' FreeBSD image is a bit broken? I
           # get build errors, may be related to this issue:
           # https://github.com/cross-rs/cross/issues/1291
-        features: ["--all-features", "--no-default-features"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -252,27 +251,23 @@ jobs:
           key: ${{ matrix.info.target }}
           cache-all-crates: true
 
-      - name: Run clippy
+      - name: Check (default features)
         uses: ClementTsang/cargo-action@v0.0.5
-        if: matrix.info.no-clippy != 'true'
+        if: ${{ matrix.info.no-default-features != true }}
         with:
           command: clippy
-          args: ${{ matrix.features }} --all-targets --workspace --target=${{ matrix.info.target }} --locked
+          args: --all-targets --workspace --target=${{ matrix.info.target }} --locked
           use-cross: ${{ matrix.info.cross }}
           cross-version: ${{ matrix.info.cross-version || '0.2.5' }}
-        env:
-          RUST_BACKTRACE: full
 
-      - name: Try building with only default features enabled
+      - name: Check (no features enabled)
         uses: ClementTsang/cargo-action@v0.0.5
-        if: matrix.info.no-clippy == 'true'
+        if: ${{ matrix.info.no-default-features == true  }}
         with:
-          command: build
-          args: ${{ matrix.features }} --all-targets --verbose --target=${{ matrix.info.target }} --locked
+          command: clippy
+          args: --all-targets --workspace --target=${{ matrix.info.target }} --locked --no-default-features
           use-cross: ${{ matrix.info.cross }}
           cross-version: ${{ matrix.info.cross-version || '0.2.5' }}
-        env:
-          RUST_BACKTRACE: full
 
   vm-check:
     name: "Test using VMs"
@@ -319,22 +314,13 @@ jobs:
           release: "${{ matrix.info.os_release }}"
           envs: "CARGO_INCREMENTAL CARGO_PROFILE_DEV_DEBUG CARGO_HUSKY_DONT_INSTALL_HOOKS"
           prepare: |
-            pkg install -y curl
+            pkg install -y curl bash
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup.sh
             sh rustup.sh --default-toolchain stable -y
           run: |
+            chsh -s /usr/local/bin/bash
             . $HOME/.cargo/env
-            cargo fmt --all -- --check
-
-            # Test with default features
-            cargo test --no-run --locked
-            cargo test --no-fail-fast -- --nocapture --quiet
             cargo clippy --all-targets --workspace -- -D warnings
-
-            # Test with no default features
-            cargo test --no-run --locked --no-default-features
-            cargo test --no-fail-fast --no-default-features -- --nocapture --quiet
-            cargo clippy --all-targets --workspace --no-default-features -- -D warnings
 
   completion:
     name: "CI Pass Check"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,12 +229,9 @@ jobs:
               no-default-features: true,
             }
 
-          # FreeBSD 13
-          - {
-              os: "ubuntu-latest",
-              target: "x86_64-unknown-freebsd",
-              cross: true,
-            }
+          # Seems like cross' FreeBSD image is a bit broken? I
+          # get build errors, may be related to this issue:
+          # https://github.com/cross-rs/cross/issues/1291
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,7 @@ jobs:
         with:
           toolchain: ${{ matrix.info.rust || 'stable' }}
           target: ${{ matrix.info.target }}
+          components: "clippy"
 
       - name: Enable Rust cache
         uses: Swatinem/rust-cache@9bdad043e88c75890e36ad3bbc8d27f0090dd609 # 2.7.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,7 @@ jobs:
 
   vm-check:
     name: "Test using VMs"
+    needs: pre-job
     runs-on: "ubuntu-latest"
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,9 +9,10 @@ on:
   workflow_dispatch:
     inputs:
       isMock:
-        description: "Replace with any word other than 'mock' to trigger a non-mock run."
-        default: "mock"
+        description: "Mock run"
+        default: true
         required: false
+        type: boolean
 
 env:
   CARGO_INCREMENTAL: 0
@@ -43,7 +44,7 @@ jobs:
           echo "${{ github.event.inputs.isMock }}";
           if [[ -z "${{ github.event.inputs.isMock }}" ]]; then
             echo "This is a scheduled nightly run."
-          elif [[ "${{ github.event.inputs.isMock }}" == "mock" ]]; then
+          elif [[ ${{ github.event.inputs.isMock }} == true ]]; then
             echo "This is a mock run."
           else
             echo "This is NOT a mock run. Watch for the generated files!"

--- a/src/app/data_farmer.rs
+++ b/src/app/data_farmer.rs
@@ -206,6 +206,8 @@ impl DataCollection {
         self.timed_data_vec.shrink_to_fit();
     }
 
+    // Clippy allow to avoid warning on certain platforms (e.g. 32-bit).
+    #[allow(clippy::boxed_local)]
     pub fn eat_data(&mut self, harvested_data: Box<Data>) {
         let harvested_time = harvested_data.collection_time;
         let mut new_entry = TimedData::default();


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Ideally we minimize our usage of Cirrus CI, especially for typical PR CI workflows, since it's a bit cludgy to work with. This method is also more extendable to things like OpenBSD.

Fine for deploys I guess since that's not super frequent and at this point I have that working fairly well when automated + I don't usually have to wait for it.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
