### PR TITLE
refactor: bump 'msrv' to 1.81 and update deprecated code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ exclude = [
     "rustfmt.toml",
 ]
 # The oldest version I've tested that should still build - note this is not an official MSRV!
-rust-version = "1.74.0"
+rust-version = "1.81.0"
 
 [[bin]]
 name = "btm"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[path = "src/options/args.rs"]
 mod args;
 

--- a/src/app/data_farmer.rs
+++ b/src/app/data_farmer.rs
@@ -206,8 +206,10 @@ impl DataCollection {
         self.timed_data_vec.shrink_to_fit();
     }
 
-    // Clippy allow to avoid warning on certain platforms (e.g. 32-bit).
-    #[allow(clippy::boxed_local)]
+    #[allow(
+        clippy::boxed_local,
+        reason = "Clippy allow to avoid warning on certain platforms (e.g. 32-bit)."
+    )]
     pub fn eat_data(&mut self, harvested_data: Box<Data>) {
         let harvested_time = harvested_data.collection_time;
         let mut new_entry = TimedData::default();

--- a/src/app/layout_manager.rs
+++ b/src/app/layout_manager.rs
@@ -19,7 +19,7 @@ type ColumnMappings = (u32, BTreeMap<LineSegment, ColumnRowMappings>);
 
 impl BottomLayout {
     pub fn get_movement_mappings(&mut self) {
-        #[allow(clippy::suspicious_operation_groupings)] // Have to enable this, clippy really doesn't like me doing this with tuples...
+        #[expect(clippy::suspicious_operation_groupings)] // Have to enable this, clippy really doesn't like me doing this with tuples...
         fn is_intersecting(a: LineSegment, b: LineSegment) -> bool {
             a.0 >= b.0 && a.1 <= b.1
                 || a.1 >= b.1 && a.0 <= b.0

--- a/src/canvas/components/data_table.rs
+++ b/src/canvas/components/data_table.rs
@@ -126,7 +126,7 @@ impl<DataType: DataToCell<H>, H: ColumnHeader, S: SortType, C: DataTableColumn<H
     }
 
     /// Updates the scroll position to a selected index.
-    #[allow(clippy::comparison_chain)]
+    #[expect(clippy::comparison_chain)]
     pub fn set_position(&mut self, new_index: usize) {
         let new_index = new_index.clamp_upper(self.data.len().saturating_sub(1));
         if self.state.current_index < new_index {

--- a/src/data_collection/disks/freebsd.rs
+++ b/src/data_collection/disks/freebsd.rs
@@ -29,7 +29,6 @@ struct FileSystem {
 pub fn get_io_usage() -> CollectionResult<IoHarvest> {
     // TODO: Should this (and other I/O collectors) fail fast? In general, should
     // collection ever fail fast?
-    #[expect(unused_mut)]
     let mut io_harvest: HashMap<String, Option<IoData>> =
         get_disk_info().map(|storage_system_information| {
             storage_system_information

--- a/src/data_collection/disks/freebsd.rs
+++ b/src/data_collection/disks/freebsd.rs
@@ -29,7 +29,7 @@ struct FileSystem {
 pub fn get_io_usage() -> CollectionResult<IoHarvest> {
     // TODO: Should this (and other I/O collectors) fail fast? In general, should
     // collection ever fail fast?
-    #[allow(unused_mut)]
+    #[expect(unused_mut)]
     let mut io_harvest: HashMap<String, Option<IoData>> =
         get_disk_info().map(|storage_system_information| {
             storage_system_information

--- a/src/data_collection/disks/unix/file_systems.rs
+++ b/src/data_collection/disks/unix/file_systems.rs
@@ -88,7 +88,7 @@ impl FileSystem {
         matches!(self, FileSystem::Other(..))
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     #[inline]
     /// Returns a string literal identifying this filesystem.
     pub fn as_str(&self) -> &str {

--- a/src/data_collection/disks/unix/linux/partition.rs
+++ b/src/data_collection/disks/unix/linux/partition.rs
@@ -138,7 +138,7 @@ impl FromStr for Partition {
     }
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 /// Returns a [`Vec`] containing all partitions.
 pub(crate) fn partitions() -> anyhow::Result<Vec<Partition>> {
     const PROC_MOUNTS: &str = "/proc/mounts";

--- a/src/data_collection/disks/unix/macos/io_kit/bindings.rs
+++ b/src/data_collection/disks/unix/macos/io_kit/bindings.rs
@@ -12,24 +12,24 @@ use core_foundation::{
 use libc::c_char;
 use mach2::{kern_return::kern_return_t, port::MACH_PORT_NULL};
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub type io_object_t = mach_port_t;
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub type io_iterator_t = io_object_t;
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub type io_registry_entry_t = io_object_t;
 
 pub type IOOptionBits = u32;
 
 /// See https://github.com/1kc/librazermacos/pull/27#issuecomment-1042368531.
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 pub const kIOMasterPortDefault: mach_port_t = MACH_PORT_NULL;
 
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 pub const kIOServicePlane: &str = "IOService\0";
 
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 pub const kIOMediaClass: &str = "IOMedia\0";
 
 // See [here](https://developer.apple.com/documentation/iokit) for more details.

--- a/src/data_collection/disks/unix/other/partition.rs
+++ b/src/data_collection/disks/unix/other/partition.rs
@@ -84,7 +84,7 @@ fn partitions_iter() -> anyhow::Result<impl Iterator<Item = Partition>> {
     }))
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 /// Returns a [`Vec`] containing all partitions.
 pub(crate) fn partitions() -> anyhow::Result<Vec<Partition>> {
     partitions_iter().map(|iter| iter.collect())

--- a/src/data_collection/disks/unix/usage.rs
+++ b/src/data_collection/disks/unix/usage.rs
@@ -2,7 +2,7 @@ pub struct Usage(libc::statvfs);
 
 // Note that x86 returns `u32` values while x86-64 returns `u64`s, so we convert
 // everything to `u64` for consistency.
-#[allow(clippy::useless_conversion)]
+#[expect(clippy::useless_conversion)]
 impl Usage {
     pub(crate) fn new(vfs: libc::statvfs) -> Self {
         Self(vfs)
@@ -19,7 +19,7 @@ impl Usage {
         u64::from(self.0.f_bfree) * u64::from(self.0.f_frsize)
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     /// Returns the total number of bytes used. Equal to `total - available` on
     /// Unix.
     pub fn used(&self) -> u64 {

--- a/src/data_collection/processes/linux.rs
+++ b/src/data_collection/processes/linux.rs
@@ -360,7 +360,6 @@ pub(crate) fn linux_process_data(
                 let pid = process.pid;
                 let prev_proc_details = pid_mapping.entry(pid).or_default();
 
-                #[allow(unused_mut)]
                 if let Ok((mut process_harvest, new_process_times)) =
                     read_proc(prev_proc_details, process, args, user_table)
                 {

--- a/src/data_collection/processes/linux.rs
+++ b/src/data_collection/processes/linux.rs
@@ -360,6 +360,7 @@ pub(crate) fn linux_process_data(
                 let pid = process.pid;
                 let prev_proc_details = pid_mapping.entry(pid).or_default();
 
+                #[cfg_attr(not(feature = "gpu"), expect(unused_mut))]
                 if let Ok((mut process_harvest, new_process_times)) =
                     read_proc(prev_proc_details, process, args, user_table)
                 {

--- a/src/data_collection/processes/macos/sysctl_bindings.rs
+++ b/src/data_collection/processes/macos/sysctl_bindings.rs
@@ -12,14 +12,12 @@ use mach2::vm_types::user_addr_t;
 
 use crate::data_collection::Pid;
 
-#[expect(non_camel_case_types)]
 #[repr(C)]
 pub(crate) struct kinfo_proc {
     pub kp_proc: extern_proc,
     pub kp_eproc: eproc,
 }
 
-#[expect(non_camel_case_types)]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct p_st1 {
@@ -28,7 +26,6 @@ pub struct p_st1 {
     p_back: user_addr_t,
 }
 
-#[expect(non_camel_case_types)]
 #[repr(C)]
 pub union p_un {
     pub p_st1: p_st1,
@@ -39,7 +36,6 @@ pub union p_un {
 
 /// Exported fields for kern sysctl. See
 /// [`proc.h`](https://opensource.apple.com/source/xnu/xnu-201/bsd/sys/proc.h)
-#[expect(non_camel_case_types)]
 #[repr(C)]
 pub(crate) struct extern_proc {
     pub p_un: p_un,
@@ -182,7 +178,6 @@ type segsz_t = i32;
 type fixpt_t = u32;
 
 /// See [`proc.h`](https://opensource.apple.com/source/xnu/xnu-201/bsd/sys/proc.h)
-#[expect(non_camel_case_types)]
 #[repr(C)]
 pub(crate) struct pcred {
     pub pc_lock: [c_char; 72],
@@ -195,7 +190,6 @@ pub(crate) struct pcred {
 }
 
 /// See `vm.h`.
-#[expect(non_camel_case_types)]
 #[repr(C)]
 pub(crate) struct vmspace {
     pub dummy: i32,
@@ -205,7 +199,6 @@ pub(crate) struct vmspace {
 }
 
 /// See [`sysctl.h`](https://opensource.apple.com/source/xnu/xnu-344/bsd/sys/sysctl.h).
-#[expect(non_camel_case_types)]
 #[repr(C)]
 pub(crate) struct eproc {
     /// Address of proc. We just cheat and use a c_void pointer since we aren't

--- a/src/data_collection/processes/macos/sysctl_bindings.rs
+++ b/src/data_collection/processes/macos/sysctl_bindings.rs
@@ -12,14 +12,14 @@ use mach2::vm_types::user_addr_t;
 
 use crate::data_collection::Pid;
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 #[repr(C)]
 pub(crate) struct kinfo_proc {
     pub kp_proc: extern_proc,
     pub kp_eproc: eproc,
 }
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct p_st1 {
@@ -28,7 +28,7 @@ pub struct p_st1 {
     p_back: user_addr_t,
 }
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 #[repr(C)]
 pub union p_un {
     pub p_st1: p_st1,
@@ -39,7 +39,7 @@ pub union p_un {
 
 /// Exported fields for kern sysctl. See
 /// [`proc.h`](https://opensource.apple.com/source/xnu/xnu-201/bsd/sys/proc.h)
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 #[repr(C)]
 pub(crate) struct extern_proc {
     pub p_un: p_un,
@@ -170,19 +170,19 @@ const WMESGLEN: usize = 7;
 const COMAPT_MAXLOGNAME: usize = 12;
 
 /// See `_caddr_t.h`.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 type caddr_t = *const libc::c_char;
 
 /// See `types.h`.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 type segsz_t = i32;
 
 /// See `types.h`.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 type fixpt_t = u32;
 
 /// See [`proc.h`](https://opensource.apple.com/source/xnu/xnu-201/bsd/sys/proc.h)
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 #[repr(C)]
 pub(crate) struct pcred {
     pub pc_lock: [c_char; 72],
@@ -195,7 +195,7 @@ pub(crate) struct pcred {
 }
 
 /// See `vm.h`.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 #[repr(C)]
 pub(crate) struct vmspace {
     pub dummy: i32,
@@ -205,7 +205,7 @@ pub(crate) struct vmspace {
 }
 
 /// See [`sysctl.h`](https://opensource.apple.com/source/xnu/xnu-344/bsd/sys/sysctl.h).
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 #[repr(C)]
 pub(crate) struct eproc {
     /// Address of proc. We just cheat and use a c_void pointer since we aren't

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,11 +24,10 @@ pub mod event;
 pub mod options;
 pub mod widgets;
 
-#[allow(deprecated)]
-use std::panic::{self, PanicInfo};
 use std::{
     boxed::Box,
     io::{stderr, stdout, Write},
+    panic::{self, PanicHookInfo},
     sync::{
         mpsc::{self, Receiver, Sender},
         Arc,
@@ -52,7 +51,7 @@ use event::{handle_key_event_or_break, handle_mouse_event, BottomEvent, Collecti
 use options::{args, get_or_create_config, init_app};
 use tui::{backend::CrosstermBackend, Terminal};
 use utils::cancellation_token::CancellationToken;
-#[allow(unused_imports)]
+#[allow(unused_imports, reason = "this is needed if logging is enabled")]
 use utils::logging::*;
 
 // Used for heap allocation debugging purposes.
@@ -104,8 +103,7 @@ fn check_if_terminal() {
 
 /// A panic hook to properly restore the terminal in the case of a panic.
 /// Originally based on [spotify-tui's implementation](https://github.com/Rigellute/spotify-tui/blob/master/src/main.rs).
-#[allow(deprecated)]
-fn panic_hook(panic_info: &PanicInfo<'_>) {
+fn panic_hook(panic_info: &PanicHookInfo<'_>) {
     let mut stdout = stdout();
 
     let msg = match panic_info.payload().downcast_ref::<&'static str>() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,10 +24,11 @@ pub mod event;
 pub mod options;
 pub mod widgets;
 
+#[allow(deprecated)]
+use std::panic::{self, PanicInfo};
 use std::{
     boxed::Box,
     io::{stderr, stdout, Write},
-    panic::{self, PanicInfo},
     sync::{
         mpsc::{self, Receiver, Sender},
         Arc,
@@ -103,6 +104,7 @@ fn check_if_terminal() {
 
 /// A panic hook to properly restore the terminal in the case of a panic.
 /// Originally based on [spotify-tui's implementation](https://github.com/Rigellute/spotify-tui/blob/master/src/main.rs).
+#[allow(deprecated)]
 fn panic_hook(panic_info: &PanicInfo<'_>) {
     let mut stdout = stdout();
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -857,18 +857,21 @@ fn get_enable_gpu(_: &BottomArgs, _: &Config) -> bool {
     false
 }
 
+#[cfg(not(target_os = "windows"))]
 fn get_enable_cache_memory(args: &BottomArgs, config: &Config) -> bool {
-    #[cfg(not(target_os = "windows"))]
-    {
-        if args.memory.enable_cache_memory {
-            return true;
-        } else if let Some(flags) = &config.flags {
-            if let Some(enable_cache_memory) = flags.enable_cache_memory {
-                return enable_cache_memory;
-            }
+    if args.memory.enable_cache_memory {
+        return true;
+    } else if let Some(flags) = &config.flags {
+        if let Some(enable_cache_memory) = flags.enable_cache_memory {
+            return enable_cache_memory;
         }
     }
 
+    false
+}
+
+#[cfg(target_os = "windows")]
+fn get_enable_cache_memory(_args: &BottomArgs, _config: &Config) -> bool {
     false
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -811,28 +811,31 @@ fn get_default_widget_and_count(
     }
 }
 
+#[cfg(feature = "battery")]
 fn get_use_battery(args: &BottomArgs, config: &Config) -> bool {
-    #[cfg(feature = "battery")]
-    {
-        // TODO: Move this so it's dynamic in the app itself and automatically hide if
-        // there are no batteries?
-        if let Ok(battery_manager) = Manager::new() {
-            if let Ok(batteries) = battery_manager.batteries() {
-                if batteries.count() == 0 {
-                    return false;
-                }
-            }
-        }
-
-        if args.battery.battery {
-            return true;
-        } else if let Some(flags) = &config.flags {
-            if let Some(battery) = flags.battery {
-                return battery;
+    // TODO: Move this so it's dynamic in the app itself and automatically hide if
+    // there are no batteries?
+    if let Ok(battery_manager) = Manager::new() {
+        if let Ok(batteries) = battery_manager.batteries() {
+            if batteries.count() == 0 {
+                return false;
             }
         }
     }
 
+    if args.battery.battery {
+        return true;
+    } else if let Some(flags) = &config.flags {
+        if let Some(battery) = flags.battery {
+            return battery;
+        }
+    }
+
+    false
+}
+
+#[cfg(not(feature = "battery"))]
+fn get_use_battery(_args: &BottomArgs, _config: &Config) -> bool {
     false
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -811,7 +811,6 @@ fn get_default_widget_and_count(
     }
 }
 
-#[allow(unused_variables)]
 fn get_use_battery(args: &BottomArgs, config: &Config) -> bool {
     #[cfg(feature = "battery")]
     {
@@ -855,7 +854,6 @@ fn get_enable_gpu(_: &BottomArgs, _: &Config) -> bool {
     false
 }
 
-#[allow(unused_variables)]
 fn get_enable_cache_memory(args: &BottomArgs, config: &Config) -> bool {
     #[cfg(not(target_os = "windows"))]
     {


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

A simple PR that bumps the unofficial MSRV to 1.81. This allows us to update some std code usage that is deprecated and use `expect` to replace `allow` for lints, which also caught some bad `allow` usages.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
