### PR TITLE
deps: bump to ratatui 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
  "clap_mangen",
  "concat-string",
  "core-foundation",
- "crossterm",
+ "crossterm 0.27.0",
  "ctrlc",
  "dirs",
  "fern",
@@ -331,13 +331,14 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "compact_str"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
 dependencies = [
  "castaway",
  "cfg-if",
  "itoa",
+ "rustversion",
  "ryu",
  "static_assertions",
 ]
@@ -398,8 +399,24 @@ dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
  "libc",
- "mio",
+ "mio 0.8.11",
  "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm_winapi",
+ "mio 1.0.2",
+ "parking_lot",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -629,6 +646,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +678,16 @@ name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
+name = "instability"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "ioctl-rs"
@@ -798,6 +831,19 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1043,18 +1089,18 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16546c5b5962abf8ce6e2881e722b4e0ae3b6f1a08a26ae3573c55853ca68d3"
+checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
 dependencies = [
  "bitflags 2.6.0",
  "cassowary",
  "compact_str",
- "crossterm",
+ "crossterm 0.28.1",
+ "instability",
  "itertools",
  "lru",
  "paste",
- "stability",
  "strum",
  "strum_macros",
  "unicode-segmentation",
@@ -1334,7 +1380,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
+ "mio 1.0.2",
  "signal-hook",
 ]
 
@@ -1352,16 +1399,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "stability"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
-dependencies = [
- "quote",
- "syn",
-]
 
 [[package]]
 name = "starship-battery"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
  "clap_mangen",
  "concat-string",
  "core-foundation",
- "crossterm 0.27.0",
+ "crossterm",
  "ctrlc",
  "dirs",
  "fern",
@@ -392,29 +392,13 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
-dependencies = [
- "bitflags 2.6.0",
- "crossterm_winapi",
- "libc",
- "mio 0.8.11",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
- "mio 1.0.2",
+ "mio",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -823,18 +807,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
@@ -1096,7 +1068,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cassowary",
  "compact_str",
- "crossterm 0.28.1",
+ "crossterm",
  "instability",
  "itertools",
  "lru",
@@ -1380,8 +1352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio 0.8.11",
- "mio 1.0.2",
+ "mio",
  "signal-hook",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ backtrace = "0.3.74"
 cfg-if = "1.0.0"
 clap = { version = "4.5.20", features = ["default", "cargo", "wrap_help", "derive"] }
 concat-string = "1.0.1"
-crossterm = "0.27.0"
+crossterm = "0.28.1"
 ctrlc = { version = "3.4.5", features = ["termination"] }
 dirs = "5.0.1"
 # Maybe consider https://github.com/rust-lang/rustc-hash for some cases too?
@@ -97,7 +97,7 @@ serde = { version = "1.0.214", features = ["derive"] }
 starship-battery = { version = "0.10.0", optional = true }
 sysinfo = "=0.30.13"
 toml_edit = { version = "0.22.22", features = ["serde"] }
-tui = { version = "0.27.0", package = "ratatui" }
+tui = { version = "0.28.1", package = "ratatui" }
 unicode-ellipsis = "0.2.0"
 unicode-segmentation = "1.12.0"
 unicode-width = "0.2.0"

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -178,10 +178,10 @@ impl Painter {
                 // TODO: Remove built-in cache?
                 let split_loc = Layout::default()
                     .constraints([Constraint::Min(0), Constraint::Length(1)])
-                    .split(f.size());
+                    .split(f.area());
                 (split_loc[0], Some(split_loc[1]))
             } else {
-                (f.size(), None)
+                (f.area(), None)
             };
             let terminal_height = terminal_size.height;
             let terminal_width = terminal_size.width;

--- a/src/canvas/components/tui_widget/pipe_gauge.rs
+++ b/src/canvas/components/tui_widget/pipe_gauge.rs
@@ -203,13 +203,15 @@ impl<'a> Widget for PipeGauge<'a> {
                 let pipe_end =
                     start + (f64::from(end.saturating_sub(start)) * self.ratio).floor() as u16;
                 for col in start..pipe_end {
-                    buf.get_mut(col, row).set_symbol("|").set_style(Style {
-                        fg: self.gauge_style.fg,
-                        bg: None,
-                        add_modifier: self.gauge_style.add_modifier,
-                        sub_modifier: self.gauge_style.sub_modifier,
-                        underline_color: None,
-                    });
+                    if let Some(cell) = buf.cell_mut((col, row)) {
+                        cell.set_symbol("|").set_style(Style {
+                            fg: self.gauge_style.fg,
+                            bg: None,
+                            add_modifier: self.gauge_style.add_modifier,
+                            sub_modifier: self.gauge_style.sub_modifier,
+                            underline_color: None,
+                        });
+                    }
                 }
 
                 if (end_label.width() as u16) < end.saturating_sub(start) {

--- a/src/canvas/components/tui_widget/time_chart.rs
+++ b/src/canvas/components/tui_widget/time_chart.rs
@@ -723,7 +723,10 @@ impl Widget for TimeChart<'_> {
         // Sample the style of the entire widget. This sample will be used to reset the
         // style of the cells that are part of the components put on top of the
         // grah area (i.e legend and axis names).
-        let original_style = buf.get(area.left(), area.top()).style();
+        let Some(original_style) = buf.cell((area.left(), area.top())).map(|cell| cell.style())
+        else {
+            return;
+        };
 
         let layout = self.layout(chart_area);
         let graph_area = layout.graph_area;
@@ -736,25 +739,28 @@ impl Widget for TimeChart<'_> {
 
         if let Some(y) = layout.axis_x {
             for x in graph_area.left()..graph_area.right() {
-                buf.get_mut(x, y)
-                    .set_symbol(symbols::line::HORIZONTAL)
-                    .set_style(self.x_axis.style);
+                if let Some(cell) = buf.cell_mut((x, y)) {
+                    cell.set_symbol(symbols::line::HORIZONTAL)
+                        .set_style(self.x_axis.style);
+                }
             }
         }
 
         if let Some(x) = layout.axis_y {
             for y in graph_area.top()..graph_area.bottom() {
-                buf.get_mut(x, y)
-                    .set_symbol(symbols::line::VERTICAL)
-                    .set_style(self.y_axis.style);
+                if let Some(cell) = buf.cell_mut((x, y)) {
+                    cell.set_symbol(symbols::line::VERTICAL)
+                        .set_style(self.y_axis.style);
+                }
             }
         }
 
         if let Some(y) = layout.axis_x {
             if let Some(x) = layout.axis_y {
-                buf.get_mut(x, y)
-                    .set_symbol(symbols::line::BOTTOM_LEFT)
-                    .set_style(self.x_axis.style);
+                if let Some(cell) = buf.cell_mut((x, y)) {
+                    cell.set_symbol(symbols::line::BOTTOM_LEFT)
+                        .set_style(self.x_axis.style);
+                }
             }
         }
 
@@ -892,7 +898,7 @@ mod tests {
                             .iter()
                             .enumerate()
                             .map(|(i, (x, y, cell))| {
-                                let expected_cell = expected.get(*x, *y);
+                                let expected_cell = expected.cell((*x, *y)).unwrap();
                                 indoc::formatdoc! {"
                                     {i}: at ({x}, {y})
                                       expected: {expected_cell:?}

--- a/src/canvas/components/tui_widget/time_chart/canvas.rs
+++ b/src/canvas/components/tui_widget/time_chart/canvas.rs
@@ -639,10 +639,11 @@ where
         {
             if ch != ' ' && ch != '\u{2800}' {
                 let (x, y) = (i % width, i / width);
-                buf.get_mut(x as u16 + canvas_area.left(), y as u16 + canvas_area.top())
-                    .set_char(ch)
-                    .set_fg(fg)
-                    .set_bg(bg);
+                if let Some(cell) =
+                    buf.cell_mut((x as u16 + canvas_area.left(), y as u16 + canvas_area.top()))
+                {
+                    cell.set_char(ch).set_fg(fg).set_bg(bg);
+                }
             }
         }
 

--- a/src/canvas/components/widget_carousel.rs
+++ b/src/canvas/components/widget_carousel.rs
@@ -1,8 +1,8 @@
 use tui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    terminal::Frame,
     text::{Line, Span},
     widgets::{Block, Paragraph},
+    Frame,
 };
 
 use crate::{

--- a/src/canvas/dialogs/dd_dialog.rs
+++ b/src/canvas/dialogs/dd_dialog.rs
@@ -3,9 +3,9 @@ use std::cmp::min;
 
 use tui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    terminal::Frame,
     text::{Line, Span, Text},
     widgets::{Block, Borders, Paragraph, Wrap},
+    Frame,
 };
 
 use crate::{

--- a/src/canvas/dialogs/help_dialog.rs
+++ b/src/canvas/dialogs/help_dialog.rs
@@ -2,9 +2,9 @@ use std::cmp::{max, min};
 
 use tui::{
     layout::{Alignment, Rect},
-    terminal::Frame,
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
+    Frame,
 };
 use unicode_width::UnicodeWidthStr;
 

--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -1,8 +1,8 @@
 use tui::{
     layout::{Constraint, Direction, Layout, Rect},
-    terminal::Frame,
     text::{Line, Span},
     widgets::{Block, Borders, Cell, Paragraph, Row, Table, Tabs},
+    Frame,
 };
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -2,8 +2,8 @@ use std::cmp::min;
 
 use tui::{
     layout::{Constraint, Direction, Layout, Rect},
-    terminal::Frame,
     widgets::Block,
+    Frame,
 };
 
 use crate::{

--- a/src/canvas/widgets/cpu_graph.rs
+++ b/src/canvas/widgets/cpu_graph.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use tui::{
     layout::{Constraint, Direction, Layout, Rect},
     symbols::Marker,
-    terminal::Frame,
+    Frame,
 };
 
 use crate::{

--- a/src/canvas/widgets/disk_table.rs
+++ b/src/canvas/widgets/disk_table.rs
@@ -1,4 +1,4 @@
-use tui::{layout::Rect, terminal::Frame};
+use tui::{layout::Rect, Frame};
 
 use crate::{
     app,

--- a/src/canvas/widgets/mem_basic.rs
+++ b/src/canvas/widgets/mem_basic.rs
@@ -1,7 +1,7 @@
 use tui::{
     layout::{Constraint, Direction, Layout, Rect},
-    terminal::Frame,
     widgets::Block,
+    Frame,
 };
 
 use crate::{

--- a/src/canvas/widgets/mem_graph.rs
+++ b/src/canvas/widgets/mem_graph.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use tui::{
     layout::{Constraint, Rect},
     symbols::Marker,
-    terminal::Frame,
+    Frame,
 };
 
 use crate::{

--- a/src/canvas/widgets/network_basic.rs
+++ b/src/canvas/widgets/network_basic.rs
@@ -1,8 +1,8 @@
 use tui::{
     layout::{Constraint, Direction, Layout, Rect},
-    terminal::Frame,
     text::{Line, Span},
     widgets::{Block, Paragraph},
+    Frame,
 };
 
 use crate::{app::App, canvas::Painter, constants::*};

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -1,9 +1,9 @@
 use tui::{
     layout::{Constraint, Direction, Layout, Rect},
     symbols::Marker,
-    terminal::Frame,
     text::Text,
     widgets::{Block, Borders, Row, Table},
+    Frame,
 };
 
 use crate::{

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -1,9 +1,9 @@
 use tui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::Style,
-    terminal::Frame,
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
+    Frame,
 };
 use unicode_segmentation::UnicodeSegmentation;
 

--- a/src/canvas/widgets/temperature_table.rs
+++ b/src/canvas/widgets/temperature_table.rs
@@ -1,4 +1,4 @@
-use tui::{layout::Rect, terminal::Frame};
+use tui::{layout::Rect, Frame};
 
 use crate::{
     app,


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Following https://github.com/ratatui/ratatui/blob/main/CHANGELOG.md#0280---2024-08-07 and https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md as a precursor to bumping to 0.29. This only bumps the versions + fixes any breakages, and not integrating any improvements at the moment.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
