### PR TITLE
fix: selected text bg in default-light theme

### DIFF
--- a/src/options/config/style/themes/default.rs
+++ b/src/options/config/style/themes/default.rs
@@ -69,7 +69,7 @@ impl ColourPalette {
 
     pub fn default_light_mode() -> Self {
         Self {
-            selected_text_style: color!(Color::White),
+            selected_text_style: color!(Color::White).bg(Color::LightBlue),
             table_header_style: color!(Color::Black).add_modifier(Modifier::BOLD),
             ram_style: color!(Color::Blue),
             #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Description

This change fixes a regression in `btm --theme default-light`. Currently, `selected_text_style` is `White` with no background, which causes the text to be borderline unreadable in a white background terminal (see below).

![image](https://github.com/user-attachments/assets/f4883ebe-4860-4289-a697-41737f7a1c09)

This change adds back the `LightBlue` background that was present before the theming changes introduced in https://github.com/ClementTsang/bottom/pull/1499.

![image](https://github.com/user-attachments/assets/141fdd00-4708-4738-b3f2-0716045cb82f)

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
