### PR TITLE
docs: Add installation with gah

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
   - [Snap](#snap)
   - [Solus](#solus)
   - [Void](#void)
+  - [gah](#gah)
   - [Homebrew](#homebrew)
   - [MacPorts](#macports)
   - [Chocolatey](#chocolatey)
@@ -324,6 +325,14 @@ Available [in the void-packages repo](https://github.com/void-linux/void-package
 
 ```bash
 sudo xbps-install bottom
+```
+
+### gah
+
+bottom can also be installed on Linux or macOS using [gah](https://github.com/marverix/gah):
+
+```bash
+gah install bottom
 ```
 
 ### Homebrew


### PR DESCRIPTION
## Description

Hello,
this PR adds to the documentation the installation method using [gah](https://github.com/marverix/gah/):
> gah is an GitHub Releases app installer, that DOES NOT REQUIRE SUDO! It is a simple bash script that downloads the latest release of an app from GitHub and installs it in ~/.local/bin. It is designed to be used with apps that are distributed as a single binary file.
