### PR TITLE
Update reference to "--color" to say "--theme" instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <img src="assets/demo.gif" alt="Quick demo recording showing off bottom's searching, expanding, and process killing."/>
   <p>
     <sub>
-      Demo using the <a href="https://github.com/morhetz/gruvbox">Gruvbox</a> theme (<code>--color gruvbox</code>), along with <a href="https://www.ibm.com/plex/">IBM Plex Mono</a> and <a href="https://sw.kovidgoyal.net/kitty/">Kitty</a>
+      Demo using the <a href="https://github.com/morhetz/gruvbox">Gruvbox</a> theme (<code>--theme gruvbox</code>), along with <a href="https://www.ibm.com/plex/">IBM Plex Mono</a> and <a href="https://sw.kovidgoyal.net/kitty/">Kitty</a>
     </sub>
   </p>
 </div>


### PR DESCRIPTION
## Description

As per [the changelog](https://github.com/ClementTsang/bottom/blob/d20dc49c95e085dd2ba3aa2b699c5a830ea9753a/CHANGELOG.md?plain=1#L90), `--color` was replaced by `--theme`. This updates the screenshot comment in the README to reflect this change.
