### PR TITLE
ci: keep three days of nightly builds at once

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,11 +74,12 @@ jobs:
           echo "Generated $(ls ./release | wc -l) files:"
           du -h -d 0 ./release/*
 
-      - name: Delete tag and release if not mock
+      - name: Delete old tags and release if not mock
         if: github.event.inputs.isMock != 'true'
         run: |
+          THREE_DAYS_AGO=$(date +%s --date='3 days ago')
           while true; do
-            PREV_NIGHTLY=$(gh release list --json name,tagName | jq -c '[.[] | select (.tagName | contains("nightly-"))][0] | .tagName' | tr -d '"')
+            PREV_NIGHTLY=$(gh release list --json name,tagName,publishedAt | jq --arg THREE_DAYS_AGO "$THREE_DAYS_AGO" -c '[.[] | select (.tagName | contains("nightly-")) | select (.publishedAt | fromdateiso8601 > $THREE_DAYS_AGO)][0] | .tagName' | tr -d '"')
 
             if [[ "$PREV_NIGHTLY" != "null" && "$PREV_NIGHTLY" == *"nightly-"* ]]; then
               echo "Will delete nightly release with tag '$PREV_NIGHTLY'";


### PR DESCRIPTION
<!-- Please use this template (unless you have a very good reason not to). PRs that do not use the template may be closed. -->

## Description

_A description of the change, what it does, and why it was made. If relevant (e.g. UI changes), **please also provide screenshots/recordings**:_

Might be a better experience to have 3 days of builds available as opposed to pruning them every day.

Still figuring out a way to have a permalink to the _newest_ nightly though.

## Issue

_If applicable, what issue does this address?_

Closes: #<issue-number>

## Testing

Nightly passes:
- Mock: https://github.com/ClementTsang/bottom/actions/runs/20511140892
- Non-mock: https://github.com/ClementTsang/bottom/actions/runs/20511256083

## Checklist

_Ensure **all** of these are met:_

- [ ] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [ ] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [ ] _If this is a code change, new tests were added if relevant_
- [ ] _If this is a code change, your changes pass `cargo test`_
- [ ] _The change has been tested to work (see above) and doesn't appear to break other things_
- [ ] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [ ] _There are no merge conflicts_
- [ ] _You have reviewed the changes first_
- [ ] _The pull request passes the provided CI pipeline_

## Other

_Anything else that maintainers should know about this PR:_
