### PR TITLE
bug: fix support for nilfs2 file system

### DIFF
--- a/src/data_collection/disks/unix/file_systems.rs
+++ b/src/data_collection/disks/unix/file_systems.rs
@@ -157,7 +157,7 @@ impl FromStr for FileSystem {
             FileSystem::Bcachefs
         } else if s.eq_ignore_ascii_case("minix") {
             FileSystem::Minix
-        } else if s.eq_ignore_ascii_case("nilfs") {
+        } else if multi_eq_ignore_ascii_case!(s, "nilfs" | "nilfs2") {
             FileSystem::Nilfs
         } else if s.eq_ignore_ascii_case("xfs") {
             FileSystem::Xfs


### PR DESCRIPTION
## Description

Fix the problem that the nilfs2 file system partition is not displayed in the disk list.

## Issue

Related discussions: #1595

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_
![2024-09-13-05:30:19-w](https://github.com/user-attachments/assets/777d7318-e93e-4885-ac4b-8f38a823f718)


_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
