### PR TITLE
bug: fix increment for data tables if the change is greater than the number of entries left

### DIFF
--- a/src/canvas/components/data_table.rs
+++ b/src/canvas/components/data_table.rs
@@ -109,18 +109,29 @@ impl<DataType: DataToCell<H>, H: ColumnHeader, S: SortType, C: DataTableColumn<H
 
         let csp: Result<i64, _> = self.state.current_index.try_into();
         if let Ok(csp) = csp {
-            let proposed: Result<usize, _> = (csp + change).try_into();
-            if let Ok(proposed) = proposed {
-                if proposed < self.data.len() {
-                    self.state.current_index = proposed;
-                    self.state.scroll_direction = if change < 0 {
-                        ScrollDirection::Up
-                    } else {
-                        ScrollDirection::Down
-                    };
+            let proposed = csp + change;
 
-                    return Some(self.state.current_index);
-                }
+            let proposed: Result<usize, _> = if proposed.is_negative() {
+                Ok(0)
+            } else {
+                proposed.try_into()
+            };
+
+            if let Ok(proposed) = proposed {
+                let proposed = if proposed >= max_index {
+                    max_index - 1
+                } else {
+                    proposed
+                };
+
+                self.state.current_index = proposed;
+                self.state.scroll_direction = if change < 0 {
+                    ScrollDirection::Up
+                } else {
+                    ScrollDirection::Down
+                };
+
+                return Some(self.state.current_index);
             }
         }
 


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Current implementation refuses to paginate (e.g. page up) if there isn't enough rows. This is only an issue for widgets. (Pagination works just fine for help menu or kill process menu.)
This PR fixes the issue so that pagination behaves as one would expect.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [x] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
