### PR TITLE
feature: adding spacebar to toggle tree mode

### DIFF
--- a/docs/content/usage/widgets/process.md
+++ b/docs/content/usage/widgets/process.md
@@ -93,7 +93,7 @@ Linux, macOS, and FreeBSD), then a simpler termination screen with just yes or n
 
 ### Tree mode
 
-Pressing ++t++ or ++f5++ in the table toggles tree mode in the process widget, displaying processes in regard to their parent-child process relationships.
+Pressing ++t++, ++f5++ or ++Space++ in the table toggles tree mode in the process widget, displaying processes in regard to their parent-child process relationships.
 
 <figure>
     <img src="../../../assets/screenshots/process/process_tree.webp" alt="A picture of tree mode in a process widget."/>
@@ -230,7 +230,7 @@ Note that key bindings are generally case-sensitive.
 | ++s++ , ++f6++, ++delete++ (++fn+delete++ on macOS) | Toggle showing the sort sub-widget                               |
 | ++I++                                               | Invert the current sort                                          |
 | ++"%"++                                             | Toggle between values and percentages for memory usage           |
-| ++t++ , ++f5++                                      | Toggle tree mode                                                 |
+| ++t++ , ++f5++, ++Space++                           | Toggle tree mode                                                 |
 | ++M++                                               | Sort by gpu memory usage, press again to reverse sorting order   |
 | ++C++                                               | Sort by gpu usage, press again to reverse sorting order          |
 | ++z++                                               | Toggle the hiding of kernel threads                              |

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -78,7 +78,7 @@ const PROCESS_HELP_TEXT: [&str; 20] = [
     "s, F6            Open process sort widget",
     "I                Invert current sort",
     "%                Toggle between values and percentages for memory usage",
-    "t, F5            Toggle tree mode",
+    "t, F5, Space     Toggle tree mode",
     "Right            Collapse a branch while in tree mode",
     "Left             Expand a branch while in tree mode",
     "+, -, click      Toggle whether a branch is expanded or collapsed in tree mode",

--- a/src/event.rs
+++ b/src/event.rs
@@ -67,6 +67,7 @@ pub fn handle_key_event_or_break(
             KeyCode::Down => app.on_down_key(),
             KeyCode::Left => app.on_left_key(),
             KeyCode::Right => app.on_right_key(),
+            KeyCode::Char(' ') => app.toggle_tree_mode(),
             KeyCode::Char(caught_char) => app.on_char_key(caught_char),
             KeyCode::Esc => app.on_esc(),
             KeyCode::Enter => app.on_enter(),

--- a/src/event.rs
+++ b/src/event.rs
@@ -56,25 +56,15 @@ pub fn handle_key_event_or_break(
     // c_debug!("KeyEvent: {event:?}");
 
     if event.modifiers.is_empty() {
-        // Required catch for searching - otherwise you couldn't search with q.
-        if event.code == KeyCode::Char('q') && !app.is_in_search_widget() {
-            return true;
-        }
-
-        // Handle spacebar.
-        // Without the search check, you couldn’t search for names with spaces.
-        if event.code == KeyCode::Char(' ') && !app.is_in_search_widget() {
-            app.toggle_tree_mode();
-            return false;
-        }
-
         match event.code {
+            KeyCode::Char('q') if !app.is_in_search_widget() => return true,
             KeyCode::End => app.skip_to_last(),
             KeyCode::Home => app.skip_to_first(),
             KeyCode::Up => app.on_up_key(),
             KeyCode::Down => app.on_down_key(),
             KeyCode::Left => app.on_left_key(),
             KeyCode::Right => app.on_right_key(),
+            KeyCode::Char(' ') if !app.is_in_search_widget() => app.toggle_tree_mode(),
             KeyCode::Char(caught_char) => app.on_char_key(caught_char),
             KeyCode::Esc => app.on_esc(),
             KeyCode::Enter => app.on_enter(),

--- a/src/event.rs
+++ b/src/event.rs
@@ -60,6 +60,14 @@ pub fn handle_key_event_or_break(
         if event.code == KeyCode::Char('q') && !app.is_in_search_widget() {
             return true;
         }
+
+        // Handle spacebar.
+        // Without the search check, you couldn’t search for names with spaces.
+        if event.code == KeyCode::Char(' ') && !app.is_in_search_widget() {
+            app.toggle_tree_mode();
+            return false;
+        }
+
         match event.code {
             KeyCode::End => app.skip_to_last(),
             KeyCode::Home => app.skip_to_first(),
@@ -67,7 +75,6 @@ pub fn handle_key_event_or_break(
             KeyCode::Down => app.on_down_key(),
             KeyCode::Left => app.on_left_key(),
             KeyCode::Right => app.on_right_key(),
-            KeyCode::Char(' ') => app.toggle_tree_mode(),
             KeyCode::Char(caught_char) => app.on_char_key(caught_char),
             KeyCode::Esc => app.on_esc(),
             KeyCode::Enter => app.on_enter(),


### PR DESCRIPTION
## Description

Adds space key as a toggle for tree mode in the function `handle_key_event_or_break`. Also moved the if statement for quit (Keybind q) inside the match case.

## Issue

https://github.com/ClementTsang/bottom/issues/1808

Closes: #

## Testing

- Checked if space toggle tree mode
- Checked if space is captured during search mode

The tests were run on Linux only.

- [ ] _Windows_
- [ ] _macOS_
- [X] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [X] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [X] _The change has been tested and doesn't appear to cause any unintended breakage_
- [X] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
