### PR TITLE
Implemented Enter key for accepting search pattern in Proc widget

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -448,17 +448,35 @@ impl App {
             // Not the best way of doing things for now but works as glue.
             self.process_kill_dialog.on_enter();
         } else if !self.is_in_dialog() {
-            if let BottomWidgetType::ProcSort = self.current_widget.widget_type {
-                if let Some(proc_widget_state) = self
-                    .states
-                    .proc_state
-                    .widget_states
-                    .get_mut(&(self.current_widget.widget_id - 2))
-                {
-                    proc_widget_state.use_sort_table_value();
-                    self.move_widget_selection(&WidgetDirection::Right);
-                    self.is_force_redraw = true;
+            match self.current_widget.widget_type {
+                BottomWidgetType::ProcSearch => {
+                    if let Some(proc_widget_state) = self
+                        .states
+                        .proc_state
+                        .get_mut_widget_state(self.current_widget.widget_id - 1)
+                    {
+                        if proc_widget_state.is_search_enabled() {
+                            proc_widget_state.proc_search.search_state.is_enabled = false;
+                            self.move_widget_selection(&WidgetDirection::Up);
+                            self.is_force_redraw = true;
+                        }
+                    }
                 }
+                BottomWidgetType::ProcSort => {
+                    if let Some(proc_widget_state) = self
+                        .states
+                        .proc_state
+                        .get_mut_widget_state(self.current_widget.widget_id - 2)
+                    {
+                        proc_widget_state.use_sort_table_value();
+                        if proc_widget_state.is_sort_open {
+                            proc_widget_state.is_sort_open = false;
+                            self.move_widget_selection(&WidgetDirection::Right);
+                            self.is_force_redraw = true;
+                        }
+                    }
+                }
+                _ => {}
             }
         }
     }


### PR DESCRIPTION
<!-- Please use this template (unless you have a very good reason not to). PRs that do not use the template may be closed. -->

## Description

Added the ability to press Enter after typing a search term in the Proc widget, making it more Vim-like for those with muscle-memory for Vim's '/' search. If you don't want this behaviour, then I won't be offended if you deny it.

## Testing

I've run the program and tried using '/' followed by 'Enter' to leave search box. I've tested the existing '/' followed by 'Esc' to leave search box as well. Both worked well.

_If this change affects the program, please also indicate which platforms were tested:_

- [x] _Windows_
- [ ] _macOS (specify version below)_
- [x] _Linux (specify distro below)_
  - [x]  NixOS
- [ ] _Other (specify below)_

## Checklist

_Ensure **all** of these are met:_

- [x] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [x] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [ ] _If this is a code change, new tests were added if relevant_
- [x] _If this is a code change, your changes pass `cargo test`_
- [x] _The change has been tested to work (see above) and doesn't appear to break other things_
- [ ] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [x] _There are no merge conflicts_
- [ ] _You have reviewed the changes first_
- [ ] _The pull request passes the provided CI pipeline_

## Other

_Anything else that maintainers should know about this PR:_
