### PR TITLE
other: fix non-applicable warning about regex creation in loop

### DIFF
--- a/src/app/data_farmer.rs
+++ b/src/app/data_farmer.rs
@@ -370,6 +370,11 @@ impl DataCollection {
 
                         // Must trim one level further for macOS!
                         static DISK_REGEX: OnceLock<Regex> = OnceLock::new();
+
+                        #[expect(
+                            clippy::regex_creation_in_loops,
+                            reason = "this is fine since it's done via a static OnceLock. In the future though, separate it out."
+                        )]
                         if let Some(new_name) = DISK_REGEX
                             .get_or_init(|| Regex::new(r"disk\d+").unwrap())
                             .find(checked_name)


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

On macOS we use an additional regex to check some things in disk; we initialize it using a `static OnceLock`, so despite it being in a loop, which causes clippy to think there's a problem, this doesn't actually pose a problem as it'll only ever be created once.

Proof: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=452c49b24c0a86787afcc2a407ac9f68

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
