### PR TITLE
bug: fix using 'none' for chart legend position in configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ That said, these are more guidelines rather than hardset rules, though the proje
 - [#1551](https://github.com/ClementTsang/bottom/pull/1551): Fix missing parent section names in default config.
 - [#1552](https://github.com/ClementTsang/bottom/pull/1552): Fix typo in default config.
 - [#1578](https://github.com/ClementTsang/bottom/pull/1578): Fix missing selected text background colour in `default-light` theme.
+- [#1593](https://github.com/ClementTsang/bottom/pull/1593): Fix using `"none"` for chart legend position in configs.
 
 ### Changes
 

--- a/src/canvas/components/tui_widget/time_chart.rs
+++ b/src/canvas/components/tui_widget/time_chart.rs
@@ -223,7 +223,7 @@ impl FromStr for LegendPosition {
     type Err = ParseLegendPositionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
+        match s {
             "top" => Ok(Self::Top),
             "top-left" => Ok(Self::TopLeft),
             "top-right" => Ok(Self::TopRight),

--- a/src/options.rs
+++ b/src/options.rs
@@ -984,8 +984,11 @@ fn get_memory_legend_position(
             position => Some(parse_config_value!(position.parse(), "memory_legend")?),
         }
     } else if let Some(flags) = &config.flags {
-        if let Some(legend) = &flags.memory_legend {
-            Some(parse_arg_value!(legend.parse(), "memory_legend")?)
+        if let Some(s) = &flags.memory_legend {
+            match s.to_ascii_lowercase().trim() {
+                "none" => None,
+                position => Some(parse_arg_value!(position.parse(), "memory_legend")?),
+            }
         } else {
             Some(LegendPosition::default())
         }

--- a/src/options.rs
+++ b/src/options.rs
@@ -960,8 +960,11 @@ fn get_network_legend_position(
             position => Some(parse_config_value!(position.parse(), "network_legend")?),
         }
     } else if let Some(flags) = &config.flags {
-        if let Some(legend) = &flags.network_legend {
-            Some(parse_arg_value!(legend.parse(), "network_legend")?)
+        if let Some(s) = &flags.network_legend {
+            match s.to_ascii_lowercase().trim() {
+                "none" => None,
+                position => Some(parse_arg_value!(position.parse(), "network_legend")?),
+            }
         } else {
             Some(LegendPosition::default())
         }


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Parse `"none"` when checking legend position in configs. This was being done in args but not config for whatever reason.

## Issue

_If applicable, what issue does this address?_

Closes: #1591

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
