### PR TITLE
Remove sudo on Readme for Yay and Paru

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ If you want the latest changes that are not yet stable, you can also install `bo
 
 ```bash
 # Using paru
-sudo paru -S bottom-git
+paru -S bottom-git
 
 # Using yay
-sudo yay -S bottom-git
+yay -S bottom-git
 ```
 
 ### Debian / Ubuntu


### PR DESCRIPTION
## Description

Bad pratice to use sudo with a aur helper on arch linux

## Issue

Avoid using sudo for AUR helper

Closes: #

## Testing

No test

## Checklist

_If relevant, ensure the following have been met:_

A test nothing, just remove 2 word on the README.md
