### PR TITLE
bug: fix crash caused by multi-byte UTF8 chars in process names

### DIFF
--- a/src/collection/processes/linux/mod.rs
+++ b/src/collection/processes/linux/mod.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use concat_string::concat_string;
+use itertools::Itertools;
 use process::*;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use sysinfo::ProcessStatus;
@@ -312,7 +313,7 @@ fn binary_name_from_cmdline(cmdline: &str) -> String {
     }
 
     // Bit of a hack to handle cases like "firefox -blah"
-    let partial = &cmdline[start..end];
+    let partial = cmdline.chars().skip(start).take(end - start).join("");
     partial
         .split_once(" -")
         .map(|(name, _)| name.to_string())
@@ -557,6 +558,15 @@ mod tests {
         assert_eq!(
             binary_name_from_cmdline("firefox -contentproc -isForBrowser -prefsHandle 0"),
             "firefox"
+        );
+        assert_eq!(binary_name_from_cmdline("こんにちは\0"), "こんにちは");
+        assert_eq!(
+            binary_name_from_cmdline("こんにちは -こんばんは"),
+            "こんにちは"
+        );
+        assert_eq!(
+            binary_name_from_cmdline("/usr/bin/こんにちは -こんばんは\0"),
+            "こんにちは"
         );
     }
 }


### PR DESCRIPTION
<!-- Please use this template (unless you have a very good reason not to). PRs that do not use the template may be closed. -->

## Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
When a process name contains multi-byte characters, `cmdline[start..end]`
is unsafe since it operates on bytes and can cause panic when start/end
are not char boundaries.

<!-- === GH HISTORY FENCE === -->

## Issue

_If applicable, what issue does this address?_

N/A

## Testing

_If relevant, please state how this was tested (including steps):_

1. Choose a random program and rename it to `こんにちは` (best if it's a
   long-running program, e.g. something that waits on stdin)
2. Run the program
3. Wait for `bottom` to refresh process list
4. Before: `bottom` crashes with `` byte index 5 is not a char boundary; it is inside 'ん' (bytes 3..6) of `こんにちは` ``; After: `bottom` shows the process normally

_If this change affects the program, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS (specify version below)_
- [x] _Linux (specify distro below)_
- [ ] _Other (specify below)_

Arch Linux

## Checklist

_Ensure **all** of these are met:_

- [x] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [x] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [x] _If this is a code change, new tests were added if relevant_
- [x] _If this is a code change, your changes pass `cargo test`_
- [x] _The change has been tested to work (see above) and doesn't appear to break other things_
- [ ] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [x] _There are no merge conflicts_
- [x] _You have reviewed the changes first_
- [ ] _The pull request passes the provided CI pipeline_ (needs approval?)

## Other

_Anything else that maintainers should know about this PR:_

Found this issue when running some games using Wine.
