### PR TITLE
feature: make it possible to override generate dirs via env

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -38,11 +38,12 @@ fn btm_generate() -> io::Result<()> {
 
     match env::var_os(ENV_KEY) {
         Some(var) if !var.is_empty() => {
-            const COMPLETION_DIR: &str = "./target/tmp/bottom/completion/";
-            const MANPAGE_DIR: &str = "./target/tmp/bottom/manpage/";
+            let completion_dir =
+                option_env!("COMPLETION_DIR").unwrap_or("./target/tmp/bottom/completion/");
+            let manpage_dir = option_env!("MANPAGE_DIR").unwrap_or("./target/tmp/bottom/manpage/");
 
-            let completion_out_dir = PathBuf::from(COMPLETION_DIR);
-            let manpage_out_dir = PathBuf::from(MANPAGE_DIR);
+            let completion_out_dir = PathBuf::from(completion_dir);
+            let manpage_out_dir = PathBuf::from(manpage_dir);
 
             create_dir(&completion_out_dir)?;
             create_dir(&manpage_out_dir)?;

--- a/docs/content/contribution/packaging-and-distribution.md
+++ b/docs/content/contribution/packaging-and-distribution.md
@@ -54,6 +54,9 @@ This will automatically generate completion and manpage files in `target/tmp/bot
 files, modify/delete either these files or set `BTM_GENERATE` to some other non-empty value to retrigger the build
 script.
 
+You may override the default diretories used to generate both completion and manpage files by specifying the
+`COMPLETION_DIR` and `MANPAGE_DIR` environment variables respectively.
+
 For more information, you may want to look at either the [`build.rs`](https://github.com/ClementTsang/bottom/blob/main/build.rs)
 file or the [binary build CI workflow](https://github.com/ClementTsang/bottom/blob/main/.github/workflows/build_releases.yml).
 


### PR DESCRIPTION
## Description

This change simply makes it possible to optionally specify `COMPLETION_DIR` or `MANPAGE_DIR` via environment variables to specify the location where completion and manpage files are created. This is especially handy when using `cargo install` and is a similar approach used by [hyperfine](https://github.com/sharkdp/hyperfine/blob/master/build.rs).

This also makes sure the docs align with the implementation as **build_process.md** states the following:

> - Build a release build with:
> 
>   - `--features deploy`, which enables only crates needed for release builds.
>   - `--locked` to lock the dependency versions.
>   - The following env variables set:
> 
>     - `BTM_GENERATE: true`
>     - `COMPLETION_DIR: "target/tmp/bottom/completion/"`
>     - `MANPAGE_DIR: "target/tmp/bottom/manpage/"`

## Issue

Partially addresses https://github.com/ClementTsang/bottom/issues/1654 for those using `cargo install`

## Testing

**Windows**

```
~\source\bottom on  allow_generate_customization_via_env is 📦 v0.11.0 via 🦀 v1.85.0-nightly
🕙 [ 08:18:10 PM ] ❯ ls C:\Users\Fots\Downloads\bottom-generation
Get-ChildItem: Cannot find path 'C:\Users\Fots\Downloads\bottom-generation' because it does not exist.

~\source\bottom on  allow_generate_customization_via_env is 📦 v0.11.0 via 🦀 v1.85.0-nightly
🕙 [ 08:18:10 PM ] ❯ $env:BTM_GENERATE = '1'

~\source\bottom on  allow_generate_customization_via_env is 📦 v0.11.0 via 🦀 v1.85.0-nightly
🕙 [ 08:18:13 PM ] ❯ $env:COMPLETION_DIR = 'C:\Users\Fots\Downloads\bottom-generation'

~\source\bottom on  allow_generate_customization_via_env is 📦 v0.11.0 via 🦀 v1.85.0-nightly
🕙 [ 08:18:15 PM ] ❯ $env:MANPAGE_DIR = 'C:\Users\Fots\Downloads\bottom-generation'

~\source\bottom on  allow_generate_customization_via_env is 📦 v0.11.0 via 🦀 v1.85.0-nightly
🕙 [ 08:18:16 PM ] ❯ cargo build
   Compiling bottom v0.11.0 (C:\Users\Fots\source\bottom)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.02s

~\source\bottom on  allow_generate_customization_via_env is 📦 v0.11.0 via 🦀 v1.85.0-nightly took 4s
🕙 [ 08:18:22 PM ] ❯ ls C:\Users\Fots\Downloads\bottom-generation

    Directory: C:\Users\Fots\Downloads\bottom-generation

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---           7/01/2025  8:18 PM           5155 _btm
-a---           7/01/2025  8:18 PM          10734 _btm.ps1
-a---           7/01/2025  8:18 PM           9025 btm.1
-a---           7/01/2025  8:18 PM           4110 btm.bash
-a---           7/01/2025  8:18 PM           5477 btm.elv
-a---           7/01/2025  8:18 PM           4315 btm.fish
-a---           7/01/2025  8:18 PM           4457 btm.nu
-a---           7/01/2025  8:18 PM           7403 btm.ts
```

**Linux**

```
fots@Fotsies-PC:~/bottom$ ls -l ~/
total 4
drwxr-xr-x 16 fots fots 4096 Jan  7 20:33 bottom
fots@Fotsies-PC:~/bottom$ export BTM_GENERATE=1
fots@Fotsies-PC:~/bottom$ export COMPLETION_DIR=/home/fots/bottom-generate-completions
fots@Fotsies-PC:~/bottom$ export MANPAGE_DIR=/home/fots/bottom-generate-manpage
fots@Fotsies-PC:~/bottom$ cargo build
   Compiling bottom v0.11.0 (/home/fots/bottom)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.51s
fots@Fotsies-PC:~/bottom$ ls -l ~/
total 12
drwxr-xr-x 16 fots fots 4096 Jan  7 20:33 bottom
drwxr-xr-x  2 fots fots 4096 Jan  7 20:34 bottom-generate-completions
drwxr-xr-x  2 fots fots 4096 Jan  7 20:34 bottom-generate-manpage
fots@Fotsies-PC:~/bottom$ ls -l ~/bottom-generate-*
/home/fots/bottom-generate-completions:
total 60
-rw-r--r-- 1 fots fots  5241 Jan  7 20:34 _btm
-rw-r--r-- 1 fots fots 10921 Jan  7 20:34 _btm.ps1
-rw-r--r-- 1 fots fots  4132 Jan  7 20:34 btm.bash
-rw-r--r-- 1 fots fots  5577 Jan  7 20:34 btm.elv
-rw-r--r-- 1 fots fots  4418 Jan  7 20:34 btm.fish
-rw-r--r-- 1 fots fots  4548 Jan  7 20:34 btm.nu
-rw-r--r-- 1 fots fots  7534 Jan  7 20:34 btm.ts

/home/fots/bottom-generate-manpage:
total 12
-rw-r--r-- 1 fots fots 9150 Jan  7 20:34 btm.1
```

- [x] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_ - N/A, only changes the `build.rs` script 😄 
