### PR TITLE
ci: test using no permissions by default for most CI jobs + bump setup-python

### DIFF
--- a/.github/workflows/bsd_vm_check.yml
+++ b/.github/workflows/bsd_vm_check.yml
@@ -1,7 +1,5 @@
 # Run BSD VM jobs with manually-implemented retries.
 
-name: "BSD VM Check"
-
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/bsd_vm_check.yml
+++ b/.github/workflows/bsd_vm_check.yml
@@ -14,6 +14,8 @@ on:
         description: "Release version"
         required: true
 
+permissions: {}
+
 # Duplicated because GHA doesn't support passing env vars through without making them all inputs or something.
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -10,10 +10,7 @@
 # TODO: Break this up into scripts instead.
 # TODO: Trigger this in CI as well if this file changes, so I don't have to spam nightly builds.
 
-name: "build releases"
-
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       caller:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 env:
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/clear_workflow_cache.yml
+++ b/.github/workflows/clear_workflow_cache.yml
@@ -15,6 +15,8 @@ on:
   schedule:
     - cron: "0 11 * * 0"
 
+permissions: {}
+
 jobs:
   clear-cache:
     if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }} # If it is a PR, only if not a fork

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_HUSKY_DONT_INSTALL_HOOKS: true

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -12,7 +12,10 @@ on:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
-permissions: {}
+permissions:
+  id-token: write
+  contents: read
+  attestations: write
 
 env:
   CARGO_INCREMENTAL: 0
@@ -43,10 +46,6 @@ jobs:
   build-release:
     needs: [initialize]
     uses: ./.github/workflows/build_releases.yml
-    permissions:
-      id-token: write
-      contents: read
-      attestations: write
     with:
       caller: "deployment"
     secrets: inherit

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -12,6 +12,8 @@ on:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
+permissions: {}
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -43,6 +43,10 @@ jobs:
   build-release:
     needs: [initialize]
     uses: ./.github/workflows/build_releases.yml
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
     with:
       caller: "deployment"
     secrets: inherit

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -93,6 +93,7 @@ jobs:
     name: upload-release
     runs-on: ubuntu-24.04
     needs: [initialize, generate-choco, build-release]
+    environment: production
     steps:
       - name: Set release version
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,9 @@ on:
       - "docs/**"
       - ".github/workflows/docs.yml"
 
-permissions: {}
+permissions:
+  pages: write
+  id-token: write
 
 env:
   # Assign commit authorship to official GitHub Actions bot when pushing to the `gh-pages` branch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,8 @@ on:
       - "docs/**"
       - ".github/workflows/docs.yml"
 
+permissions: {}
+
 env:
   # Assign commit authorship to official GitHub Actions bot when pushing to the `gh-pages` branch:
   GIT_USER: "github-actions[bot]"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,6 +50,10 @@ jobs:
     needs: initialize-job
     if: ${{ needs.initialize-job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/build_releases.yml
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
     with:
       caller: "nightly"
     secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,11 @@ on:
         required: false
         type: boolean
 
-permissions: {}
+permissions:
+  id-token: write
+  contents: read
+  attestations: write
+  pages: write
 
 env:
   CARGO_INCREMENTAL: 0
@@ -50,10 +54,6 @@ jobs:
     needs: initialize-job
     if: ${{ needs.initialize-job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/build_releases.yml
-    permissions:
-      id-token: write
-      contents: read
-      attestations: write
     with:
       caller: "nightly"
     secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,8 @@ on:
         required: false
         type: boolean
 
+permissions: {}
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -13,7 +13,9 @@ on:
         description: "Which tag to deploy as:"
         required: true
 
-permissions: {}
+permissions:
+  pages: write
+  id-token: write
 
 env:
   # Assign commit authorship to official GitHub Actions bot when pushing to the `gh-pages` branch:

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -13,6 +13,8 @@ on:
         description: "Which tag to deploy as:"
         required: true
 
+permissions: {}
+
 env:
   # Assign commit authorship to official GitHub Actions bot when pushing to the `gh-pages` branch:
   GIT_USER: "github-actions[bot]"

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12
 

--- a/.github/workflows/publish_github_pages.yml
+++ b/.github/workflows/publish_github_pages.yml
@@ -8,8 +8,6 @@ on:
   workflow_dispatch:
   workflow_call:
 
-permissions: {}
-
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/publish_github_pages.yml
+++ b/.github/workflows/publish_github_pages.yml
@@ -8,6 +8,8 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12
 

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'ClementTsang/bottom' }}

--- a/.github/workflows/validate_schema.yml
+++ b/.github/workflows/validate_schema.yml
@@ -1,6 +1,7 @@
 # Workflow to validate the latest schema.
 
 name: "validate schema"
+
 on:
   workflow_dispatch:
   pull_request:
@@ -13,6 +14,8 @@ on:
       - ".github/workflows/validate_schema.yml"
       - "src/bin/schema.rs"
       - "Cargo.toml"
+
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/validate_schema.yml
+++ b/.github/workflows/validate_schema.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12
 


### PR DESCRIPTION
<!-- Please use this template (unless you have a very good reason not to). PRs that do not use the template may be closed. -->

## Description

_A description of the change, what it does, and why it was made. If relevant (e.g. UI changes), **please also provide screenshots/recordings**:_

This is a test to try and disable all permissions by default + tweak perm rules for the repo. Also contains a driveby bump for `setup-python` to 6.2.0 to avoid node20 warnings.

## Issue

_If applicable, what issue does this address?_

Closes: #<issue-number>

## Testing

_If relevant, please state how this was tested (including steps):_

Test all affected CI flows.

## Checklist

_Ensure **all** of these are met:_

- [ ] _If this PR adds or changes a dependency, please justify this in the description_
- [ ] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [ ] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [ ] _If this is a code change, new tests were added if relevant_
- [ ] _If this is a code change, your changes pass `cargo test`_
- [ ] _The change has been tested to work (see above) and doesn't appear to break other things_
- [ ] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [ ] _There are no merge conflicts_
- [ ] _You have reviewed your changes first_
- [ ] _The pull request passes the provided CI pipeline_

## Other

_Anything else that maintainers should know about this PR:_
