### PR TITLE
ci: fix incorrect asset name for 2.17 linux builds

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -269,18 +269,18 @@ jobs:
         shell: bash
         run: |
           mv signed/btm.exe btm.exe
-          ASSET_NAME=bottom_${{ matrix.info.artifact_name || matrix.info.target }}.zip
-          7z a $ASSET_NAME "btm.exe"
-          7z a $ASSET_NAME "completion"
+          ASSET_NAME="bottom_${{ matrix.info.artifact_name || matrix.info.target }}.zip"
+          7z a "$ASSET_NAME" "btm.exe"
+          7z a "$ASSET_NAME" "completion"
           echo "ASSET=$ASSET_NAME" >> $GITHUB_ENV
 
       - name: Bundle release and completion (Linux and macOS)
         if: ${{ !(startsWith(matrix.info.os, 'windows')) }}
         shell: bash
         run: |
-          ASSET_NAME= bottom_${{ matrix.info.artifact_name || matrix.info.target }}.tar.gz
+          ASSET_NAME="bottom_${{ matrix.info.artifact_name || matrix.info.target }}.tar.gz"
           cp target/${{ matrix.info.target }}/release/btm ./btm
-          tar -czvf $ASSET_NAME btm completion
+          tar -czvf "$ASSET_NAME" btm completion
           echo "ASSET=$ASSET_NAME" >> $GITHUB_ENV
 
       - name: Generate artifact attestation for file

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -131,9 +131,9 @@ jobs:
           - {
               target: "x86_64-unknown-linux-gnu",
               os: "ubuntu-22.04",
+              artifact_name: "x86_64-unknown-linux-gnu-2-17",
               cross: true,
               cross_image: "ghcr.io/cross-rs/x86_64-unknown-linux-gnu@sha256:ab2070e67704b2c85d0d1fa50a0165ec438ed87fd1dc1a4058692a2348c071cb", # edge-centos
-              artifact_name: "x86_64-unknown-linux-gnu-2-17",
             }
 
           # Android
@@ -269,17 +269,19 @@ jobs:
         shell: bash
         run: |
           mv signed/btm.exe btm.exe
-          7z a bottom_${{ matrix.info.target }}.zip "btm.exe"
-          7z a bottom_${{ matrix.info.target }}.zip "completion"
-          echo "ASSET=bottom_${{ matrix.info.target }}.zip" >> $GITHUB_ENV
+          ASSET_NAME=bottom_${{ matrix.info.artifact_name || matrix.info.target }}.zip
+          7z a $ASSET_NAME "btm.exe"
+          7z a $ASSET_NAME "completion"
+          echo "ASSET=$ASSET_NAME" >> $GITHUB_ENV
 
       - name: Bundle release and completion (Linux and macOS)
         if: ${{ !(startsWith(matrix.info.os, 'windows')) }}
         shell: bash
         run: |
+          ASSET_NAME= bottom_${{ matrix.info.artifact_name || matrix.info.target }}.tar.gz
           cp target/${{ matrix.info.target }}/release/btm ./btm
-          tar -czvf bottom_${{ matrix.info.target }}.tar.gz btm completion
-          echo "ASSET=bottom_${{ matrix.info.target }}.tar.gz" >> $GITHUB_ENV
+          tar -czvf $ASSET_NAME btm completion
+          echo "ASSET=$ASSET_NAME" >> $GITHUB_ENV
 
       - name: Generate artifact attestation for file
         uses: actions/attest-build-provenance@6149ea5740be74af77f260b9db67e633f6b0a9a1 # v1.4.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,7 +55,7 @@ jobs:
           cd docs
           if [[ -n "${{ inputs.alias }}" ]]; then
             mike deploy --push ${{ inputs.version }} --update-aliases ${{ inputs.alias }}
-          else if [[ ${{ inputs.version }} == "nightly" ]]; then
+          else if [[ "${{ inputs.version }}" == "nightly" ]]; then
             mike deploy --push ${{ inputs.version }}
           else
             mike deploy --push nightly


### PR DESCRIPTION
<!-- Please use this template (unless you have a very good reason not to). PRs that do not use the template may be closed. -->

## Description

_A description of the change, what it does, and why it was made. If relevant (e.g. UI changes), **please also provide screenshots/recordings**:_

I was using the wrong name for the asset file so it was overwriting each other :facepalm:.

## Issue

_If applicable, what issue does this address?_

Closes: #<issue-number>

## Testing

_If relevant, please state how this was tested (including steps):_

A build workflow should pass: https://github.com/ClementTsang/bottom/actions/runs/24297702172

## Checklist

_Ensure **all** of these are met:_

- [ ] _If this PR adds or changes a dependency, please justify this in the description_
- [ ] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [ ] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [ ] _If this is a code change, new tests were added if relevant_
- [ ] _If this is a code change, your changes pass `cargo test`_
- [ ] _The change has been tested to work (see above) and doesn't appear to break other things_
- [ ] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [ ] _There are no merge conflicts_
- [ ] _You have reviewed your changes first_
- [ ] _The pull request passes the provided CI pipeline_

## Other

_Anything else that maintainers should know about this PR:_
