### PR TITLE
refactor: don't duplicate AMD GPU temperature retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ That said, these are more guidelines rather than hardset rules, though the proje
   - `--colors` is now `--theme`
 - [#1513](https://github.com/ClementTsang/bottom/pull/1513): Table headers are now bold by default.
 - [#1515](https://github.com/ClementTsang/bottom/pull/1515): Show the config path in the error message if unable to read/create a config.
+- [#1682](https://github.com/ClementTsang/bottom/pull/1682): On Linux, temperature sensor labels now always have their first letter capitalized (e.g. "k10temp: tctl" -> "k10temp: Tctl").
 
 ### Bug Fixes
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -8,6 +8,11 @@ pub mod nvidia;
 #[cfg(all(target_os = "linux", feature = "gpu"))]
 pub mod amd;
 
+#[cfg(target_os = "linux")]
+mod linux {
+    pub mod utils;
+}
+
 #[cfg(feature = "battery")]
 pub mod batteries;
 pub mod cpu;
@@ -370,18 +375,9 @@ impl DataCollector {
             }
 
             #[cfg(target_os = "linux")]
-            if let Some(data) = amd::get_amd_vecs(
-                &self.filters.temp_filter,
-                &self.widgets_to_harvest,
-                self.last_collection_time,
-            ) {
-                if let Some(mut temp) = data.temperature {
-                    if let Some(sensors) = &mut self.data.temperature_sensors {
-                        sensors.append(&mut temp);
-                    } else {
-                        self.data.temperature_sensors = Some(temp);
-                    }
-                }
+            if let Some(data) =
+                amd::get_amd_vecs(&self.widgets_to_harvest, self.last_collection_time)
+            {
                 if let Some(mut mem) = data.memory {
                     local_gpu.append(&mut mem);
                 }

--- a/src/collection/amd/amd_gpu_marketing.rs
+++ b/src/collection/amd/amd_gpu_marketing.rs
@@ -2,7 +2,7 @@
 
 pub const AMDGPU_DEFAULT_NAME: &str = "AMD Radeon Graphics";
 
-pub const AMDGPU_MARKETING_NAME: &[(u32, u32, &str)] = &[
+pub const AMD_GPU_MARKETING_NAME: &[(u32, u32, &str)] = &[
     (0x6798, 0x00, "AMD Radeon R9 200 / HD 7900 Series"),
     (0x6799, 0x00, "AMD Radeon HD 7900 Series"),
     (0x679A, 0x00, "AMD Radeon HD 7900 Series"),

--- a/src/collection/linux/utils.rs
+++ b/src/collection/linux/utils.rs
@@ -1,0 +1,30 @@
+use std::{fs, path::Path};
+
+/// Whether the temperature should *actually* be read during enumeration.
+/// Will return false if the state is not D0/unknown, or if it does not support
+/// `device/power_state`.
+///
+/// `path` is a path to the device itself (e.g. `/sys/class/hwmon/hwmon1/device`).
+#[inline]
+pub fn is_device_awake(device: &Path) -> bool {
+    // Whether the temperature should *actually* be read during enumeration.
+    // Set to false if the device is in ACPI D3cold.
+    // Documented at https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-power_state
+    let power_state = device.join("power_state");
+    if power_state.exists() {
+        if let Ok(state) = fs::read_to_string(power_state) {
+            let state = state.trim();
+            // The zenpower3 kernel module (incorrectly?) reports "unknown", causing this
+            // check to fail and temperatures to appear as zero instead of
+            // having the file not exist.
+            //
+            // Their self-hosted git instance has disabled sign up, so this bug cant be
+            // reported either.
+            state == "D0" || state == "unknown"
+        } else {
+            true
+        }
+    } else {
+        true
+    }
+}

--- a/src/collection/temperature.rs
+++ b/src/collection/temperature.rs
@@ -1,7 +1,7 @@
 //! Data collection for temperature metrics.
 //!
-//! For Linux and macOS, this is handled by Heim.
-//! For Windows, this is handled by sysinfo.
+//! For Linux, this is handled by custom code.
+//! For everything else, this is handled by sysinfo.
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "linux")] {

--- a/src/collection/temperature/linux.rs
+++ b/src/collection/temperature/linux.rs
@@ -148,11 +148,12 @@ fn finalize_name(
             (false, true) => name.to_owned(),
             (true, true) => EMPTY_NAME.to_string(),
         },
-        (None, Some(label)) => match fallback_sensor_name {
+        (None, Some(mut label)) => match fallback_sensor_name {
             Some(fallback) if !fallback.is_empty() => {
                 if label.is_empty() {
                     fallback.to_owned()
                 } else {
+                    uppercase_first_letter(&mut label);
                     format!("{fallback}: {label}")
                 }
             }
@@ -160,6 +161,7 @@ fn finalize_name(
                 if label.is_empty() {
                     EMPTY_NAME.to_string()
                 } else {
+                    uppercase_first_letter(&mut label);
                     label
                 }
             }
@@ -393,7 +395,7 @@ mod tests {
                 &Some("test".to_string()),
                 &mut seen_names
             ),
-            "hwmon: sensor"
+            "hwmon: Sensor"
         );
 
         assert_eq!(
@@ -413,7 +415,7 @@ mod tests {
                 &Some("test".to_string()),
                 &mut seen_names
             ),
-            "test: sensor"
+            "test: Sensor"
         );
 
         assert_eq!(
@@ -423,7 +425,7 @@ mod tests {
                 &Some("test".to_string()),
                 &mut seen_names
             ),
-            "hwmon: sensor (1)"
+            "hwmon: Sensor (1)"
         );
 
         assert_eq!(

--- a/src/collection/temperature/linux.rs
+++ b/src/collection/temperature/linux.rs
@@ -9,12 +9,15 @@ use anyhow::Result;
 use hashbrown::{HashMap, HashSet};
 
 use super::TempSensorData;
-use crate::app::filter::Filter;
+use crate::{
+    app::filter::Filter,
+    collection::{amd::get_amd_name, linux::utils::is_device_awake},
+};
 
 const EMPTY_NAME: &str = "Unknown";
 
 /// Returned results from grabbing hwmon/coretemp temperature sensor
-/// values/names.
+/// values or names.
 struct HwmonResults {
     temperatures: Vec<TempSensorData>,
     num_hwmon: usize,
@@ -115,32 +118,33 @@ fn counted_name(seen_names: &mut HashMap<String, u32>, name: String) -> String {
     }
 }
 
-#[inline]
+fn uppercase_first_letter(s: &mut str) {
+    if let Some(r) = s.get_mut(0..1) {
+        r.make_ascii_uppercase();
+    }
+}
+
 fn finalize_name(
     hwmon_name: Option<String>, sensor_label: Option<String>,
     fallback_sensor_name: &Option<String>, seen_names: &mut HashMap<String, u32>,
 ) -> String {
     let candidate_name = match (hwmon_name, sensor_label) {
-        (Some(name), Some(label)) => match (name.is_empty(), label.is_empty()) {
+        (Some(name), Some(mut label)) => match (name.is_empty(), label.is_empty()) {
             (false, false) => {
+                uppercase_first_letter(&mut label);
                 format!("{name}: {label}")
             }
-            (true, false) => match fallback_sensor_name {
-                Some(fallback) if !fallback.is_empty() => {
-                    if label.is_empty() {
-                        fallback.to_owned()
-                    } else {
+            (true, false) => {
+                uppercase_first_letter(&mut label);
+
+                // We assume label must not be empty.
+                match fallback_sensor_name {
+                    Some(fallback) if !fallback.is_empty() => {
                         format!("{fallback}: {label}")
                     }
+                    _ => label,
                 }
-                _ => {
-                    if label.is_empty() {
-                        EMPTY_NAME.to_string()
-                    } else {
-                        label
-                    }
-                }
-            },
+            }
             (false, true) => name.to_owned(),
             (true, true) => EMPTY_NAME.to_string(),
         },
@@ -174,34 +178,6 @@ fn finalize_name(
     };
 
     counted_name(seen_names, candidate_name)
-}
-
-/// Whether the temperature should *actually* be read during enumeration.
-/// Will return false if the state is not D0/unknown, or if it does not support
-/// `device/power_state`.
-#[inline]
-fn is_device_awake(path: &Path) -> bool {
-    // Whether the temperature should *actually* be read during enumeration.
-    // Set to false if the device is in ACPI D3cold.
-    // Documented at https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-power_state
-    let device = path.join("device");
-    let power_state = device.join("power_state");
-    if power_state.exists() {
-        if let Ok(state) = fs::read_to_string(power_state) {
-            let state = state.trim();
-            // The zenpower3 kernel module (incorrectly?) reports "unknown", causing this
-            // check to fail and temperatures to appear as zero instead of
-            // having the file not exist.
-            //
-            // Their self-hosted git instance has disabled sign up, so this bug cant be
-            // reported either.
-            state == "D0" || state == "unknown"
-        } else {
-            true
-        }
-    } else {
-        true
-    }
 }
 
 /// Get temperature sensors from the linux sysfs interface `/sys/class/hwmon`
@@ -243,8 +219,9 @@ fn hwmon_temperatures(filter: &Option<Filter>) -> HwmonResults {
     // also allow easy cancellation/timeouts.
     for file_path in dirs {
         let sensor_name = read_to_string_lossy(file_path.join("name"));
+        let device = file_path.join("device");
 
-        if !is_device_awake(&file_path) {
+        if !is_device_awake(&device) {
             let name = finalize_name(None, None, &sensor_name, &mut seen_names);
             temperatures.push(TempSensorData {
                 name,
@@ -284,23 +261,20 @@ fn hwmon_temperatures(filter: &Option<Filter>) -> HwmonResults {
                     if drm.exists() {
                         // This should never actually be empty. If it is though, we'll fall back to
                         // the sensor name later on.
-                        let mut gpu = None;
 
-                        if let Ok(cards) = drm.read_dir() {
-                            for card in cards.flatten() {
-                                if let Some(name) = card.file_name().to_str() {
-                                    if name.starts_with("card") {
-                                        gpu = Some(humanize_name(
-                                            name.trim().to_string(),
-                                            sensor_name.as_ref(),
-                                        ));
-                                        break;
-                                    }
-                                }
-                            }
+                        if let Some(amd_gpu_name) = get_amd_name(&device) {
+                            Some(amd_gpu_name)
+                        } else if let Ok(cards) = drm.read_dir() {
+                            cards.flatten().find_map(|card| {
+                                card.file_name().to_str().and_then(|name| {
+                                    name.starts_with("card").then(|| {
+                                        humanize_name(name.trim().to_string(), sensor_name.as_ref())
+                                    })
+                                })
+                            })
+                        } else {
+                            None
                         }
-
-                        gpu
                     } else {
                         // This little mess is to account for stuff like k10temp. This is needed
                         // because the `device` symlink points to `nvme*`


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_
 
We were pulling the AMD GPU temps twice, so this fixes that. This also avoids checking AMD GPU details if the card is asleep.

This change also capitalizes the first letter of temp labels.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

- [x] _Linux_

Looks fine to me:

![image](https://github.com/user-attachments/assets/2d4c132b-c736-4479-9bd2-2fd8d2ff5459)
![image](https://github.com/user-attachments/assets/53cadb5f-1d48-42a9-a502-811f89fcc277)


## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
