### PR TITLE
fix: prevent graph lines from showing up behind legend

### DIFF
--- a/src/canvas/components/time_graph/time_chart.rs
+++ b/src/canvas/components/time_graph/time_chart.rs
@@ -12,7 +12,7 @@ use std::{cmp::max, str::FromStr, time::Instant};
 use canvas::*;
 use tui::{
     buffer::Buffer,
-    layout::{Alignment, Constraint, Flex, Layout, Rect},
+    layout::{Alignment, Constraint, Flex, Layout, Position, Rect},
     style::{Color, Style, Styled},
     symbols::{self, Marker},
     text::{Line, Span},
@@ -872,10 +872,13 @@ impl Widget for TimeChart<'_> {
 
         if let Some(legend_area) = layout.legend_area {
             buf.set_style(legend_area, original_style);
-            Block::default()
+            let block = Block::default()
                 .borders(Borders::ALL)
-                .border_style(self.legend_style)
-                .render(legend_area, buf);
+                .border_style(self.legend_style);
+            for Position { x, y } in block.inner(legend_area).positions() {
+                buf[(x, y)].set_symbol(" ");
+            }
+            block.render(legend_area, buf);
 
             for (i, (dataset_name, dataset_style)) in self
                 .datasets

--- a/src/canvas/components/time_graph/time_chart.rs
+++ b/src/canvas/components/time_graph/time_chart.rs
@@ -12,7 +12,7 @@ use std::{cmp::max, str::FromStr, time::Instant};
 use canvas::*;
 use tui::{
     buffer::Buffer,
-    layout::{Alignment, Constraint, Flex, Layout, Position, Rect},
+    layout::{Alignment, Constraint, Flex, Layout, Rect},
     style::{Color, Style, Styled},
     symbols::{self, Marker},
     text::{Line, Span},
@@ -875,8 +875,10 @@ impl Widget for TimeChart<'_> {
             let block = Block::default()
                 .borders(Borders::ALL)
                 .border_style(self.legend_style);
-            for Position { x, y } in block.inner(legend_area).positions() {
-                buf[(x, y)].set_symbol(" ");
+            for pos in block.inner(legend_area).positions() {
+                if let Some(cell) = buf.cell_mut(pos) {
+                    cell.set_symbol(" ");
+                }
             }
             block.render(legend_area, buf);
 


### PR DESCRIPTION
## Description

Currently, when some entries in a graph's legend are shorter than others, it's possible for the graph lines to show up through the legend. This can be seen in the following screenshot:

![bottom-bug-circled-screenshot](https://github.com/user-attachments/assets/93b286d7-cc92-49bc-bac5-9724067dafe5)

This pull request fixes the issue. In terms of how the fix is actually implemented, I'm not that familiar with ratatui so lmk if there's a better way to ensure the legend is fully opaque.

## Issue

N/A

## Testing

I visually examined the graphs to confirm that the bug no longer appears.

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
