### PR TITLE
other: rename Linux icon to avoid collision with generic `bottom` icon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,8 +208,8 @@ assets = [
         "644",
     ],
     [
-        "assets/icons/bottom.svg",
-        "/usr/share/icons/hicolor/scalable/apps/bottom.svg",
+        "assets/icons/bottom-system-monitor.svg",
+        "/usr/share/icons/hicolor/scalable/apps/bottom-system-monitor.svg",
         "644",
     ],
 ]
@@ -240,7 +240,7 @@ assets = [
     { source = "completion/btm.fish", dest = "/usr/share/fish/vendor_completions.d/btm.fish", mode = "644" },
     { source = "completion/_btm", dest = "/usr/share/zsh/vendor-completions/", mode = "644" },
     { source = "desktop/bottom.desktop", dest = "/usr/share/applications/bottom.desktop", mode = "644" },
-    { source = "assets/icons/bottom.svg", dest = "/usr/share/icons/hicolor/scalable/apps/bottom.svg", mode = "644" },
+    { source = "assets/icons/bottom-system-monitor.svg", dest = "/usr/share/icons/hicolor/scalable/apps/bottom-system-monitor.svg", mode = "644" },
 ]
 
 [lints.rust]

--- a/assets/icons/bottom-system-monitor.svg
+++ b/assets/icons/bottom-system-monitor.svg
@@ -8,7 +8,7 @@
    version="1.1"
    id="svg1"
    inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
-   sodipodi:docname="bottom.svg"
+   sodipodi:docname="bottom-system-monitor.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"

--- a/desktop/bottom.desktop
+++ b/desktop/bottom.desktop
@@ -8,4 +8,4 @@ Terminal=true
 Type=Application
 Categories=System;ConsoleOnly;Monitor;
 StartupNotify=false
-Icon=bottom
+Icon=bottom-system-monitor


### PR DESCRIPTION
<!-- Please use this template (unless you have a very good reason not to). PRs that do not use the template may be closed. -->

## Description

Many icon themes, e.g. the [Papirus icon theme](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme), ship with a generic icon named `bottom` under `<scale>/actions/bottom.<extension>`. This currently causes the icon for the bottom application to be displayed as the generic icon when using an icon theme that ships with it. This was observed on NixOS 25.11 with GNOME 49. 

<img width="170" height="172" alt="image" src="https://github.com/user-attachments/assets/f3f6d76b-ca8f-4f75-a296-362443ce7a40" />

This PR proposes to rename the Linux icon to avoid this naming collision.

## Issue

N/A

## Testing

_If relevant, please state how this was tested (including steps):_

Applied this patch, recompiled using Nix, verified that the correct icon is displayed.

_If this change affects the program, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS (specify version below)_
- [x] _Linux (specify distro below)_
- [ ] _Other (specify below)_

NixOS 25.11, GNOME 49

## Checklist

_Ensure **all** of these are met:_

- [ ] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [ ] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [ ] _If this is a code change, new tests were added if relevant_
- [ ] _If this is a code change, your changes pass `cargo test`_
- [x] _The change has been tested to work (see above) and doesn't appear to break other things_
- [ ] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [x] _There are no merge conflicts_
- [x] _You have reviewed the changes first_
- [ ] _The pull request passes the provided CI pipeline_ (waiting for maintainer)

## Other

Some other icon themes that ship with a `bottom` icon:

- https://github.com/Fausto-Korpsvart/Rose-Pine-GTK-Theme
- https://github.com/ZorinOS/zorin-icon-themes
