### PR TITLE
bug: fix parsing issue around certain disk names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ That said, these are more guidelines rather than hardset rules, though the proje
 - [#1663](https://github.com/ClementTsang/bottom/pull/1663): Fix network graphs using log scaling having broken lines when a point was 0.
 - [#1683](https://github.com/ClementTsang/bottom/pull/1683): Fix graph lines potentially showing up behind legends.
 - [#1701](https://github.com/ClementTsang/bottom/pull/1701): Fix process kill dialog occasionally causing panics.
+- [#1755](https://github.com/ClementTsang/bottom/pull/1755): Fix missing stats/incorrect mount name for certain entries in the disk widget.
 
 ### Changes
 

--- a/src/collection/disks/unix/linux/partition.rs
+++ b/src/collection/disks/unix/linux/partition.rs
@@ -76,6 +76,7 @@ impl Partition {
 
     /// Returns the usage stats for this partition.
     pub fn usage(&self) -> anyhow::Result<Usage> {
+        // TODO: This might be unoptimal.
         let path = self
             .mount_point
             .to_str()
@@ -103,6 +104,18 @@ impl Partition {
     }
 }
 
+fn fix_mount_point(s: &str) -> String {
+    const ESCAPED_BACKSLASH: &str = "\\134";
+    const ESCAPED_SPACE: &str = "\\040";
+    const ESCAPED_TAB: &str = "\\011";
+    const ESCAPED_NEWLINE: &str = "\\012";
+
+    s.replace(ESCAPED_BACKSLASH, "\\")
+        .replace(ESCAPED_SPACE, " ")
+        .replace(ESCAPED_TAB, "\t")
+        .replace(ESCAPED_NEWLINE, "\n")
+}
+
 impl FromStr for Partition {
     type Err = anyhow::Error;
 
@@ -117,14 +130,9 @@ impl FromStr for Partition {
                 bail!("missing device");
             }
         };
+
         let mount_point = match parts.next() {
-            Some(point) => PathBuf::from(
-                point
-                    .replace("\\134", "\\")
-                    .replace("\\040", " ")
-                    .replace("\\011", "\t")
-                    .replace("\\012", "\n"),
-            ),
+            Some(mount_point) => PathBuf::from(fix_mount_point(mount_point)),
             None => {
                 bail!("missing mount point");
             }
@@ -196,4 +204,16 @@ pub(crate) fn physical_partitions() -> anyhow::Result<Vec<Partition>> {
     }
 
     Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fix_mount_point() {
+        let line = "/run/media/test/Samsung\\040980";
+
+        assert_eq!(fix_mount_point(line), "/run/media/test/Samsung 980");
+    }
 }


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Turns out that in /proc/mount disk names may have weird escape characters, which led to incorrect path names, causing problems - these need to be changed when parsing it.


## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
