### PR TITLE
bug: fix invalid values in desktop file

### DIFF
--- a/desktop/bottom.desktop
+++ b/desktop/bottom.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
 Name=bottom
-Version=0.10.2
+Version=1.5
 GenericName=System Monitor
 Comment=A customizable cross-platform graphical process/system monitor for the terminal.
 Exec=btm
 Terminal=true
 Type=Application
-Categories=Utility;System;ConsoleOnly;Monitor;
+Categories=System;ConsoleOnly;Monitor;
 StartupNotify=false


### PR DESCRIPTION
## Description

### Background

The current desktop file caused an error and a hint from `desktop-file-validate` 0.28.

```console
> desktop-file-validate bottom.desktop
bottom.desktop: error: value "0.10.2" for key "Version" in group "Desktop Entry" is not a known version
bottom.desktop: hint: value "Utility;System;ConsoleOnly;Monitor;" for key "Categories" in group "Desktop Entry" contains more than one main category; application might appear more than once in the application menu
```

Especially, this error becomes a blocker when adding local patches for issues like https://github.com/ClementTsang/bottom/issues/1447. Because of `desktop-file-edit` also reports the same validation error.

### Changes

This PR addresses those issues:

- The "Version" field must be empty or a desktop entry specification version (e.g., `1.0`, `1.5`), not the tool's version.
- The "Categories" field should only contain one main category to avoid warnings.

ref: https://specifications.freedesktop.org/desktop-entry-spec/1.5/recognized-keys.html

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
