### PR TITLE
Add config for progress bars

### DIFF
--- a/docs/content/configuration/config-file/styling.md
+++ b/docs/content/configuration/config-file/styling.md
@@ -166,3 +166,4 @@ These can be set under `[styles.widgets]`:
 | `selected_text`         | Text styling for text when representing something that is selected                           | `selected_text = { color = "black", bg_color = "blue", bold = true }` |
 | `disabled_text`         | Text styling for text when representing something that is disabled                           | `disabled_text = { color = "black", bg_color = "blue", bold = true }` |
 | `thread_text`           | Text styling for text when representing process threads. Only usable on Linux at the moment. | `thread_text = { color = "green", bg_color = "blue", bold = true }`   |
+| `progress_bar_chars`    | Characters to use for progress bars                                                          | `progress_bar_chars = ["▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"]`       |

--- a/src/canvas/widgets/cpu_basic.rs
+++ b/src/canvas/widgets/cpu_basic.rs
@@ -61,7 +61,7 @@ impl Painter {
                 avg_loc.width -= 2;
 
                 f.render_widget(
-                    PipeGauge::default()
+                    PipeGauge::new(&self.styles.progress_bar_chars.0)
                         .gauge_style(style)
                         .label_style(style)
                         .inner_label(inner)
@@ -128,7 +128,7 @@ impl Painter {
 
                     for ((start_label, inner_label, ratio, style), row) in chunk.zip(rows.iter()) {
                         f.render_widget(
-                            PipeGauge::default()
+                            PipeGauge::new(&self.styles.progress_bar_chars.0)
                                 .gauge_style(style)
                                 .label_style(style)
                                 .inner_label(inner_label)

--- a/src/canvas/widgets/mem_basic.rs
+++ b/src/canvas/widgets/mem_basic.rs
@@ -73,7 +73,7 @@ impl Painter {
         };
 
         draw_widgets.push(
-            PipeGauge::default()
+            PipeGauge::new(&self.styles.progress_bar_chars.0)
                 .ratio(ram_percentage / 100.0)
                 .start_label("RAM")
                 .inner_label(ram_label)
@@ -86,7 +86,7 @@ impl Painter {
             let swap_label = memory_label(swap_harvest, app_state.basic_mode_use_percent);
 
             draw_widgets.push(
-                PipeGauge::default()
+                PipeGauge::new(&self.styles.progress_bar_chars.0)
                     .ratio(swap_percentage / 100.0)
                     .start_label("SWP")
                     .inner_label(swap_label)
@@ -103,7 +103,7 @@ impl Painter {
                     memory_label(cache_harvest, app_state.basic_mode_use_percent);
 
                 draw_widgets.push(
-                    PipeGauge::default()
+                    PipeGauge::new(&self.styles.progress_bar_chars.0)
                         .ratio(cache_percentage / 100.0)
                         .start_label("CHE")
                         .inner_label(cache_fraction_label)
@@ -121,7 +121,7 @@ impl Painter {
                     memory_label(arc_harvest, app_state.basic_mode_use_percent);
 
                 draw_widgets.push(
-                    PipeGauge::default()
+                    PipeGauge::new(&self.styles.progress_bar_chars.0)
                         .ratio(arc_percentage / 100.0)
                         .start_label("ARC")
                         .inner_label(arc_fraction_label)
@@ -152,7 +152,7 @@ impl Painter {
                 };
 
                 draw_widgets.push(
-                    PipeGauge::default()
+                    PipeGauge::new(&self.styles.progress_bar_chars.0)
                         .ratio(percentage / 100.0)
                         .start_label("GPU")
                         .inner_label(label)

--- a/src/options/config/style.rs
+++ b/src/options/config/style.rs
@@ -25,7 +25,9 @@ use utils::{opt, set_colour, set_colour_list, set_style};
 use widgets::WidgetStyle;
 
 use super::Config;
-use crate::options::{OptionError, OptionResult, args::BottomArgs};
+use crate::options::{
+    OptionError, OptionResult, args::BottomArgs, config::style::widgets::ProgressBarChars,
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "generate_schema", derive(schemars::JsonSchema))]
@@ -127,6 +129,7 @@ pub struct Styles {
     #[cfg(target_os = "linux")]
     pub(crate) thread_text_style: Style,
     pub(crate) border_type: BorderType,
+    pub(crate) progress_bar_chars: ProgressBarChars,
 }
 
 impl Default for Styles {

--- a/src/options/config/style/themes/default.rs
+++ b/src/options/config/style/themes/default.rs
@@ -4,7 +4,7 @@ use tui::{
 };
 
 use super::color;
-use crate::options::config::style::Styles;
+use crate::options::config::style::{Styles, widgets::ProgressBarChars};
 
 impl Styles {
     pub(crate) fn default_palette() -> Self {
@@ -69,6 +69,7 @@ impl Styles {
             border_type: BorderType::Plain,
             #[cfg(target_os = "linux")]
             thread_text_style: color!(Color::Green),
+            progress_bar_chars: ProgressBarChars::default(),
         }
     }
 

--- a/src/options/config/style/themes/gruvbox.rs
+++ b/src/options/config/style/themes/gruvbox.rs
@@ -4,7 +4,7 @@ use tui::{
 };
 
 use super::{color, hex};
-use crate::options::config::style::{Styles, themes::hex_colour};
+use crate::options::config::style::{Styles, themes::hex_colour, widgets::ProgressBarChars};
 
 impl Styles {
     pub(crate) fn gruvbox_palette() -> Self {
@@ -69,6 +69,7 @@ impl Styles {
             border_type: BorderType::Plain,
             #[cfg(target_os = "linux")]
             thread_text_style: hex!("#458588"),
+            progress_bar_chars: ProgressBarChars::default(),
         }
     }
 
@@ -134,6 +135,7 @@ impl Styles {
             border_type: BorderType::Plain,
             #[cfg(target_os = "linux")]
             thread_text_style: hex!("#458588"),
+            progress_bar_chars: ProgressBarChars::default(),
         }
     }
 }

--- a/src/options/config/style/themes/nord.rs
+++ b/src/options/config/style/themes/nord.rs
@@ -4,7 +4,7 @@ use tui::{
 };
 
 use super::{color, hex};
-use crate::options::config::style::{Styles, themes::hex_colour};
+use crate::options::config::style::{Styles, themes::hex_colour, widgets::ProgressBarChars};
 
 impl Styles {
     pub(crate) fn nord_palette() -> Self {
@@ -57,6 +57,7 @@ impl Styles {
             border_type: BorderType::Plain,
             #[cfg(target_os = "linux")]
             thread_text_style: hex!("#a3be8c"),
+            progress_bar_chars: ProgressBarChars::default(),
         }
     }
 
@@ -110,6 +111,7 @@ impl Styles {
             border_type: BorderType::Plain,
             #[cfg(target_os = "linux")]
             thread_text_style: hex!("#a3be8c"),
+            progress_bar_chars: ProgressBarChars::default(),
         }
     }
 }

--- a/src/options/config/style/widgets.rs
+++ b/src/options/config/style/widgets.rs
@@ -33,4 +33,59 @@ pub(crate) struct WidgetStyle {
 
     /// Widget borders type.
     pub(crate) widget_border_type: Option<WidgetBorderType>,
+
+    /// Progress bar characters to use
+    pub(crate) progress_bar_chars: Option<ProgressBarChars>,
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub(crate) struct ProgressBarChars(pub(crate) Vec<char>);
+
+impl<'de> Deserialize<'de> for ProgressBarChars {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Vec::<char>::deserialize(deserializer).and_then(|chars| {
+            if chars.is_empty() {
+                Err(<D::Error as serde::de::Error>::custom(
+                    "the array of progress bar characters must be non-empty",
+                ))
+            } else {
+                Ok(Self(chars))
+            }
+        })
+    }
+}
+
+impl Serialize for ProgressBarChars {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "generate_schema")]
+impl schemars::JsonSchema for ProgressBarChars {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        Vec::<char>::schema_name()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let mut schema = generator.subschema_for::<Vec<char>>();
+        schema.insert(
+            "minItems".into(),
+            serde_json::Value::Number(serde_json::Number::from(1u64)),
+        );
+        schema
+    }
+}
+
+impl Default for ProgressBarChars {
+    fn default() -> Self {
+        Self(vec!['▏', '▎', '▍', '▌', '▋', '▊', '▉', '█'])
+    }
 }

--- a/tests/invalid_configs/empty_progress_bar_chars.toml
+++ b/tests/invalid_configs/empty_progress_bar_chars.toml
@@ -1,0 +1,2 @@
+[styles.widgets]
+progress_bar_chars = []

--- a/tests/valid_configs/progress_bar_chars.toml
+++ b/tests/valid_configs/progress_bar_chars.toml
@@ -1,0 +1,2 @@
+[styles.widgets]
+progress_bar_chars = ["x"]


### PR DESCRIPTION
<!-- Please use this template (unless you have a very good reason not to). PRs that do not use the template may be closed. -->

## Description

This PR:

- Allows to customize the progress bar characters used via `styles.widgets.progress_bar_chars`
- Makes the progress bars more precise by using a larger range of unicode characters: `['▏', '▎', '▍', '▌', '▋', '▊', '▉', '█']`, instead of `|`. This also makes them look smoother

<img width="1450" height="243" alt="Screenshot from 2026-01-01 15-42-34" src="https://github.com/user-attachments/assets/7c38d374-d237-4c2c-9a67-dcaace029703" />

## Issue

None

## Testing

- Run `cargo test progress_bar`
- Open with `cargo run --basic` and observe

Tested platforms:

- [ ] _Windows_
- [ ] _macOS
- [x] _Linux (Arch Linux)
- [ ] _Other

## Checklist

_Ensure **all** of these are met:_

- [x] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [x] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [x] _If this is a code change, new tests were added if relevant_
- [x] _If this is a code change, your changes pass `cargo test`_
- [x] _The change has been tested to work (see above) and doesn't appear to break other things_
- [x] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [x] _There are no merge conflicts_
- [x] _You have reviewed the changes first_
- [ ] _The pull request passes the provided CI pipeline_