### PR TITLE
bug: skip avg cpu in basic mode with dedicated row

### DIFF
--- a/sample_configs/default_config.toml
+++ b/sample_configs/default_config.toml
@@ -9,6 +9,9 @@
 # Whether to hide the average cpu entry.
 #hide_avg_cpu = false
 
+# Whether to use a dedicated row for the average cpu entry
+#average_cpu_row = false
+
 # Whether to use dot markers rather than braille.
 #dot_marker = false
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -351,7 +351,8 @@ impl Painter {
                     let c = (actual_cpu_data_len / 4) as u16
                         + u16::from(actual_cpu_data_len % 4 != 0)
                         + u16::from(
-                            app_state.app_config_fields.dedicated_average_row
+                            app_state.app_config_fields.show_average_cpu
+                                && app_state.app_config_fields.dedicated_average_row
                                 && actual_cpu_data_len.saturating_sub(1) % 4 != 0,
                         );
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -258,6 +258,9 @@ pub(crate) const CONFIG_TEXT: &str = r#"# This is a default config file for bott
 # Whether to hide the average cpu entry.
 #hide_avg_cpu = false
 
+# Whether to use a dedicated row for the average cpu entry
+#average_cpu_row = false
+
 # Whether to use dot markers rather than braille.
 #dot_marker = false
 


### PR DESCRIPTION
## Description

 The basic mode cpu widget after 0.11.0 shows the AVG CPU entry in the core bars and the dedicated row when `hide_avg_cpu = false` and `average_cpu_row = true`. This was not the behaviour with 0.10.2. It is caused by an off by 1 error resulting in a core being hidden too(core 15 in screenshot). This change uses the index to skip the AVG in the `cpu_data`, includes `hide_avg_cpu` and updates the configuration for `average_cpu_row`.

Screenshot: Top is nightly with bug, bottom is this PR fixed

<img width="3788" height="914" alt="btm-basic-avg" src="https://github.com/user-attachments/assets/811973c9-9bdf-4b15-b5db-910bf63b573b" />


## Testing

Ran on linux in basic mode with `hide_avg_cpu` and `average_cpu_row` set to true/false.

- [ ] _Windows_
- [ ] _macOS_
- [X] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [X] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [X] _The change has been tested and doesn't appear to cause any unintended breakage_
- [X] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [X] _The pull request passes the provided CI pipeline_
- [X] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
