### PR TITLE
docs: use local link in docs to reference itself & missing CPU config

### DIFF
--- a/docs/content/contribution/documentation.md
+++ b/docs/content/contribution/documentation.md
@@ -12,7 +12,7 @@ There are a few areas where documentation changes are often needed:
 
 - The [`README.md`](https://github.com/ClementTsang/bottom/blob/main/README.md)
 - The help menu inside of the application (located [here](https://github.com/ClementTsang/bottom/blob/main/src/constants.rs))
-- The [extended documentation](https://clementtsang.github.io/bottom/nightly/) (here)
+- The [extended documentation](../index.md) (what you're reading right now)
 - The [`CHANGELOG.md`](https://github.com/ClementTsang/bottom/blob/main/CHANGELOG.md)
 
 ## How should I add/update documentation?

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -166,11 +166,12 @@ nav:
       - "Command-line Options": configuration/command-line-options.md
       - "Config File":
           - configuration/config-file/index.md
-          - "Flags": configuration/config-file/flags.md
-          - "Styling": configuration/config-file/styling.md
-          - "Layout": configuration/config-file/layout.md
+          - "CPU Widget": configuration/config-file/cpu.md
           - "Data Filtering": configuration/config-file/data-filtering.md
-          - "Processes": configuration/config-file/processes.md
+          - "Flags": configuration/config-file/flags.md
+          - "Layout": configuration/config-file/layout.md
+          - "Processes Widget": configuration/config-file/processes.md
+          - "Styling": configuration/config-file/styling.md
   - "Contribution":
       - "Issues, Pull Requests, and Discussions": contribution/issues-and-pull-requests.md
       - "Documentation": contribution/documentation.md


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Noticed this when doing https://github.com/ClementTsang/bottom/pull/1703

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
