### PR TITLE
bug: fix incorrect colours for gruvbox-light

### DIFF
--- a/src/options/config/style.rs
+++ b/src/options/config/style.rs
@@ -96,8 +96,6 @@ pub(crate) struct StyleConfig {
 /// as a "palette".
 #[derive(Debug)]
 pub struct ColourPalette {
-    pub selected_text_style: Style,
-    pub table_header_style: Style,
     pub ram_style: Style,
     #[cfg(not(target_os = "windows"))]
     pub cache_style: Style,
@@ -114,6 +112,8 @@ pub struct ColourPalette {
     pub border_style: Style,
     pub highlighted_border_style: Style,
     pub text_style: Style,
+    pub selected_text_style: Style,
+    pub table_header_style: Style,
     pub widget_title_style: Style,
     pub graph_style: Style,
     pub graph_legend_style: Style,

--- a/src/options/config/style/themes/default.rs
+++ b/src/options/config/style/themes/default.rs
@@ -20,8 +20,6 @@ impl ColourPalette {
         const TEXT_COLOUR: Color = Color::Gray;
 
         Self {
-            selected_text_style: DEFAULT_SELECTED_TEXT_STYLE,
-            table_header_style: color!(HIGHLIGHT_COLOUR).add_modifier(Modifier::BOLD),
             ram_style: color!(FIRST_COLOUR),
             #[cfg(not(target_os = "windows"))]
             cache_style: color!(FIFTH_COLOUR),
@@ -55,6 +53,8 @@ impl ColourPalette {
             border_style: color!(TEXT_COLOUR),
             highlighted_border_style: color!(HIGHLIGHT_COLOUR),
             text_style: color!(TEXT_COLOUR),
+            selected_text_style: DEFAULT_SELECTED_TEXT_STYLE,
+            table_header_style: color!(HIGHLIGHT_COLOUR).add_modifier(Modifier::BOLD),
             widget_title_style: color!(TEXT_COLOUR),
             graph_style: color!(TEXT_COLOUR),
             graph_legend_style: color!(TEXT_COLOUR),
@@ -68,8 +68,6 @@ impl ColourPalette {
 
     pub fn default_light_mode() -> Self {
         Self {
-            selected_text_style: color!(Color::White).bg(Color::LightBlue),
-            table_header_style: color!(Color::Black).add_modifier(Modifier::BOLD),
             ram_style: color!(Color::Blue),
             #[cfg(not(target_os = "windows"))]
             cache_style: color!(Color::LightRed),
@@ -99,6 +97,8 @@ impl ColourPalette {
             ],
             border_style: color!(Color::Black),
             text_style: color!(Color::Black),
+            selected_text_style: color!(Color::White).bg(Color::LightBlue),
+            table_header_style: color!(Color::Black).add_modifier(Modifier::BOLD),
             widget_title_style: color!(Color::Black),
             graph_style: color!(Color::Black),
             graph_legend_style: color!(Color::Black),

--- a/src/options/config/style/themes/gruvbox.rs
+++ b/src/options/config/style/themes/gruvbox.rs
@@ -6,8 +6,6 @@ use crate::options::config::style::{utils::convert_hex_to_color, ColourPalette};
 impl ColourPalette {
     pub(crate) fn gruvbox_palette() -> Self {
         Self {
-            selected_text_style: hex!("#1d2021").bg(convert_hex_to_color("#ebdbb2").unwrap()),
-            table_header_style: hex!("#83a598").add_modifier(Modifier::BOLD),
             ram_style: hex!("#8ec07c"),
             #[cfg(not(target_os = "windows"))]
             cache_style: hex!("#b16286"),
@@ -53,6 +51,8 @@ impl ColourPalette {
             border_style: hex!("#ebdbb2"),
             highlighted_border_style: hex!("#fe8019"),
             text_style: hex!("#ebdbb2"),
+            selected_text_style: hex!("#1d2021").bg(convert_hex_to_color("#ebdbb2").unwrap()),
+            table_header_style: hex!("#83a598").add_modifier(Modifier::BOLD),
             widget_title_style: hex!("#ebdbb2"),
             graph_style: hex!("#ebdbb2"),
             graph_legend_style: hex!("#ebdbb2"),
@@ -66,8 +66,6 @@ impl ColourPalette {
 
     pub(crate) fn gruvbox_light_palette() -> Self {
         Self {
-            selected_text_style: hex!("#ebdbb2").bg(convert_hex_to_color("#3c3836").unwrap()),
-            table_header_style: hex!("#076678").add_modifier(Modifier::BOLD),
             ram_style: hex!("#427b58"),
             #[cfg(not(target_os = "windows"))]
             cache_style: hex!("#d79921"),
@@ -110,17 +108,19 @@ impl ColourPalette {
                 hex!("#d65d03"),
                 hex!("#af3a03"),
             ],
-            border_style: hex!("#ebdbb2"),
-            highlighted_border_style: hex!("#fe8019"),
-            text_style: hex!("#ebdbb2"),
-            widget_title_style: hex!("#ebdbb2"),
-            graph_style: hex!("#ebdbb2"),
-            graph_legend_style: hex!("#ebdbb2"),
+            border_style: hex!("#3c3836"),
+            highlighted_border_style: hex!("#af3a03"),
+            text_style: hex!("#3c3836"),
+            selected_text_style: hex!("#ebdbb2").bg(convert_hex_to_color("#3c3836").unwrap()),
+            table_header_style: hex!("#076678").add_modifier(Modifier::BOLD),
+            widget_title_style: hex!("#3c3836"),
+            graph_style: hex!("#3c3836"),
+            graph_legend_style: hex!("#3c3836"),
             high_battery: hex!("#98971a"),
-            medium_battery: hex!("#fabd2f"),
-            low_battery: hex!("#fb4934"),
+            medium_battery: hex!("#d79921"),
+            low_battery: hex!("#cc241d"),
             invalid_query_style: color!(Color::Red),
-            disabled_text_style: hex!("#665c54"),
+            disabled_text_style: hex!("#d5c4a1"),
         }
     }
 }

--- a/src/options/config/style/themes/nord.rs
+++ b/src/options/config/style/themes/nord.rs
@@ -6,8 +6,6 @@ use crate::options::config::style::{utils::convert_hex_to_color, ColourPalette};
 impl ColourPalette {
     pub(crate) fn nord_palette() -> Self {
         Self {
-            selected_text_style: hex!("#2e3440").bg(convert_hex_to_color("#88c0d0").unwrap()),
-            table_header_style: hex!("#81a1c1").add_modifier(Modifier::BOLD),
             ram_style: hex!("#88c0d0"),
             #[cfg(not(target_os = "windows"))]
             cache_style: hex!("#d8dee9"),
@@ -41,6 +39,8 @@ impl ColourPalette {
             border_style: hex!("#88c0d0"),
             highlighted_border_style: hex!("#5e81ac"),
             text_style: hex!("#e5e9f0"),
+            selected_text_style: hex!("#2e3440").bg(convert_hex_to_color("#88c0d0").unwrap()),
+            table_header_style: hex!("#81a1c1").add_modifier(Modifier::BOLD),
             widget_title_style: hex!("#e5e9f0"),
             graph_style: hex!("#e5e9f0"),
             graph_legend_style: hex!("#e5e9f0"),
@@ -54,8 +54,6 @@ impl ColourPalette {
 
     pub(crate) fn nord_light_palette() -> Self {
         Self {
-            selected_text_style: hex!("#f5f5f5").bg(convert_hex_to_color("#5e81ac").unwrap()),
-            table_header_style: hex!("#5e81ac").add_modifier(Modifier::BOLD),
             ram_style: hex!("#81a1c1"),
             #[cfg(not(target_os = "windows"))]
             cache_style: hex!("#4c566a"),
@@ -89,6 +87,8 @@ impl ColourPalette {
             border_style: hex!("#2e3440"),
             highlighted_border_style: hex!("#5e81ac"),
             text_style: hex!("#2e3440"),
+            selected_text_style: hex!("#f5f5f5").bg(convert_hex_to_color("#5e81ac").unwrap()),
+            table_header_style: hex!("#5e81ac").add_modifier(Modifier::BOLD),
             widget_title_style: hex!("#2e3440"),
             graph_style: hex!("#2e3440"),
             graph_legend_style: hex!("#2e3440"),


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Fix incorrectly selected colours for gruvbox-light theme after the refactor in #1499. Example:

![image](https://github.com/user-attachments/assets/838711a5-47bd-4728-8060-7a25c976e922)


## Issue

_If applicable, what issue does this address?_

Closes: #1631

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
