### PR TITLE
ci: replace skip-duplicate-actions with personal fork to fix node 20 warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Check if this action should be skipped
         id: skip_check
-        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1
+        uses: ClementTsang/skip-duplicate-actions@41b0a75f656d455934ffa6a46b779d8d996ac47c
         with:
           skip_after_successful_duplicate: "true"
           paths: '[".cargo/**", ".github/workflows/ci.yml", ".github/ci/**", "sample_configs/**", "src/**", "tests/**", "build.rs", "Cargo.lock", "Cargo.toml", "clippy.toml", "rustfmt.toml", "Cross.toml"]'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1
+        uses: ClementTsang/skip-duplicate-actions@41b0a75f656d455934ffa6a46b779d8d996ac47c
         with:
           skip_after_successful_duplicate: "false"
           paths: '["tests/**", "src/**", ".github/workflows/coverage.yml", ".github/ci", ".cargo/**", "Cargo.toml", "Cargo.lock", "build.rs"]'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Check if this action should be skipped
         id: skip_check
-        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1
+        uses: ClementTsang/skip-duplicate-actions@41b0a75f656d455934ffa6a46b779d8d996ac47c
         with:
           skip_after_successful_duplicate: "true"
           do_not_skip: '["workflow_dispatch"]'

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -17,7 +17,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1
+        uses: ClementTsang/skip-duplicate-actions@41b0a75f656d455934ffa6a46b779d8d996ac47c
         with:
           skip_after_successful_duplicate: "true"
           paths: '["docs/**", ".github/workflows/docs.yml", ".github/workflows/test_docs.yml"]'

--- a/.github/workflows/validate_schema.yml
+++ b/.github/workflows/validate_schema.yml
@@ -25,7 +25,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1
+        uses: ClementTsang/skip-duplicate-actions@41b0a75f656d455934ffa6a46b779d8d996ac47c
         with:
           skip_after_successful_duplicate: "true"
           paths: '["schema/**", "scripts/schema/**", ".github/workflows/validate_schema.yml", ".github/ci", "src/bin/schema.rs", "Cargo.toml"]'


### PR DESCRIPTION

## Description

_A description of the change, what it does, and why it was made. If relevant (e.g. UI changes), **please also provide screenshots/recordings**:_

Use a personal fork of skip-duplicate-actions that bumps it to node 24.

## Issue

_If applicable, what issue does this address?_

Closes: #<issue-number>

## Testing

_If relevant, please state how this was tested (including steps):_

_If this change affects the program, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS (specify version below)_
- [ ] _Linux (specify distro below)_
- [ ] _Other (specify below)_

## Checklist

_Ensure **all** of these are met:_

- [x] _If this PR adds or changes a dependency, please justify this in the description_
- [ ] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [ ] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [ ] _If this is a code change, new tests were added if relevant_
- [ ] _If this is a code change, your changes pass `cargo test`_
- [x] _The change has been tested to work (see above) and doesn't appear to break other things_
- [ ] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [x] _There are no merge conflicts_
- [x] _You have reviewed your changes first_
- [x] _The pull request passes the provided CI pipeline_

## Other

_Anything else that maintainers should know about this PR:_
