### PR TITLE
bug: fix issue with process name isolation on Linux

### DIFF
--- a/src/collection/processes/linux/mod.rs
+++ b/src/collection/processes/linux/mod.rs
@@ -229,12 +229,6 @@ fn read_proc(
                 // If the comm fits then we'll default to whatever is set.
                 // If it doesn't, we need to do some magic to determine what it's
                 // supposed to be.
-                //
-                // We follow something similar to how htop does it to identify a valid name based on the cmdline.
-                // - https://github.com/htop-dev/htop/blob/bcb18ef82269c68d54a160290e5f8b2e939674ec/Process.c#L268 (kinda)
-                // - https://github.com/htop-dev/htop/blob/bcb18ef82269c68d54a160290e5f8b2e939674ec/Process.c#L573
-                //
-                // Also note that cmdline is (for us) separated by \0.
 
                 // TODO: We might want to re-evaluate if we want to do it like this,
                 // as it turns out I was dumb and sometimes comm != process name...
@@ -246,7 +240,7 @@ fn read_proc(
                 //
                 // Stuff like htop also offers the option to "highlight" basename and comm in command. Might be neat?
                 let name = if comm.len() >= MAX_STAT_NAME_LEN {
-                    name_from_cmdline(&cmdline)
+                    binary_name_from_cmdline(&cmdline)
                 } else {
                     comm
                 };
@@ -301,7 +295,12 @@ fn read_proc(
     ))
 }
 
-fn name_from_cmdline(cmdline: &str) -> String {
+/// We follow something similar to how htop does it to identify a valid name based on the cmdline.
+/// - https://github.com/htop-dev/htop/blob/bcb18ef82269c68d54a160290e5f8b2e939674ec/Process.c#L268 (kinda)
+/// - https://github.com/htop-dev/htop/blob/bcb18ef82269c68d54a160290e5f8b2e939674ec/Process.c#L573
+///
+/// Also note that cmdline is (for us) separated by \0.
+fn binary_name_from_cmdline(cmdline: &str) -> String {
     let mut start = 0;
     let mut end = cmdline.len();
 
@@ -314,7 +313,12 @@ fn name_from_cmdline(cmdline: &str) -> String {
         }
     }
 
-    cmdline[start..end].to_string()
+    // Bit of a hack to handle cases like "firefox -blah"
+    let partial = &cmdline[start..end];
+    partial
+        .split_once(" -")
+        .map(|(name, _)| name.to_string())
+        .unwrap_or_else(|| partial.to_string())
 }
 
 pub(crate) struct PrevProc<'a> {
@@ -538,16 +542,20 @@ mod tests {
 
     #[test]
     fn test_name_from_cmdline() {
-        assert_eq!(name_from_cmdline("/usr/bin/btm"), "btm");
-        assert_eq!(name_from_cmdline("/usr/bin/btm\0--asdf\0--asdf/gkj"), "btm");
-        assert_eq!(name_from_cmdline("/usr/bin/btm:"), "btm");
-        assert_eq!(name_from_cmdline("/usr/bin/b tm"), "b tm");
-        assert_eq!(name_from_cmdline("/usr/bin/b tm:"), "b tm");
-        assert_eq!(name_from_cmdline("/usr/bin/b tm\0--test"), "b tm");
-        assert_eq!(name_from_cmdline("/usr/bin/b tm:\0--test"), "b tm");
+        assert_eq!(binary_name_from_cmdline("/usr/bin/btm"), "btm");
+        assert_eq!(binary_name_from_cmdline("/usr/bin/btm\0--asdf\0--asdf/gkj"), "btm");
+        assert_eq!(binary_name_from_cmdline("/usr/bin/btm:"), "btm");
+        assert_eq!(binary_name_from_cmdline("/usr/bin/b tm"), "b tm");
+        assert_eq!(binary_name_from_cmdline("/usr/bin/b tm:"), "b tm");
+        assert_eq!(binary_name_from_cmdline("/usr/bin/b tm\0--test"), "b tm");
+        assert_eq!(binary_name_from_cmdline("/usr/bin/b tm:\0--test"), "b tm");
         assert_eq!(
-            name_from_cmdline("/usr/bin/b t m:\0--\"test thing\""),
+            binary_name_from_cmdline("/usr/bin/b t m:\0--\"test thing\""),
             "b t m"
+        );
+        assert_eq!(
+            binary_name_from_cmdline("firefox -contentproc -isForBrowser -prefsHandle 0"),
+            "firefox"
         );
     }
 }

--- a/src/collection/processes/linux/mod.rs
+++ b/src/collection/processes/linux/mod.rs
@@ -543,7 +543,10 @@ mod tests {
     #[test]
     fn test_name_from_cmdline() {
         assert_eq!(binary_name_from_cmdline("/usr/bin/btm"), "btm");
-        assert_eq!(binary_name_from_cmdline("/usr/bin/btm\0--asdf\0--asdf/gkj"), "btm");
+        assert_eq!(
+            binary_name_from_cmdline("/usr/bin/btm\0--asdf\0--asdf/gkj"),
+            "btm"
+        );
         assert_eq!(binary_name_from_cmdline("/usr/bin/btm:"), "btm");
         assert_eq!(binary_name_from_cmdline("/usr/bin/b tm"), "b tm");
         assert_eq!(binary_name_from_cmdline("/usr/bin/b tm:"), "b tm");


### PR DESCRIPTION
## Description

_A description of the change, what it does, and why it was made. If relevant (such as any change that modifies the UI), **please provide screenshots** of the changes:_

Things like `firefox -bin -blah` were being displayed as `firefox -bin -blah` and not `firefox`. This was caused by a bug in https://github.com/ClementTsang/bottom/pull/1800.

## Issue

_If applicable, what issue does this address?_

Closes: #

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_

_If this is a code change, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS_
- [x] _Linux_

Tested on Linux (only affects Linux), and a unit test added.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [ ] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
