### PR TITLE
ci: migrate FreeBSD release builds to GHA, update macOS and FreeBSD targets

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,22 +49,6 @@ release_task:
     MANPAGE_DIR: "target/tmp/bottom/manpage/"
     # -PLACEHOLDER FOR CI-
   matrix:
-    - name: "FreeBSD 14 Build"
-      alias: "freebsd_14_0_build"
-      freebsd_instance:
-        image_family: freebsd-14-0
-      env:
-        TARGET: "x86_64-unknown-freebsd"
-        NAME: "x86_64-unknown-freebsd-14-0"
-
-    - name: "FreeBSD 13 Build"
-      alias: "freebsd_13_3_build"
-      freebsd_instance:
-        image_family: freebsd-13-3
-      env:
-        TARGET: "x86_64-unknown-freebsd"
-        NAME: "x86_64-unknown-freebsd-13-3"
-
     - name: "Legacy Linux (2.17)"
       alias: "linux_2_17_build"
       container:

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -1,11 +1,10 @@
 # Builds the following releases:
-# - Binary releases
+# - Binaries
+# - Binaries via VMs
+# - Cirrus binaries (currently just Linux 2.17)
+# - MSI installer for Windows (.msi)
 # - .deb releases
 # - .rpm releases
-# - MSI installer for Windows (.msi)
-# - Cirrus CI binaries
-#   - FreeBSD (x86_64)
-#   - macOS (aarch64)
 
 name: "build releases"
 
@@ -133,12 +132,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Checkout repository (non-GitHub container)
-        if: matrix.info.container != ''
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-        with:
-          fetch-depth: 1
-
       - name: Set up Rust toolchain
         if: matrix.info.container == ''
         uses: dtolnay/rust-toolchain@21dc36fb71dd22e3317045c0c31a3f4249868b17
@@ -185,8 +178,8 @@ jobs:
         shell: bash
         run: |
           cp target/${{ matrix.info.target }}/release/btm ./btm
-          tar -czvf bottom_${{ matrix.info.target }}${{ matrix.info.suffix }}.tar.gz btm completion
-          echo "ASSET=bottom_${{ matrix.info.target }}${{ matrix.info.suffix }}.tar.gz" >> $GITHUB_ENV
+          tar -czvf bottom_${{ matrix.info.target }}.tar.gz btm completion
+          echo "ASSET=bottom_${{ matrix.info.target }}.tar.gz" >> $GITHUB_ENV
 
       - name: Generate artifact attestation for file
         uses: actions/attest-build-provenance@6149ea5740be74af77f260b9db67e633f6b0a9a1 # v1.4.2
@@ -224,7 +217,82 @@ jobs:
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
           retention-days: 3
-          name: "release-${{ matrix.info.target }}${{ matrix.info.suffix }}"
+          name: "release-${{ matrix.info.target }}"
+          path: release
+
+  build-vm:
+    name: "Build binaries via VMs"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 12
+    strategy:
+      fail-fast: false
+      matrix:
+        info:
+          # Seems like cross' FreeBSD image is a bit broken? I get build errors, may be related to this issue:
+          # https://github.com/cross-rs/cross/issues/1291
+          #
+          # Alas, that's why we do it with VMs.
+          - {
+              type: "freebsd",
+              os_release: "14.1",
+              target: "x86_64-unknown-freebsd",
+            }
+          - {
+              type: "freebsd",
+              os_release: "13.3",
+              target: "x86_64-unknown-freebsd",
+            }
+    steps:
+      - name: Checkout repository
+        if: matrix.info.container == ''
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 1
+
+      - name: Build (FreeBSD)
+        if: ${{ matrix.info.type == 'freebsd' }}
+        uses: vmactions/freebsd-vm@v1.0.8
+        with:
+          release: "${{ matrix.info.os_release }}"
+          envs: "RUST_BACKTRACE CARGO_INCREMENTAL CARGO_PROFILE_DEV_DEBUG CARGO_HUSKY_DONT_INSTALL_HOOKS COMPLETION_DIR MANPAGE_DIR"
+          usesh: true
+          prepare: |
+            pkg install -y curl bash
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup.sh
+            sh rustup.sh --default-toolchain stable -y
+          run: |
+            . "$HOME/.cargo/env"
+            cargo build --release --verbose --locked --target=${{ matrix.info.target }} --features deploy
+
+      - name: Move automatically generated completion/manpage
+        shell: bash
+        run: |
+          mv "$COMPLETION_DIR" completion
+          mv "$MANPAGE_DIR" manpage
+
+      - name: Bundle release and completion
+        shell: bash
+        run: |
+          cp target/${{ matrix.info.target }}/release/btm ./btm
+          tar -czvf bottom_${{ matrix.info.target }}.tar.gz btm completion
+          echo "ASSET=bottom_${{ matrix.info.target }}.tar.gz" >> $GITHUB_ENV
+
+      - name: Generate artifact attestation for file
+        uses: actions/attest-build-provenance@6149ea5740be74af77f260b9db67e633f6b0a9a1 # v1.4.2
+        with:
+          subject-path: ${{ env.ASSET }}
+
+      - name: Create release directory for artifact, move file
+        shell: bash
+        run: |
+          mkdir release
+          mv ${{ env.ASSET }} release/
+
+      - name: Save release as artifact
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        with:
+          retention-days: 3
+          name: "release-${{ matrix.info.target }}-${{ matrix.info.os_release }}"
           path: release
 
   build-msi:

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -279,8 +279,8 @@ jobs:
         shell: bash
         run: |
           cp target/${{ matrix.info.target }}/release/btm ./btm
-          tar -czvf bottom_${{ matrix.info.target }}.tar.gz btm completion
-          echo "ASSET=bottom_${{ matrix.info.target }}.tar.gz" >> $GITHUB_ENV
+          tar -czvf bottom_${{ matrix.info.target }}-${{ matrix.info.os_release }}.tar.gz btm completion
+          echo "ASSET=bottom_${{ matrix.info.target }}-${{ matrix.info.os_release }}.tar.gz" >> $GITHUB_ENV
 
       - name: Generate artifact attestation for file
         uses: actions/attest-build-provenance@6149ea5740be74af77f260b9db67e633f6b0a9a1 # v1.4.2

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -79,7 +79,7 @@ jobs:
             }
 
           # macOS (x86-64 and aarch64)
-          - { os: "macos-12", target: "x86_64-apple-darwin", cross: false }
+          - { os: "macos-13", target: "x86_64-apple-darwin", cross: false }
           - { os: "macos-14", target: "aarch64-apple-darwin", cross: false }
 
           # Windows (x86-64, x86)

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -234,6 +234,11 @@ jobs:
           # Alas, that's why we do it with VMs.
           - {
               type: "freebsd",
+              os_release: "15.0",
+              target: "x86_64-unknown-freebsd",
+            }
+          - {
+              type: "freebsd",
               os_release: "14.1",
               target: "x86_64-unknown-freebsd",
             }
@@ -251,7 +256,7 @@ jobs:
 
       - name: Build (FreeBSD)
         if: ${{ matrix.info.type == 'freebsd' }}
-        uses: vmactions/freebsd-vm@v1.0.8
+        uses: vmactions/freebsd-vm@debf37ca7b7fa40e19c542ef7ba30d6054a706a4 # v1.1.5
         with:
           release: "${{ matrix.info.os_release }}"
           envs: "RUST_BACKTRACE CARGO_INCREMENTAL CARGO_PROFILE_DEV_DEBUG CARGO_HUSKY_DONT_INSTALL_HOOKS COMPLETION_DIR MANPAGE_DIR"
@@ -262,7 +267,7 @@ jobs:
             sh rustup.sh --default-toolchain stable -y
           run: |
             . "$HOME/.cargo/env"
-            cargo build --release --verbose --locked --target=${{ matrix.info.target }} --features deploy
+            BTM_GENERATE=true BTM_BUILD_RELEASE_CALLER=${{ inputs.caller }} cargo build --release --verbose --locked --target=${{ matrix.info.target }} --features deploy
 
       - name: Move automatically generated completion/manpage
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,8 +274,7 @@ jobs:
       fail-fast: false
       matrix:
         info:
-          # Seems like cross' FreeBSD image is a bit broken? I
-          # get build errors, may be related to this issue:
+          # Seems like cross' FreeBSD image is a bit broken? I get build errors, may be related to this issue:
           # https://github.com/cross-rs/cross/issues/1291
           #
           # Alas, that's why we do it with VMs.
@@ -295,12 +294,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@21dc36fb71dd22e3317045c0c31a3f4249868b17
-        with:
-          toolchain: ${{ matrix.info.rust || 'stable' }}
-          target: ${{ matrix.info.target }}
-
       - name: Enable Rust cache
         uses: Swatinem/rust-cache@9bdad043e88c75890e36ad3bbc8d27f0090dd609 # 2.7.3
         if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }} # If it is a PR, only if not a fork
@@ -313,7 +306,7 @@ jobs:
         uses: vmactions/freebsd-vm@v1.0.8
         with:
           release: "${{ matrix.info.os_release }}"
-          envs: "CARGO_INCREMENTAL CARGO_PROFILE_DEV_DEBUG CARGO_HUSKY_DONT_INSTALL_HOOKS"
+          envs: "RUST_BACKTRACE CARGO_INCREMENTAL CARGO_PROFILE_DEV_DEBUG CARGO_HUSKY_DONT_INSTALL_HOOKS"
           usesh: true
           prepare: |
             pkg install -y curl bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
               target: "aarch64-unknown-linux-gnu",
               cross: true,
             }
-          - { os: "macos-12", target: "x86_64-apple-darwin", cross: false }
+          - { os: "macos-13", target: "x86_64-apple-darwin", cross: false }
           - { os: "macos-14", target: "aarch64-apple-darwin", cross: false }
           - {
               os: "windows-2019",
@@ -177,8 +177,8 @@ jobs:
               rust: "beta",
             }
           - {
-              os: "macos-12",
-              target: "x86_64-apple-darwin",
+              os: "macos-14",
+              target: "aarch64-apple-darwin",
               cross: false,
               rust: "beta",
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,11 @@ jobs:
           # Alas, that's why we do it with VMs.
           - {
               type: "freebsd",
+              os_release: "15.0",
+              target: "x86_64-unknown-freebsd",
+            }
+          - {
+              type: "freebsd",
               os_release: "14.1",
               target: "x86_64-unknown-freebsd",
             }
@@ -303,7 +308,7 @@ jobs:
 
       - name: Clippy (FreeBSD)
         if: ${{ matrix.info.type == 'freebsd' }}
-        uses: vmactions/freebsd-vm@v1.0.8
+        uses: vmactions/freebsd-vm@debf37ca7b7fa40e19c542ef7ba30d6054a706a4 # v1.1.5
         with:
           release: "${{ matrix.info.os_release }}"
           envs: "RUST_BACKTRACE CARGO_INCREMENTAL CARGO_PROFILE_DEV_DEBUG CARGO_HUSKY_DONT_INSTALL_HOOKS"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         info:
           - { os: "ubuntu-latest", target: "x86_64-unknown-linux-gnu" }
-          - { os: "macos-12", target: "x86_64-apple-darwin" }
+          - { os: "macos-14", target: "aarch64-apple-darwin", cross: false }
           - { os: "windows-2019", target: "x86_64-pc-windows-msvc" }
     steps:
       - name: Checkout repository

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,18 +75,18 @@ jobs:
           du -h -d 0 ./release/*
 
       - name: Delete tag and release if not mock
-        if: github.event.inputs.isMock != 'mock'
+        if: github.event.inputs.isMock != 'true'
         run: gh release delete nightly --cleanup-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sleep for a few seconds to prevent timing issues between the deletion and creation of the release
         run: sleep 10
-        if: github.event.inputs.isMock != 'mock'
+        if: github.event.inputs.isMock != 'true'
 
       - name: Add all release files and create nightly release if not mock
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # 2.0.8
-        if: github.event.inputs.isMock != 'mock'
+        if: github.event.inputs.isMock != 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true

--- a/scripts/cirrus/release.py
+++ b/scripts/cirrus/release.py
@@ -20,8 +20,6 @@ from urllib.request import Request, urlopen, urlretrieve
 
 # Form of each task is (TASK_ALIAS, FILE_NAME).
 TASKS: List[Tuple[str, str]] = [
-    ("freebsd_13_3_build", "bottom_x86_64-unknown-freebsd-13-3.tar.gz"),
-    ("freebsd_14_0_build", "bottom_x86_64-unknown-freebsd-14-0.tar.gz"),
     ("linux_2_17_build", "bottom_x86_64-unknown-linux-gnu-2-17.tar.gz"),
 ]
 URL = "https://api.cirrus-ci.com/graphql"


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

I would love to migrate off cirrus just to make things easier. Also update macOS targets since macOS-12 is deprecated, and fixes a bug regarding nightly mocks.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
