### PR TITLE
ci: add code signing for Windows artifacts

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -208,17 +208,51 @@ jobs:
           mv "$COMPLETION_DIR" completion
           mv "$MANPAGE_DIR" manpage
 
-      - name: Bundle release and completion (Windows)
-        if: matrix.info.os == 'windows-2022'
+      # FIXME: Change this to release-signing in general later, for now this is fine.
+      - name: Determine signing slug for Windows signing
+        id: get-signing-slug
+        if: startsWith(matrix.info.os, 'windows')
         shell: bash
         run: |
-          cp target/${{ matrix.info.target }}/release/btm.exe btm.exe
+          mkdir -p signed
+          if [[ ${{ inputs.caller }} == "nightly" ]]; then
+            echo "slug=test-signing" >> $GITHUB_OUTPUT
+          else
+            echo "slug=release-signing" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload unsigned Windows artifact
+        id: upload-unsigned-artifact
+        if: startsWith(matrix.info.os, 'windows')
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        with:
+          retention-days: 1
+          name: "unsigned-${{ matrix.info.target }}"
+          path: target/${{ matrix.info.target }}/release/btm.exe
+
+      - name: Sign Windows artifacts
+        if: startsWith(matrix.info.os, 'windows')
+        uses: signpath/github-action-submit-signing-request@3f9250c56651ff692d6729a2fbb0603a42d7d322 # v2.0
+        with:
+          api-token: "${{ secrets.SIGNPATH_API_TOKEN }}"
+          organization-id: "06b1a1ff-74e1-4d9d-93b1-fa8180c67727"
+          project-slug: "bottom"
+          signing-policy-slug: "${{ steps.get-signing-slug.outputs.slug }}"
+          github-artifact-id: "${{ steps.upload-unsigned-artifact.outputs.artifact-id }}"
+          wait-for-completion: true
+          output-artifact-directory: "signed"
+
+      - name: Bundle release and completion (Windows)
+        if: startsWith(matrix.info.os, 'windows')
+        shell: bash
+        run: |
+          mv signed/btm.exe btm.exe
           7z a bottom_${{ matrix.info.target }}.zip "btm.exe"
           7z a bottom_${{ matrix.info.target }}.zip "completion"
           echo "ASSET=bottom_${{ matrix.info.target }}.zip" >> $GITHUB_ENV
 
       - name: Bundle release and completion (Linux and macOS)
-        if: matrix.info.os != 'windows-2022'
+        if: ${{ !(startsWith(matrix.info.os, 'windows')) }}
         shell: bash
         run: |
           cp target/${{ matrix.info.target }}/release/btm ./btm


### PR DESCRIPTION
<!-- Please use this template (unless you have a very good reason not to). PRs that do not use the template may be closed. -->

## Description

_A description of the change, what it does, and why it was made. If relevant (e.g. UI changes), **please also provide screenshots/recordings**:_

Uses [signpath](https://signpath.org/) to do code signing for Windows artifacts; hopefully this helps a bit with false positives from VT. We will only run this on non-nightly.

This PR/branch also uses [Jujutsu](https://github.com/jj-vcs/jj) to try it out, hence the weird branch name.

## Issue

_If applicable, what issue does this address?_

Closes: #<issue-number>

## Testing

Build via nightly should succeed:

- With signing: https://github.com/ClementTsang/bottom/actions/runs/21127849070
- Without signing (normally nightly will not sign for now to avoid signing spam): https://github.com/ClementTsang/bottom/actions/runs/21129115350

## Checklist

_Ensure **all** of these are met:_

- [ ] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [ ] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [ ] _If this is a code change, new tests were added if relevant_
- [ ] _If this is a code change, your changes pass `cargo test`_
- [ ] _The change has been tested to work (see above) and doesn't appear to break other things_
- [ ] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [ ] _There are no merge conflicts_
- [ ] _You have reviewed the changes first_
- [ ] _The pull request passes the provided CI pipeline_

## Other

_Anything else that maintainers should know about this PR:_
