### PR TITLE
bug: fix colon at end of process name for now on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ That said, these are more guidelines rather than hardset rules, though the proje
 
 - [#1793](https://github.com/ClementTsang/bottom/pull/1793): Add support for threads in Linux.
 
+### Bug Fixes
+
+- [#1800](https://github.com/ClementTsang/bottom/pull/1800): Fix colon at end of process name in Linux.
+
 ## [0.11.1] - 2025-08-15
 
 ### Bug Fixes

--- a/src/collection/processes/linux/mod.rs
+++ b/src/collection/processes/linux/mod.rs
@@ -239,20 +239,22 @@ fn read_proc(
 
                 // TODO: We might want to re-evaluate if we want to do it like this,
                 // as it turns out I was dumb and sometimes comm != process name...
+                //
+                // What we should do is store:
+                // - basename (what we're kinda doing now, except we're gating on comm length)
+                // - command (full thing)
+                // - comm (as a separate thing)
                 let name = if comm.len() >= MAX_STAT_NAME_LEN {
                     let mut start = 0;
                     let mut end = cmdline.len();
 
-                    let mut i = 0;
-                    for c in cmdline.chars() {
+                    for (i, c) in cmdline.chars().enumerate() {
                         if c == '/' {
                             start = i + 1;
                         } else if c == ' ' || c == ':' {
                             end = i;
                             break;
                         }
-
-                        i += 1;
                     }
 
                     cmdline[start..end].to_string()

--- a/src/collection/processes/linux/mod.rs
+++ b/src/collection/processes/linux/mod.rs
@@ -137,7 +137,7 @@ fn read_proc(
     thread_parent: Option<Pid>,
 ) -> CollectionResult<(ProcessHarvest, u64)> {
     let Process {
-        pid: _,
+        pid: _pid,
         uid,
         stat,
         io,
@@ -221,36 +221,49 @@ fn read_proc(
     };
 
     let (command, name) = {
-        let truncated_name = stat.comm;
+        let comm = stat.comm;
         if let Some(cmdline) = cmdline {
             if cmdline.is_empty() {
-                (concat_string!("[", truncated_name, "]"), truncated_name)
+                (concat_string!("[", comm, "]"), comm)
             } else {
-                let name = if truncated_name.len() >= MAX_STAT_NAME_LEN {
-                    let first_part = match cmdline.split_once(' ') {
-                        Some((first, _)) => first,
-                        None => &cmdline,
-                    };
+                // If the comm fits then we'll default to whatever is set.
+                // If it doesn't, we need to do some magic to determine what it's
+                // supposed to be.
+                //
+                // We follow something similar to how htop does it to identify a valid name based on the cmdline.
+                // - https://github.com/htop-dev/htop/blob/bcb18ef82269c68d54a160290e5f8b2e939674ec/Process.c
+                // - https://github.com/htop-dev/htop/blob/bcb18ef82269c68d54a160290e5f8b2e939674ec/Process.c#L573
+                //
+                // Also note that cmdline is (for us) separated by spaces, not newlines,
+                // because we pre-processed it already.
 
-                    // We're only interested in the executable part, not the file path (part of command),
-                    // so strip everything but the command name if needed.
-                    let command = match first_part.rsplit_once('/') {
-                        Some((_, last)) => last,
-                        None => first_part,
-                    };
+                // TODO: We might want to re-evaluate if we want to do it like this,
+                // as it turns out I was dumb and sometimes comm != process name...
+                let name = if comm.len() >= MAX_STAT_NAME_LEN {
+                    let mut start = 0;
+                    let mut end = cmdline.len();
 
-                    // TODO: Needed as some processes have stuff like "systemd-userwork: waiting..."
-                    // command.trim_end_matches(':').to_string()
+                    let mut i = 0;
+                    for c in cmdline.chars() {
+                        if c == '/' {
+                            start = i + 1;
+                        } else if c == ' ' || c == ':' {
+                            end = i;
+                            break;
+                        }
 
-                    command.to_string()
+                        i += 1;
+                    }
+
+                    cmdline[start..end].to_string()
                 } else {
-                    truncated_name
+                    comm
                 };
 
                 (cmdline, name)
             }
         } else {
-            (truncated_name.clone(), truncated_name)
+            (comm.clone(), comm)
         }
     };
 

--- a/src/collection/processes/linux/mod.rs
+++ b/src/collection/processes/linux/mod.rs
@@ -545,5 +545,9 @@ mod tests {
         assert_eq!(name_from_cmdline("/usr/bin/b tm:"), "b tm");
         assert_eq!(name_from_cmdline("/usr/bin/b tm\0--test"), "b tm");
         assert_eq!(name_from_cmdline("/usr/bin/b tm:\0--test"), "b tm");
+        assert_eq!(
+            name_from_cmdline("/usr/bin/b t m:\0--\"test thing\""),
+            "b t m"
+        );
     }
 }

--- a/src/collection/processes/linux/mod.rs
+++ b/src/collection/processes/linux/mod.rs
@@ -231,7 +231,7 @@ fn read_proc(
                 // supposed to be.
                 //
                 // We follow something similar to how htop does it to identify a valid name based on the cmdline.
-                // - https://github.com/htop-dev/htop/blob/bcb18ef82269c68d54a160290e5f8b2e939674ec/Process.c
+                // - https://github.com/htop-dev/htop/blob/bcb18ef82269c68d54a160290e5f8b2e939674ec/Process.c#L268 (kinda)
                 // - https://github.com/htop-dev/htop/blob/bcb18ef82269c68d54a160290e5f8b2e939674ec/Process.c#L573
                 //
                 // Also note that cmdline is (for us) separated by spaces, not newlines,
@@ -244,6 +244,8 @@ fn read_proc(
                 // - basename (what we're kinda doing now, except we're gating on comm length)
                 // - command (full thing)
                 // - comm (as a separate thing)
+                //
+                // Stuff like htop also offers the option to "highlight" basename and comm in command. Might be neat?
                 let name = if comm.len() >= MAX_STAT_NAME_LEN {
                     let mut start = 0;
                     let mut end = cmdline.len();

--- a/src/collection/processes/linux/process.rs
+++ b/src/collection/processes/linux/process.rs
@@ -305,19 +305,7 @@ impl Process {
 
 #[inline]
 fn cmdline(root: &mut PathBuf, fd: &OwnedFd, buffer: &mut String) -> anyhow::Result<()> {
-    let _ = open_at(root, "cmdline", fd)
-        .map(|mut file| file.read_to_string(buffer))
-        .inspect(|_| {
-            // SAFETY: We are only replacing a single char (NUL) with another single char (space).
-            let buf_mut = unsafe { buffer.as_mut_vec() };
-
-            for byte in buf_mut {
-                if *byte == 0 {
-                    const SPACE: u8 = ' '.to_ascii_lowercase() as u8;
-                    *byte = SPACE;
-                }
-            }
-        })?;
+    let _ = open_at(root, "cmdline", fd).map(|mut file| file.read_to_string(buffer))?;
 
     Ok(())
 }

--- a/src/collection/processes/linux/process.rs
+++ b/src/collection/processes/linux/process.rs
@@ -237,7 +237,7 @@ impl Process {
     ) -> anyhow::Result<(Process, Vec<PathBuf>)> {
         buffer.clear();
 
-        let fd = rustix::fs::openat(
+        let pid_dir = rustix::fs::openat(
             rustix::fs::CWD,
             pid_path.as_path(),
             OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
@@ -257,7 +257,7 @@ impl Process {
             .ok_or_else(|| anyhow!("PID for {pid_path:?} was not found"))?;
 
         let uid = {
-            let metadata = rustix::fs::fstat(&fd);
+            let metadata = rustix::fs::fstat(&pid_dir);
             match metadata {
                 Ok(md) => Some(md.st_uid),
                 Err(_) => None,
@@ -271,10 +271,10 @@ impl Process {
 
         // Stat is pretty long, do this first to pre-allocate up-front.
         let stat =
-            open_at(&mut root, "stat", &fd).and_then(|file| Stat::from_file(file, buffer))?;
+            open_at(&mut root, "stat", &pid_dir).and_then(|file| Stat::from_file(file, buffer))?;
         reset(&mut root, buffer);
 
-        let cmdline = if cmdline(&mut root, &fd, buffer).is_ok() {
+        let cmdline = if cmdline(&mut root, &pid_dir, buffer).is_ok() {
             // The clone will give a string with the capacity of the length of buffer, don't worry.
             Some(buffer.clone())
         } else {
@@ -282,7 +282,7 @@ impl Process {
         };
         reset(&mut root, buffer);
 
-        let io = open_at(&mut root, "io", &fd)
+        let io = open_at(&mut root, "io", &pid_dir)
             .and_then(|file| Io::from_file(file, buffer))
             .ok();
 
@@ -291,7 +291,14 @@ impl Process {
         let threads = if get_threads {
             root.push("task");
 
-            if let Ok(task) = std::fs::read_dir(root) {
+            let task_dir = rustix::fs::openat(
+                rustix::fs::CWD,
+                root.as_path(),
+                OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty(),
+            )?;
+
+            if let Ok(task) = rustix::fs::Dir::read_from(task_dir) {
                 let pid_str = pid.to_string();
 
                 task.flatten()
@@ -301,7 +308,7 @@ impl Process {
                         let file_name = file_name.trim();
 
                         if is_str_numeric(file_name) && file_name != pid_str {
-                            Some(thread_dir.path())
+                            Some(root.join(file_name).to_path_buf())
                         } else {
                             None
                         }


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

This fixes an issue in Linux where some process names that ended with `':'` would appear when they shouldn't.

Note this is kinda an interim fix; turns out I misunderstood some things about comm/cmdline/basenames which I will address later.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
