### PR TITLE
bug: fix issue with battery time and small widths

### DIFF
--- a/src/canvas/widgets/battery_display.rs
+++ b/src/canvas/widgets/battery_display.rs
@@ -117,11 +117,11 @@ impl Painter {
 
             let is_basic = app_state.app_config_fields.use_basic_mode;
 
-            let margined_draw_loc = Layout::default()
+            let [margined_draw_loc] = Layout::default()
                 .constraints([Constraint::Percentage(100)])
                 .horizontal_margin(u16::from(is_basic && !is_selected))
                 .direction(Direction::Horizontal)
-                .split(draw_loc)[0];
+                .areas(draw_loc);
 
             if let Some(battery_details) =
                 battery_harvest.get(battery_widget_state.currently_selected_battery_index)
@@ -168,13 +168,15 @@ impl Painter {
                 let mut time: String; // Keep string lifetime in scope.
                 {
                     let style = self.styles.text_style;
+                    let time_width = (full_width / 2) as usize;
+
                     match &battery_details.state {
                         BatteryState::Charging {
                             time_to_full: Some(secs),
                         } => {
                             time = long_time(*secs);
 
-                            if full_width as usize > time.len() {
+                            if time_width >= time.len() {
                                 battery_rows.push(Row::new(["Time to full", &time]).style(style));
                             } else {
                                 time = short_time(*secs);
@@ -186,7 +188,7 @@ impl Painter {
                         } => {
                             time = long_time(*secs);
 
-                            if full_width as usize > time.len() {
+                            if time_width >= time.len() {
                                 battery_rows.push(Row::new(["Time to empty", &time]).style(style));
                             } else {
                                 time = short_time(*secs);


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Fix an issue where we used the full width of the battery widget to determine when to use short times - we should use _half_ of it.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [ ] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
