### PR TITLE
Simplify `cfg` condition

### DIFF
--- a/src/collection/temperature.rs
+++ b/src/collection/temperature.rs
@@ -7,7 +7,7 @@ cfg_if::cfg_if! {
     if #[cfg(target_os = "linux")] {
         pub mod linux;
         pub use self::linux::*;
-    } else if #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "windows", target_os = "android", target_os = "ios"))] {
+    } else {
         pub mod sysinfo;
         pub use self::sysinfo::*;
     }


### PR DESCRIPTION
Using your crate currently to debug while adding support for NetBSD in `sysinfo` and needed to add `netbsd` to the list when I realized we could simplify it like this. Since `sysinfo` compiles even on unsupported targets, I guess it doesn't hurt...