### PR TITLE
fix/other: fix bug with network y-axis labels and cache height calculations

### DIFF
--- a/src/app/data/time_series.rs
+++ b/src/app/data/time_series.rs
@@ -25,7 +25,7 @@ pub type Values = ChunkedData<f64>;
 #[derive(Clone, Debug, Default)]
 pub struct TimeSeriesData {
     /// Time values.
-    pub time: Vec<Instant>,
+    pub time: Vec<Instant>, // TODO: (points_rework_v1) should we not store instant, and just store the millisecond component? Write a compatible wrapper!
 
     /// Network RX data.
     pub rx: Values,

--- a/src/widgets/network_graph.rs
+++ b/src/widgets/network_graph.rs
@@ -3,7 +3,13 @@ use std::time::Instant;
 pub struct NetWidgetState {
     pub current_display_time: u64,
     pub autohide_timer: Option<Instant>,
-    pub last_height_check: Option<(Instant, f64, u64)>,
+    pub height_cache: Option<NetWidgetHeightCache>,
+}
+
+pub struct NetWidgetHeightCache {
+    pub best_point: (Instant, f64),
+    pub right_edge: Instant,
+    pub period: u64,
 }
 
 impl NetWidgetState {
@@ -11,7 +17,7 @@ impl NetWidgetState {
         NetWidgetState {
             current_display_time,
             autohide_timer,
-            last_height_check: None,
+            height_cache: None,
         }
     }
 }

--- a/src/widgets/network_graph.rs
+++ b/src/widgets/network_graph.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 pub struct NetWidgetState {
     pub current_display_time: u64,
     pub autohide_timer: Option<Instant>,
+    pub last_height_check: Option<(Instant, f64, u64)>,
 }
 
 impl NetWidgetState {
@@ -10,6 +11,7 @@ impl NetWidgetState {
         NetWidgetState {
             current_display_time,
             autohide_timer,
+            last_height_check: None,
         }
     }
 }


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This PR has two changes:

1. Fix a bug where we were using the wrong value when creating network y-axis labels; this was a mistake from #1663, where I used the upper limit (value * 1.5) as the value to create labels. Oops.
2. Cache previous results of height calculation; this means we don't have to always scan the full range of points each time we want to find the max height for the adjusting y-axis. Instead:
    - If the cache is empty, scan the full range; store the best point, the right edge scanned, and the time range
    - If the cache is not empty, and the point is inside the current range, scan from the right edge to the cached right edge
    - If the cache is not empty but the point is _outside_ the range, scan the full thing as it's invalid
    - If the cache is not empty but the time range is different, we do the easy thing and just scan the entire thing again too

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
