### PR TITLE
process_ext.rs: fix build on FreeBSD on ARM / POWER

### DIFF
--- a/src/collection/processes/unix/process_ext.rs
+++ b/src/collection/processes/unix/process_ext.rs
@@ -172,7 +172,7 @@ fn convert_process_status_to_char(status: ProcessStatus) -> char {
                 _ => '?'
             }
         } else if #[cfg(target_os = "freebsd")] {
-            const fn assert_u8(val: i8) -> u8 {
+            const fn assert_u8(val: libc::c_char) -> u8 {
                 if val < 0 { panic!("there was an invalid i8 constant that is supposed to be a char") } else { val as u8 }
             }
 


### PR DESCRIPTION
## Description

Both ARM and POWER use unsigned char.

## Issue

Build currently fails with:
```
error[E0308]: mismatched types
   --> src/collection/processes/unix/process_ext.rs:186:40
    |
186 |             const SIDL: u8 = assert_u8(libc::SIDL);
    |                              --------- ^^^^^^^^^^ expected `i8`, found `u8`
    |                              |
    |                              arguments to this function are incorrect
    |
note: function defined here
   --> src/collection/processes/unix/process_ext.rs:182:22
    |
182 |             const fn assert_u8(val: i8) -> u8 {
    |                      ^^^^^^^^^ -------

error[E0308]: mismatched types
   --> src/collection/processes/unix/process_ext.rs:187:40
    |
187 |             const SRUN: u8 = assert_u8(libc::SRUN);
    |                              --------- ^^^^^^^^^^ expected `i8`, found `u8`
    |                              |
    |                              arguments to this function are incorrect
    |
note: function defined here
   --> src/collection/processes/unix/process_ext.rs:182:22
    |
182 |             const fn assert_u8(val: i8) -> u8 {
    |                      ^^^^^^^^^ -------

error[E0308]: mismatched types
   --> src/collection/processes/unix/process_ext.rs:188:42
    |
188 |             const SSLEEP: u8 = assert_u8(libc::SSLEEP);
    |                                --------- ^^^^^^^^^^^^ expected `i8`, found `u8`
    |                                |
    |                                arguments to this function are incorrect
    |
note: function defined here
   --> src/collection/processes/unix/process_ext.rs:182:22
    |
182 |             const fn assert_u8(val: i8) -> u8 {
    |                      ^^^^^^^^^ -------

error[E0308]: mismatched types
   --> src/collection/processes/unix/process_ext.rs:189:41
    |
189 |             const SSTOP: u8 = assert_u8(libc::SSTOP);
    |                               --------- ^^^^^^^^^^^ expected `i8`, found `u8`
    |                               |
    |                               arguments to this function are incorrect
    |
note: function defined here
   --> src/collection/processes/unix/process_ext.rs:182:22
    |
182 |             const fn assert_u8(val: i8) -> u8 {
    |                      ^^^^^^^^^ -------

error[E0308]: mismatched types
   --> src/collection/processes/unix/process_ext.rs:190:41
    |
190 |             const SZOMB: u8 = assert_u8(libc::SZOMB);
    |                               --------- ^^^^^^^^^^^ expected `i8`, found `u8`
    |                               |
    |                               arguments to this function are incorrect
    |
note: function defined here
   --> src/collection/processes/unix/process_ext.rs:182:22
    |
182 |             const fn assert_u8(val: i8) -> u8 {
    |                      ^^^^^^^^^ -------

error[E0308]: mismatched types
   --> src/collection/processes/unix/process_ext.rs:191:41
    |
191 |             const SWAIT: u8 = assert_u8(libc::SWAIT);
    |                               --------- ^^^^^^^^^^^ expected `i8`, found `u8`
    |                               |
    |                               arguments to this function are incorrect
    |
note: function defined here
   --> src/collection/processes/unix/process_ext.rs:182:22
    |
182 |             const fn assert_u8(val: i8) -> u8 {
    |                      ^^^^^^^^^ -------

error[E0308]: mismatched types
   --> src/collection/processes/unix/process_ext.rs:192:41
    |
192 |             const SLOCK: u8 = assert_u8(libc::SLOCK);
    |                               --------- ^^^^^^^^^^^ expected `i8`, found `u8`
    |                               |
    |                               arguments to this function are incorrect
    |
note: function defined here
   --> src/collection/processes/unix/process_ext.rs:182:22
    |
182 |             const fn assert_u8(val: i8) -> u8 {
    |                      ^^^^^^^^^ -------
```

## Testing

Build and run-tested on a FreeBSD 14.3-RELEASE powerpc64 VM.

## Checklist

_If relevant, ensure the following have been met:_

- [ ] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [ ] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
