### PR TITLE
bug: fix incorrect disable mouse click condition on cleanup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ fn try_drawing(
     painter: &mut canvas::Painter,
 ) -> anyhow::Result<()> {
     if let Err(err) = painter.draw_data(terminal, app) {
-        cleanup_terminal(terminal, &app.app_config_fields)?;
+        cleanup_terminal(terminal)?;
         Err(err.into())
     } else {
         Ok(())
@@ -71,14 +71,13 @@ fn try_drawing(
 
 /// Clean up the terminal before returning it to the user.
 fn cleanup_terminal(
-    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>, app_config_fields: &AppConfigFields,
+    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
 ) -> anyhow::Result<()> {
     disable_raw_mode()?;
-    if app_config_fields.disable_click {
-        execute!(terminal.backend_mut(), DisableMouseCapture)?;
-    }
+
     execute!(
         terminal.backend_mut(),
+        DisableMouseCapture,
         DisableBracketedPaste,
         LeaveAlternateScreen,
         Show,
@@ -457,7 +456,7 @@ pub fn start_bottom(enable_error_hook: &mut bool) -> anyhow::Result<()> {
     // I think doing it in this order is safe...
     // TODO: maybe move the cancellation token to the ctrl-c handler?
     cancellation_token.cancel();
-    cleanup_terminal(&mut terminal, &app.app_config_fields)?;
+    cleanup_terminal(&mut terminal)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Looks like a bug slipped through in #1706 so when stopping the program click events would continue. I could just fix the condition but I think it's fine to just unconditionally disable click events on cleanup.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
