### PR TITLE
docs: revert 0.11.0 docs change

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,7 +81,7 @@ body:
 
         It would also be helpful if you are not running [the latest version](https://github.com/ClementTsang/bottom/releases/latest)
         to try that as well to see if the issue has already been resolved.
-      placeholder: 0.11.0
+      placeholder: 0.10.2
 
   - type: textarea
     id: install

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ Alternatively, you can use `cargo install` using the repo as the source.
 rustup update stable
 
 # Option 1 - Download an archive from releases and install
-curl -LO https://github.com/ClementTsang/bottom/archive/0.11.0.tar.gz
-tar -xzvf 0.11.0.tar.gz
+curl -LO https://github.com/ClementTsang/bottom/archive/0.10.2.tar.gz
+tar -xzvf 0.10.2.tar.gz
 cargo install --path . --locked
 
 # Option 2 - Manually clone the repo and install
@@ -215,20 +215,20 @@ Some examples of installing it this way:
 
 ```bash
 # x86-64
-curl -LO https://github.com/ClementTsang/bottom/releases/download/0.11.0/bottom_0.11.0-1_amd64.deb
-sudo dpkg -i bottom_0.11.0-1_amd64.deb
+curl -LO https://github.com/ClementTsang/bottom/releases/download/0.10.2/bottom_0.10.2-1_amd64.deb
+sudo dpkg -i bottom_0.10.2-1_amd64.deb
 
 # ARM64
-curl -LO https://github.com/ClementTsang/bottom/releases/download/0.11.0/bottom_0.11.0-1_arm64.deb
-sudo dpkg -i bottom_0.11.0-1_arm64.deb
+curl -LO https://github.com/ClementTsang/bottom/releases/download/0.10.2/bottom_0.10.2-1_arm64.deb
+sudo dpkg -i bottom_0.10.2-1_arm64.deb
 
 # ARM
-curl -LO https://github.com/ClementTsang/bottom/releases/download/0.11.0/bottom_0.11.0-1_armhf.deb
-sudo dpkg -i bottom_0.11.0-1_armhf.deb
+curl -LO https://github.com/ClementTsang/bottom/releases/download/0.10.2/bottom_0.10.2-1_armhf.deb
+sudo dpkg -i bottom_0.10.2-1_armhf.deb
 
 # musl-based
-curl -LO https://github.com/ClementTsang/bottom/releases/download/0.11.0/bottom-musl_0.11.0-1_amd64.deb
-sudo dpkg -i bottom-musl_0.11.0-1_amd64.deb
+curl -LO https://github.com/ClementTsang/bottom/releases/download/0.10.2/bottom-musl_0.10.2-1_amd64.deb
+sudo dpkg -i bottom-musl_0.10.2-1_amd64.deb
 ```
 
 ### Exherbo Linux
@@ -260,8 +260,8 @@ sudo dnf install bottom
 For example:
 
 ```bash
-curl -LO https://github.com/ClementTsang/bottom/releases/download/0.11.0/bottom-0.11.0-1.x86_64.rpm
-sudo rpm -i bottom-0.11.0-1.x86_64.rpm
+curl -LO https://github.com/ClementTsang/bottom/releases/download/0.10.2/bottom-0.10.2-1.x86_64.rpm
+sudo rpm -i bottom-0.10.2-1.x86_64.rpm
 ```
 
 ### Gentoo


### PR DESCRIPTION
This reverts commit 4416cf6b29701a67b093678e60e005de74c9642c.

Didn't mean to merge this yet -_-

## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
