### PR TITLE
feature: show graph legend in more situations

### DIFF
--- a/src/canvas/components/time_graph/base.rs
+++ b/src/canvas/components/time_graph/base.rs
@@ -48,6 +48,15 @@ impl<'a> GraphData<'a> {
     }
 }
 
+#[derive(Clone, Copy)]
+pub struct LegendConstraints {
+    /// The width legend constraints.
+    pub width: Constraint,
+
+    /// The height legend constraints.
+    pub height: Constraint,
+}
+
 pub struct TimeGraph<'a> {
     /// The min x value.
     pub x_min: f64,
@@ -89,7 +98,7 @@ pub struct TimeGraph<'a> {
     pub legend_position: Option<LegendPosition>,
 
     /// Any legend constraints.
-    pub legend_constraints: Option<(Constraint, Constraint)>,
+    pub legend_constraints: Option<LegendConstraints>,
 
     /// The marker type. Unlike ratatui's native charts, we assume
     /// only a single type of marker.
@@ -178,10 +187,13 @@ impl TimeGraph<'_> {
                 .style(self.general_widget_style)
                 .legend_style(self.graph_style)
                 .legend_position(self.legend_position)
-                .hidden_legend_constraints(
-                    self.legend_constraints
-                        .unwrap_or(DEFAULT_LEGEND_CONSTRAINTS),
-                )
+                .hidden_legend_constraints({
+                    let constraints = self
+                        .legend_constraints
+                        .unwrap_or(DEFAULT_LEGEND_CONSTRAINTS);
+
+                    (constraints.width, constraints.height)
+                })
                 .scaling(self.scaling),
             draw_loc,
         )

--- a/src/canvas/components/time_graph/variants/percent.rs
+++ b/src/canvas/components/time_graph/variants/percent.rs
@@ -2,12 +2,13 @@
 
 use std::borrow::Cow;
 
-use tui::{layout::Constraint, symbols::Marker};
+use tui::symbols::Marker;
 
 use crate::{
     app::AppConfigFields,
     canvas::components::time_graph::{
-        AxisBound, ChartScaling, LegendPosition, TimeGraph, variants::get_border_style,
+        AxisBound, ChartScaling, LegendConstraints, LegendPosition, TimeGraph,
+        variants::get_border_style,
     },
     options::config::style::Styles,
 };
@@ -53,7 +54,7 @@ pub(crate) struct PercentTimeGraph<'a> {
     pub(crate) legend_position: Option<LegendPosition>,
 
     /// The constraints for the legend.
-    pub(crate) legend_constraints: Option<(Constraint, Constraint)>,
+    pub(crate) legend_constraints: Option<LegendConstraints>,
 }
 
 impl<'a> PercentTimeGraph<'a> {

--- a/src/canvas/components/time_graph/vendored.rs
+++ b/src/canvas/components/time_graph/vendored.rs
@@ -598,21 +598,19 @@ impl<'a> TimeChart<'a> {
         }
 
         if let Some(legend_position) = self.legend_position {
-            let legends = self
+            let (entry_count, min_width, max_width) = self
                 .datasets
                 .iter()
-                .filter_map(|d| Some(d.name.as_ref()?.width() as u16));
+                .filter_map(|d| Some(d.name.as_ref()?.width() as u16))
+                .fold((0u16, u16::MAX, 0u16), |(c, mn, mx), w| {
+                    (c + 1, mn.min(w), mx.max(w))
+                });
 
-            let min_width = legends.clone().min();
-            let max_width = legends.clone().max();
-
-            if let Some(max_width) = max_width
-                && let Some(min_width) = min_width
-            {
+            if entry_count > 0 {
                 let min_possible_width = max(2, min_width);
 
                 let legend_width = max_width + 2;
-                let legend_height = legends.count() as u16 + 2;
+                let legend_height = entry_count + 2;
 
                 let [max_legend_width] = Layout::horizontal([self.hidden_legend_constraints.0])
                     .flex(Flex::Start)
@@ -905,6 +903,8 @@ impl Widget for TimeChart<'_> {
 
             block.render(legend_area, buf);
 
+            let max_width = legend_area.width - 2;
+
             for (i, (dataset_name, dataset_style)) in self
                 .datasets
                 .iter()
@@ -912,15 +912,15 @@ impl Widget for TimeChart<'_> {
                 .enumerate()
                 .take((legend_area.height - 2) as usize)
             {
-                let max_width = legend_area.width - 2;
                 let line = if dataset_name.width() as u16 <= max_width {
                     dataset_name.clone()
                 } else {
                     let inner = dataset_name.to_string();
                     let truncated = unicode_ellipsis::truncate_str(&inner, max_width as usize);
 
-                    Line::from(truncated.to_string()).patch_style(dataset_style)
+                    Line::from(truncated.to_string())
                 };
+
                 let name = line.patch_style(dataset_style);
                 name.render(
                     Rect {

--- a/src/canvas/components/time_graph/vendored.rs
+++ b/src/canvas/components/time_graph/vendored.rs
@@ -27,11 +27,14 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::{
     app::data::Values,
+    canvas::components::time_graph::LegendConstraints,
     utils::general::{saturating_log2, saturating_log10},
 };
 
-pub const DEFAULT_LEGEND_CONSTRAINTS: (Constraint, Constraint) =
-    (Constraint::Ratio(1, 4), Constraint::Length(4));
+pub const DEFAULT_LEGEND_CONSTRAINTS: LegendConstraints = LegendConstraints {
+    width: Constraint::Ratio(1, 4),
+    height: Constraint::Length(4),
+};
 
 /// A single graph point.
 pub type Point = (f64, f64);
@@ -598,20 +601,15 @@ impl<'a> TimeChart<'a> {
         }
 
         if let Some(legend_position) = self.legend_position {
-            let (entry_count, min_width, max_width) = self
+            let entry_widths: Vec<u16> = self
                 .datasets
                 .iter()
                 .filter_map(|d| Some(d.name.as_ref()?.width() as u16))
-                .fold((0u16, u16::MAX, 0u16), |(c, mn, mx), w| {
-                    (c + 1, mn.min(w), mx.max(w))
-                });
+                .collect();
+
+            let entry_count = entry_widths.len() as u16;
 
             if entry_count > 0 {
-                let min_possible_width = max(2, min_width);
-
-                let legend_width = max_width + 2;
-                let legend_height = entry_count + 2;
-
                 let [max_legend_width] = Layout::horizontal([self.hidden_legend_constraints.0])
                     .flex(Flex::Start)
                     .areas(layout.graph_area);
@@ -620,25 +618,36 @@ impl<'a> TimeChart<'a> {
                     .flex(Flex::Start)
                     .areas(layout.graph_area);
 
-                if max_width > 0
-                    && max_legend_width.width > min_possible_width
-                    && max_legend_height.height > 2
-                {
-                    layout.legend_area = legend_position.layout(
-                        layout.graph_area,
-                        min(legend_width, max_legend_width.width),
-                        min(legend_height, max_legend_height.height),
-                        layout
-                            .title_x
-                            .and(self.x_axis.title.as_ref())
-                            .map(|t| t.width() as u16)
-                            .unwrap_or_default(),
-                        layout
-                            .title_y
-                            .and(self.y_axis.title.as_ref())
-                            .map(|t| t.width() as u16)
-                            .unwrap_or_default(),
-                    );
+                let max_entries = min(entry_count, max_legend_height.height.saturating_sub(2));
+                let visible = &entry_widths[..max_entries as usize];
+
+                if let Some(&max_width) = visible.iter().max() {
+                    let min_width = visible.iter().copied().min().unwrap_or(0);
+                    let min_required_width = min_width + 2;
+
+                    let legend_width = max_width + 2;
+                    let legend_height = max_entries + 2;
+
+                    if max_width > 0
+                        && max_legend_width.width >= min_required_width
+                        && max_entries > 0
+                    {
+                        layout.legend_area = legend_position.layout(
+                            layout.graph_area,
+                            min(legend_width, max_legend_width.width),
+                            legend_height,
+                            layout
+                                .title_x
+                                .and(self.x_axis.title.as_ref())
+                                .map(|t| t.width() as u16)
+                                .unwrap_or_default(),
+                            layout
+                                .title_y
+                                .and(self.y_axis.title.as_ref())
+                                .map(|t| t.width() as u16)
+                                .unwrap_or_default(),
+                        );
+                    }
                 }
             }
         }
@@ -1477,5 +1486,111 @@ mod tests {
                 "         ",
             ])
         );
+    }
+
+    #[test]
+    fn legend_truncates_entries_by_height() {
+        // 5 datasets but only room for 3 entries in the legend (height=5, so 5-2=3 entries).
+        let datasets: Vec<_> = (0..5)
+            .map(|i| Dataset::default().name(format!("D{i}")))
+            .collect();
+        let chart = TimeChart::new(datasets)
+            .hidden_legend_constraints((Constraint::Percentage(100), Constraint::Percentage(100)));
+
+        // Height 5 means room for 3 entries (5 - 2 borders).
+        let area = Rect::new(0, 0, 20, 5);
+        let layout = chart.layout(area);
+
+        assert!(layout.legend_area.is_some());
+        let legend = layout.legend_area.unwrap();
+        assert_eq!(legend.height, 5); // 3 entries + 2 borders
+    }
+
+    #[test]
+    fn legend_truncates_entries_renders_only_visible() {
+        // 5 datasets but height only fits 2 entries.
+        let datasets: Vec<_> = (0..5)
+            .map(|i| Dataset::default().name(format!("D{i}")))
+            .collect();
+        let chart = TimeChart::new(datasets)
+            .hidden_legend_constraints((Constraint::Percentage(100), Constraint::Percentage(100)));
+
+        let area = Rect::new(0, 0, 20, 4); // 4 - 2 = 2 entries
+        let mut buffer = Buffer::empty(area);
+        chart.render(buffer.area, &mut buffer);
+
+        let expected = Buffer::with_lines(vec![
+            "                ┌──┐",
+            "                │D0│",
+            "                │D1│",
+            "                └──┘",
+        ]);
+        assert_buffer_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn legend_width_capped_to_constraint() {
+        let datasets = vec![
+            Dataset::default().name("Short"),
+            Dataset::default().name("A very long dataset name"),
+        ];
+        let chart = TimeChart::new(datasets)
+            .hidden_legend_constraints((Constraint::Percentage(100), Constraint::Percentage(100)));
+
+        // Width 12 means legend_width capped to 12, inner width = 10.
+        let area = Rect::new(0, 0, 12, 10);
+        let layout = chart.layout(area);
+
+        assert!(layout.legend_area.is_some());
+        let legend = layout.legend_area.unwrap();
+        assert_eq!(legend.width, 12); // capped to area width
+    }
+
+    #[test]
+    fn legend_width_truncates_long_names_with_ellipsis() {
+        // Short entry fits untruncated (satisfies min_required_width), but the
+        // long entry exceeds the capped legend width and gets an ellipsis.
+        let datasets = vec![
+            Dataset::default().name("AB"),
+            Dataset::default().name("Very long name here"),
+        ];
+        let chart = TimeChart::new(datasets)
+            .hidden_legend_constraints((Constraint::Percentage(100), Constraint::Percentage(100)));
+
+        // Width 8, legend box capped to 8, inner is 6, long name truncated.
+        let area = Rect::new(0, 0, 8, 4);
+        let mut buffer = Buffer::empty(area);
+        chart.render(buffer.area, &mut buffer);
+
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines(vec![
+            "┌──────┐",
+            "│AB    │",
+            "│Very …│",
+            "└──────┘",
+        ]);
+        assert_buffer_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn legend_width_uses_only_visible_entries() {
+        // First 2 entries have short names, last entry has a very long name.
+        // With height=4 (2 visible entries), the legend width should be based
+        // on the short names only, not the long hidden one.
+        let datasets = vec![
+            Dataset::default().name("AB"),
+            Dataset::default().name("CD"),
+            Dataset::default().name("A very long dataset name"),
+        ];
+        let chart = TimeChart::new(datasets)
+            .hidden_legend_constraints((Constraint::Percentage(100), Constraint::Percentage(100)));
+
+        let area = Rect::new(0, 0, 30, 4); // height 4 → 2 visible entries
+        let layout = chart.layout(area);
+
+        assert!(layout.legend_area.is_some());
+        let legend = layout.legend_area.unwrap();
+        // Width should be based on "AB"/"CD" (2 chars) + 2 borders = 4, not the long name.
+        assert_eq!(legend.width, 4);
     }
 }

--- a/src/canvas/components/time_graph/vendored.rs
+++ b/src/canvas/components/time_graph/vendored.rs
@@ -8,7 +8,11 @@ mod canvas;
 mod grid;
 mod points;
 
-use std::{cmp::max, str::FromStr, time::Instant};
+use std::{
+    cmp::{max, min},
+    str::FromStr,
+    time::Instant,
+};
 
 use canvas::*;
 use tui::{
@@ -599,8 +603,15 @@ impl<'a> TimeChart<'a> {
                 .iter()
                 .filter_map(|d| Some(d.name.as_ref()?.width() as u16));
 
-            if let Some(inner_width) = legends.clone().max() {
-                let legend_width = inner_width + 2;
+            let min_width = legends.clone().min();
+            let max_width = legends.clone().max();
+
+            if let Some(max_width) = max_width
+                && let Some(min_width) = min_width
+            {
+                let min_possible_width = max(2, min_width);
+
+                let legend_width = max_width + 2;
                 let legend_height = legends.count() as u16 + 2;
 
                 let [max_legend_width] = Layout::horizontal([self.hidden_legend_constraints.0])
@@ -611,14 +622,14 @@ impl<'a> TimeChart<'a> {
                     .flex(Flex::Start)
                     .areas(layout.graph_area);
 
-                if inner_width > 0
-                    && legend_width <= max_legend_width.width
-                    && legend_height <= max_legend_height.height
+                if max_width > 0
+                    && max_legend_width.width > min_possible_width
+                    && max_legend_height.height > 2
                 {
                     layout.legend_area = legend_position.layout(
                         layout.graph_area,
-                        legend_width,
-                        legend_height,
+                        min(legend_width, max_legend_width.width),
+                        min(legend_height, max_legend_height.height),
                         layout
                             .title_x
                             .and(self.x_axis.title.as_ref())
@@ -881,14 +892,17 @@ impl Widget for TimeChart<'_> {
 
         if let Some(legend_area) = layout.legend_area {
             buf.set_style(legend_area, original_style);
+
             let block = Block::default()
                 .borders(Borders::ALL)
                 .border_style(self.legend_style);
+
             for pos in block.inner(legend_area).positions() {
                 if let Some(cell) = buf.cell_mut(pos) {
                     cell.set_symbol(" ");
                 }
             }
+
             block.render(legend_area, buf);
 
             for (i, (dataset_name, dataset_style)) in self
@@ -896,13 +910,23 @@ impl Widget for TimeChart<'_> {
                 .iter()
                 .filter_map(|ds| Some((ds.name.as_ref()?, ds.style())))
                 .enumerate()
+                .take((legend_area.height - 2) as usize)
             {
-                let name = dataset_name.clone().patch_style(dataset_style);
+                let max_width = legend_area.width - 2;
+                let line = if dataset_name.width() as u16 <= max_width {
+                    dataset_name.clone()
+                } else {
+                    let inner = dataset_name.to_string();
+                    let truncated = unicode_ellipsis::truncate_str(&inner, max_width as usize);
+
+                    Line::from(truncated.to_string()).patch_style(dataset_style)
+                };
+                let name = line.patch_style(dataset_style);
                 name.render(
                     Rect {
                         x: legend_area.x + 1,
                         y: legend_area.y + 1 + i as u16,
-                        width: legend_area.width - 2,
+                        width: max_width,
                         height: 1,
                     },
                     buf,

--- a/src/canvas/widgets/mem_graph.rs
+++ b/src/canvas/widgets/mem_graph.rs
@@ -10,7 +10,7 @@ use crate::{
     app::{App, data::Values},
     canvas::{
         Painter,
-        components::time_graph::{GraphData, PercentTimeGraph},
+        components::time_graph::{GraphData, LegendConstraints, PercentTimeGraph},
         drawing_utils::should_hide_x_label,
     },
     collection::memory::MemData,
@@ -174,7 +174,10 @@ impl Painter {
                 styles: &self.styles,
                 widget_id,
                 legend_position: app_state.app_config_fields.memory_legend_position,
-                legend_constraints: Some((Constraint::Ratio(3, 4), Constraint::Ratio(3, 4))),
+                legend_constraints: Some(LegendConstraints {
+                    width: Constraint::Ratio(3, 4),
+                    height: Constraint::Ratio(3, 4),
+                }),
             }
             .build()
             .draw(f, draw_loc, graph_data);

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -152,9 +152,9 @@ impl Painter {
                 // Always hide it. Note that I could pass in `None` to the position as well but eh this works.
                 (Constraint::Length(0), Constraint::Length(0))
             } else {
-                // Hide the legend if the width is 75% of the total widget width
+                // Hide the legend if the width is 90% of the total widget width
                 // or the height is greater than 75% of the total widget hight.
-                (Constraint::Ratio(3, 4), Constraint::Ratio(3, 4))
+                (Constraint::Ratio(9, 10), Constraint::Ratio(3, 4))
             };
 
             // TODO: Add support for clicking on legend to only show that value on chart.

--- a/src/canvas/widgets/network_graph.rs
+++ b/src/canvas/widgets/network_graph.rs
@@ -12,7 +12,9 @@ use crate::{
     app::{App, AppConfigFields, AxisScaling},
     canvas::{
         Painter,
-        components::time_graph::{AxisBound, ChartScaling, GraphData, TimeGraph},
+        components::time_graph::{
+            AxisBound, ChartScaling, GraphData, LegendConstraints, TimeGraph,
+        },
         drawing_utils::{should_hide_x_label, widget_block},
         widgets::{PacketInfo, calculate_packet_info},
     },
@@ -150,11 +152,17 @@ impl Painter {
             let use_old_network_legend = app_state.app_config_fields.use_old_network_legend;
             let legend_constraints = if use_old_network_legend {
                 // Always hide it. Note that I could pass in `None` to the position as well but eh this works.
-                (Constraint::Length(0), Constraint::Length(0))
+                LegendConstraints {
+                    width: Constraint::Length(0),
+                    height: Constraint::Length(0),
+                }
             } else {
                 // Hide the legend if the width is 90% of the total widget width
-                // or the height is greater than 75% of the total widget hight.
-                (Constraint::Ratio(9, 10), Constraint::Ratio(3, 4))
+                // or the height is greater than 75% of the total widget height.
+                LegendConstraints {
+                    width: Constraint::Ratio(9, 10),
+                    height: Constraint::Ratio(3, 4),
+                }
             };
 
             // TODO: Add support for clicking on legend to only show that value on chart.


### PR DESCRIPTION
<!-- Please use this template (unless you have a very good reason not to). PRs that do not use the template may be closed. -->

## Description

_A description of the change, what it does, and why it was made. If relevant (e.g. UI changes), **please also provide screenshots/recordings**:_

This PR makes it so that instead of always just hiding the entire legend if it's too big for the current size, we instead show less parts of the legend to make it fit. For example, if it's too tall, we just show less entries. If it is too wide, but other entries still would fit, we truncate the entries that are too long so they fit.

This is somewhat helpful because in the memory widget, the GPU entry at the moment is causing the legend to hide in situations where it used to not. We can also do more work to make that better, but IMO not always hiding the legend also makes sense to have in general.

## Issue

_If applicable, what issue does this address?_

Closes: #1999

## Testing

_If relevant, please state how this was tested (including steps):_

_If this change affects the program, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS (specify version below)_
- [ ] _Linux (specify distro below)_
- [ ] _Other (specify below)_

## Checklist

_Ensure **all** of these are met:_

- [ ] _If this PR adds or changes a dependency, please justify this in the description_
- [ ] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [ ] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [ ] _If this is a code change, new tests were added if relevant_
- [ ] _If this is a code change, your changes pass `cargo test`_
- [ ] _The change has been tested to work (see above) and doesn't appear to break other things_
- [ ] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [ ] _There are no merge conflicts_
- [ ] _You have reviewed your changes first_
- [ ] _The pull request passes the provided CI pipeline_

## Other

_Anything else that maintainers should know about this PR:_
