### PR TITLE
README: update Nix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,10 +262,18 @@ sudo emerge --ask sys-process/bottom
 
 ### Nix
 
-Available [in the nix-community repo](https://github.com/nix-community/home-manager/blob/master/modules/programs/bottom.nix):
+Available [in Nixpkgs](https://search.nixos.org/packages?channel=unstable&show=bottom&from=0&size=1&sort=relevance&type=packages) as `bottom`:
 
 ```bash
-nix-env -i bottom
+nix profile install nixpkgs#bottom
+```
+
+`bottom` can also be installed and configured through the [home-manager](https://nix-community.github.io/home-manager) module:
+
+```nix
+{
+  programs.bottom.enable = true;
+}
 ```
 
 ### Snap


### PR DESCRIPTION
## Description

This commit contains the following changes:
1. Corrects the source of the package in the Nix instructions: `bottom` isn't coming from `nix-community`, but Nixpkgs itself.
2. Updates the Nix install instructions to use the new Nix CLI.
3. The original link was pointing to a home-manager module for bottom. We now include instructions on how to enable said module.

## Issue

Not an issue, but this is a follow-up to #294.

## Testing

I... checked the rich preview in GitHub and it seems fine. It's just a README change.

## Checklist

- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
