### PR TITLE
fix: use default disk.columns when only other disk.* configs exist

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -407,7 +407,7 @@ pub(crate) fn init_app(args: BottomArgs, config: Config) -> Result<(App, BottomL
                                 DiskTableWidget::new(
                                     &app_config_fields,
                                     &styling,
-                                    config.disk.as_ref().map(|cfg| cfg.columns.as_slice()),
+                                    config.disk.as_ref().and_then(|cfg| cfg.columns.as_deref()),
                                 ),
                             );
                         }

--- a/src/options/config/disk.rs
+++ b/src/options/config/disk.rs
@@ -16,7 +16,7 @@ pub(crate) struct DiskConfig {
 
     /// A list of disk widget columns.
     #[serde(default)]
-    pub(crate) columns: Vec<DiskColumn>, // TODO: make this more composable(?) in the future, we might need to rethink how it's done for custom widgets
+    pub(crate) columns: Option<Vec<DiskColumn>>, // TODO: make this more composable(?) in the future, we might need to rethink how it's done for custom widgets
 }
 
 #[cfg(test)]
@@ -24,10 +24,17 @@ mod test {
     use super::DiskConfig;
 
     #[test]
-    fn empty_column_setting() {
+    fn none_column_setting() {
         let config = "";
         let generated: DiskConfig = toml_edit::de::from_str(config).unwrap();
-        assert!(generated.columns.is_empty());
+        assert!(generated.columns.is_none());
+    }
+
+    #[test]
+    fn empty_column_setting() {
+        let config = r#"columns = []"#;
+        let generated: DiskConfig = toml_edit::de::from_str(config).unwrap();
+        assert!(generated.columns.unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`de5de558`](https://github.com/ClementTsang/bottom/pull/1776/commits/de5de558a4f42b705aa3bdcccb8383f9b2f0d796) fix: use default disk.columns when only other disk.* configs exist

I configured `[disk.name_filter]` and after upgrading to v0.11.0, the
disk widget became empty since `disk.columns` was parsed as an empty
vector unless I added `disk.columns` to my config as well.


<!-- === GH HISTORY FENCE === -->

## Issue

N/A

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

Using a config like:

```toml
[disk]
# The columns shown by the process widget. The following columns are supported:
# Disk, Mount, Used, Free, Total, Used%, Free%, R/s, W/s
# columns = ["Disk", "Mount", "Used", "Free", "Total", "Used%", "R/s", "W/s"]
[disk.name_filter]
is_list_ignored = true
list = ["^tank.*@"]
regex = true
case_sensitive = true
whole_word = false
```

v0.11.0 renders an empty disk widget. This PR uses the default disk
widget columns.

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [x] _If relevant, new tests were added (don't worry too much about coverage)_
