### PR TITLE
ci: test freebsd 15 in CI again

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -236,12 +236,11 @@ jobs:
 
           # Alas, that's why we do it with VMs.
 
-          # Disabled as there's a weird issue with installing curl on FreeBSD 15 at the moment.
-          # - {
-          #     type: "freebsd",
-          #     os_release: "15.0",
-          #     target: "x86_64-unknown-freebsd",
-          #   }
+          - {
+              type: "freebsd",
+              os_release: "15.0",
+              target: "x86_64-unknown-freebsd",
+            }
           - {
               type: "freebsd",
               os_release: "14.3",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,12 +285,11 @@ jobs:
           #
           # Alas, that's why we do it with VMs.
 
-          # Disabled as there's a weird issue with installing curl on FreeBSD 15 at the moment.
-          # - {
-          #     type: "freebsd",
-          #     os_release: "15.0",
-          #     target: "x86_64-unknown-freebsd",
-          #   }
+          - {
+              type: "freebsd",
+              os_release: "15.0",
+              target: "x86_64-unknown-freebsd",
+            }
           - {
               type: "freebsd",
               os_release: "14.3",


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

FreeBSD 15 broke in CI a while ago, this PR exists to try it every once in a while and see if it's fixed.

The error in question is:

```
Shared object "libk5crypto.so.121" not found, required by "curl"
```

Possibly related:
- https://lists.freebsd.org/archives/freebsd-pkgbase/2025-August/000621.html
- https://github.com/vmactions/freebsd-vm/issues/108

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
