### PR TITLE
refactor: generalize input field logic for easier reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ That said, these are more guidelines rather than hard rules, though the project 
 
 ## [0.12.4]/[0.13.0] - Unreleased
 
+### Bug Fixes
+
+- [#2035](https://github.com/ClementTsang/bottom/pull/2035): Fix panic when deleting unicode words in search.
+
 ### Features
 
 - [#1938](https://github.com/ClementTsang/bottom/pull/1938), [#1980](https://github.com/ClementTsang/bottom/pull/1980): Report average packet size and packet rate.

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,13 +5,11 @@ pub mod states;
 
 use std::time::Instant;
 
-use concat_string::concat_string;
 use data::*;
 use filter::*;
 use layout_manager::*;
 use rustc_hash::FxHashMap as HashMap;
 pub use states::*;
-use unicode_segmentation::{GraphemeCursor, UnicodeSegmentation};
 
 use crate::{
     canvas::{
@@ -869,24 +867,10 @@ impl App {
                         proc_widget_state
                             .proc_search
                             .search_state
-                            .current_search_query
-                            .insert(proc_widget_state.cursor_char_index(), caught_char);
-
-                        proc_widget_state.proc_search.search_state.grapheme_cursor =
-                            GraphemeCursor::new(
-                                proc_widget_state.cursor_char_index(),
-                                proc_widget_state
-                                    .proc_search
-                                    .search_state
-                                    .current_search_query
-                                    .len(),
-                                true,
-                            );
-                        proc_widget_state.search_walk_forward();
+                            .input_field_state
+                            .insert_char(caught_char);
 
                         proc_widget_state.update_query();
-                        proc_widget_state.proc_search.search_state.cursor_direction =
-                            CursorDirection::Right;
 
                         return;
                     }
@@ -2520,9 +2504,6 @@ impl App {
 
     /// A quick and dirty way to handle paste events.
     pub fn handle_paste(&mut self, paste: String) {
-        // Partially copy-pasted from the single-char variant; should probably clean up
-        // this process in the future. In particular, encapsulate this entire
-        // logic and add some tests to make it less potentially error-prone.
         let is_in_search_widget = self.is_in_search_widget();
         if let Some(proc_widget_state) = self
             .states
@@ -2530,28 +2511,14 @@ impl App {
             .widget_states
             .get_mut(&(self.current_widget.widget_id - 1))
         {
-            let num_runes = UnicodeSegmentation::graphemes(paste.as_str(), true).count();
-
             if is_in_search_widget && proc_widget_state.is_search_enabled() {
-                let left_bound = proc_widget_state.cursor_char_index();
-
-                let curr_query = &mut proc_widget_state
+                proc_widget_state
                     .proc_search
                     .search_state
-                    .current_search_query;
-                let (left, right) = curr_query.split_at(left_bound);
-                *curr_query = concat_string!(left, paste, right);
-
-                proc_widget_state.proc_search.search_state.grapheme_cursor =
-                    GraphemeCursor::new(left_bound, curr_query.len(), true);
-
-                for _ in 0..num_runes {
-                    proc_widget_state.search_walk_forward();
-                }
+                    .input_field_state
+                    .insert_string(paste);
 
                 proc_widget_state.update_query();
-                proc_widget_state.proc_search.search_state.cursor_direction =
-                    CursorDirection::Right;
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -499,34 +499,13 @@ impl App {
                     .widget_states
                     .get_mut(&(self.current_widget.widget_id - 1))
                 {
-                    if is_in_search_widget
-                        && proc_widget_state.proc_search.search_state.is_enabled
-                        && proc_widget_state.cursor_char_index()
-                            < proc_widget_state
-                                .proc_search
-                                .search_state
-                                .current_search_query
-                                .len()
+                    if is_in_search_widget && proc_widget_state.proc_search.search_state.is_enabled
                     {
-                        let current_cursor = proc_widget_state.cursor_char_index();
-                        proc_widget_state.search_walk_forward();
-
-                        let _ = proc_widget_state
+                        proc_widget_state
                             .proc_search
                             .search_state
-                            .current_search_query
-                            .drain(current_cursor..proc_widget_state.cursor_char_index());
-
-                        proc_widget_state.proc_search.search_state.grapheme_cursor =
-                            GraphemeCursor::new(
-                                current_cursor,
-                                proc_widget_state
-                                    .proc_search
-                                    .search_state
-                                    .current_search_query
-                                    .len(),
-                                true,
-                            );
+                            .input_field_state
+                            .delete_at_cursor();
 
                         proc_widget_state.update_query();
                     }
@@ -548,33 +527,12 @@ impl App {
                 .widget_states
                 .get_mut(&(self.current_widget.widget_id - 1))
             {
-                if is_in_search_widget
-                    && proc_widget_state.proc_search.search_state.is_enabled
-                    && proc_widget_state.cursor_char_index() > 0
-                {
-                    let current_cursor = proc_widget_state.cursor_char_index();
-                    proc_widget_state.search_walk_back();
-
-                    // Remove the indices in between.
-                    let _ = proc_widget_state
+                if is_in_search_widget && proc_widget_state.proc_search.search_state.is_enabled {
+                    proc_widget_state
                         .proc_search
                         .search_state
-                        .current_search_query
-                        .drain(proc_widget_state.cursor_char_index()..current_cursor);
-
-                    proc_widget_state.proc_search.search_state.grapheme_cursor =
-                        GraphemeCursor::new(
-                            proc_widget_state.cursor_char_index(),
-                            proc_widget_state
-                                .proc_search
-                                .search_state
-                                .current_search_query
-                                .len(),
-                            true,
-                        );
-
-                    proc_widget_state.proc_search.search_state.cursor_direction =
-                        CursorDirection::Left;
+                        .input_field_state
+                        .delete_behind_cursor();
 
                     proc_widget_state.update_query();
                 }
@@ -626,12 +584,11 @@ impl App {
                         .get_mut_widget_state(self.current_widget.widget_id - 1)
                     {
                         if is_in_search_widget {
-                            let prev_cursor = proc_widget_state.cursor_char_index();
-                            proc_widget_state.search_walk_back();
-                            if proc_widget_state.cursor_char_index() < prev_cursor {
-                                proc_widget_state.proc_search.search_state.cursor_direction =
-                                    CursorDirection::Left;
-                            }
+                            proc_widget_state
+                                .proc_search
+                                .search_state
+                                .input_field_state
+                                .move_left();
                         }
                     }
                 }
@@ -674,12 +631,11 @@ impl App {
                         .get_mut_widget_state(self.current_widget.widget_id - 1)
                     {
                         if is_in_search_widget {
-                            let prev_cursor = proc_widget_state.cursor_char_index();
-                            proc_widget_state.search_walk_forward();
-                            if proc_widget_state.cursor_char_index() > prev_cursor {
-                                proc_widget_state.proc_search.search_state.cursor_direction =
-                                    CursorDirection::Right;
-                            }
+                            proc_widget_state
+                                .proc_search
+                                .search_state
+                                .input_field_state
+                                .move_right();
                         }
                     }
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -772,19 +772,11 @@ impl App {
                     .get_mut(&(self.current_widget.widget_id - 1))
                 {
                     if is_in_search_widget {
-                        proc_widget_state.proc_search.search_state.grapheme_cursor =
-                            GraphemeCursor::new(
-                                0,
-                                proc_widget_state
-                                    .proc_search
-                                    .search_state
-                                    .current_search_query
-                                    .len(),
-                                true,
-                            );
-
-                        proc_widget_state.proc_search.search_state.cursor_direction =
-                            CursorDirection::Left;
+                        proc_widget_state
+                            .proc_search
+                            .search_state
+                            .input_field_state
+                            .skip_to_beginning();
                     }
                 }
             }
@@ -802,16 +794,11 @@ impl App {
                     .get_mut(&(self.current_widget.widget_id - 1))
                 {
                     if is_in_search_widget {
-                        let query_len = proc_widget_state
+                        proc_widget_state
                             .proc_search
                             .search_state
-                            .current_search_query
-                            .len();
-
-                        proc_widget_state.proc_search.search_state.grapheme_cursor =
-                            GraphemeCursor::new(query_len, query_len, true);
-                        proc_widget_state.proc_search.search_state.cursor_direction =
-                            CursorDirection::Right;
+                            .input_field_state
+                            .skip_to_end();
                     }
                 }
             }
@@ -839,52 +826,11 @@ impl App {
                 .widget_states
                 .get_mut(&(self.current_widget.widget_id - 1))
             {
-                // Traverse backwards from the current cursor location until you hit
-                // non-whitespace characters, then continue to traverse (and
-                // delete) backwards until you hit a whitespace character.  Halt.
-
-                // So... first, let's get our current cursor position in terms of char indices.
-                let end_index = proc_widget_state.cursor_char_index();
-
-                // Then, let's crawl backwards until we hit our location, and store the
-                // "head"...
-                let query = proc_widget_state.current_search_query();
-                let mut start_index = 0;
-                let mut saw_non_whitespace = false;
-
-                for (itx, c) in query
-                    .chars()
-                    .rev()
-                    .enumerate()
-                    .skip(query.len() - end_index)
-                {
-                    if c.is_whitespace() {
-                        if saw_non_whitespace {
-                            start_index = query.len() - itx;
-                            break;
-                        }
-                    } else {
-                        saw_non_whitespace = true;
-                    }
-                }
-
-                let _ = proc_widget_state
+                proc_widget_state
                     .proc_search
                     .search_state
-                    .current_search_query
-                    .drain(start_index..end_index);
-
-                proc_widget_state.proc_search.search_state.grapheme_cursor = GraphemeCursor::new(
-                    start_index,
-                    proc_widget_state
-                        .proc_search
-                        .search_state
-                        .current_search_query
-                        .len(),
-                    true,
-                );
-
-                proc_widget_state.proc_search.search_state.cursor_direction = CursorDirection::Left;
+                    .input_field_state
+                    .delete_previous_word();
 
                 proc_widget_state.update_query();
             }

--- a/src/app/states.rs
+++ b/src/app/states.rs
@@ -46,6 +46,7 @@ impl Default for AppHelpDialogState {
 }
 
 /// AppSearchState deals with generic searching (I might do this in the future).
+#[derive(Default)]
 pub struct AppSearchState {
     pub is_enabled: bool,
     pub is_invalid_search: bool,
@@ -55,18 +56,6 @@ pub struct AppSearchState {
     /// The query. TODO: Merge this as one enum.
     pub query: Option<ProcessQuery>,
     pub error_message: Option<String>,
-}
-
-impl Default for AppSearchState {
-    fn default() -> Self {
-        AppSearchState {
-            is_enabled: false,
-            is_invalid_search: false,
-            input_field_state: InputFieldState::default(),
-            query: None,
-            error_message: None,
-        }
-    }
 }
 
 impl AppSearchState {

--- a/src/app/states.rs
+++ b/src/app/states.rs
@@ -1,13 +1,9 @@
-use std::ops::Range;
-
-use indexmap::IndexMap;
 use rustc_hash::FxHashMap as HashMap;
-use unicode_ellipsis::grapheme_width;
-use unicode_segmentation::{GraphemeCursor, GraphemeIncomplete, UnicodeSegmentation};
 
 use crate::{
     app::layout_manager::BottomWidgetType,
     constants,
+    utils::input::InputFieldState,
     widgets::{
         BatteryWidgetState, CpuWidgetState, DiskTableWidget, MemWidgetState, NetWidgetState,
         ProcWidgetState, TempWidgetState, query::ProcessQuery,
@@ -52,14 +48,10 @@ impl Default for AppHelpDialogState {
 /// AppSearchState deals with generic searching (I might do this in the future).
 pub struct AppSearchState {
     pub is_enabled: bool,
-    pub current_search_query: String,
     pub is_blank_search: bool,
     pub is_invalid_search: bool,
-    pub grapheme_cursor: GraphemeCursor,
-    pub cursor_direction: CursorDirection,
 
-    pub display_start_char_index: usize,
-    pub size_mappings: IndexMap<usize, Range<usize>>,
+    pub input_field_state: InputFieldState,
 
     /// The query. TODO: Merge this as one enum.
     pub query: Option<ProcessQuery>,
@@ -70,13 +62,9 @@ impl Default for AppSearchState {
     fn default() -> Self {
         AppSearchState {
             is_enabled: false,
-            current_search_query: String::default(),
             is_invalid_search: false,
             is_blank_search: true,
-            grapheme_cursor: GraphemeCursor::new(0, 0, true),
-            cursor_direction: CursorDirection::Right,
-            display_start_char_index: 0,
-            size_mappings: IndexMap::default(),
+            input_field_state: InputFieldState::default(),
             query: None,
             error_message: None,
         }
@@ -96,147 +84,6 @@ impl AppSearchState {
     /// Returns whether the [`AppSearchState`] has an invalid or blank search.
     pub fn is_invalid_or_blank_search(&self) -> bool {
         self.is_blank_search || self.is_invalid_search
-    }
-
-    /// Sets the starting grapheme index to draw from.
-    pub fn get_start_position(&mut self, available_width: usize, is_force_redraw: bool) {
-        // Remember - the number of columns != the number of grapheme slots/sizes, you
-        // cannot use index to determine this reliably!
-
-        let start_index = if is_force_redraw {
-            0
-        } else {
-            self.display_start_char_index
-        };
-        let cursor_index = self.grapheme_cursor.cur_cursor();
-
-        if let Some(start_range) = self.size_mappings.get(&start_index) {
-            let cursor_range = self
-                .size_mappings
-                .get(&cursor_index)
-                .cloned()
-                .unwrap_or_else(|| {
-                    self.size_mappings
-                        .last()
-                        .map(|(_, r)| r.end..(r.end + 1))
-                        .unwrap_or(start_range.end..(start_range.end + 1))
-                });
-
-            // Cases to handle in both cases:
-            // - The current start index can show the cursor's word.
-            // - The current start index cannot show the cursor's word.
-            //
-            // What differs is how we "scroll" based on the cursor movement direction.
-
-            self.display_start_char_index = match self.cursor_direction {
-                CursorDirection::Right => {
-                    if start_range.start + available_width >= cursor_range.end {
-                        // Use the current index.
-                        start_index
-                    } else if cursor_range.end >= available_width {
-                        // If the current position is past the last visible element, skip until we
-                        // see it.
-
-                        let mut index = 0;
-                        for i in 0..(cursor_index + 1) {
-                            if let Some(r) = self.size_mappings.get(&i) {
-                                if r.start + available_width >= cursor_range.end {
-                                    index = i;
-                                    break;
-                                }
-                            }
-                        }
-
-                        index
-                    } else {
-                        0
-                    }
-                }
-                CursorDirection::Left => {
-                    if cursor_range.start < start_range.end {
-                        let mut index = 0;
-                        for i in cursor_index..(self.current_search_query.len()) {
-                            if let Some(r) = self.size_mappings.get(&i) {
-                                if r.start + available_width >= cursor_range.end {
-                                    index = i;
-                                    break;
-                                }
-                            }
-                        }
-                        index
-                    } else {
-                        start_index
-                    }
-                }
-            };
-        } else {
-            // If we fail here somehow, just reset to 0 index + scroll left.
-            self.display_start_char_index = 0;
-            self.cursor_direction = CursorDirection::Left;
-        };
-    }
-
-    pub(crate) fn walk_forward(&mut self) {
-        // TODO: Add tests for this.
-        let start_position = self.grapheme_cursor.cur_cursor();
-        let chunk = &self.current_search_query[start_position..];
-
-        match self.grapheme_cursor.next_boundary(chunk, start_position) {
-            Ok(_) => {}
-            Err(err) => match err {
-                GraphemeIncomplete::PreContext(ctx) => {
-                    // Provide the entire string as context. Not efficient but should resolve
-                    // failures.
-                    self.grapheme_cursor
-                        .provide_context(&self.current_search_query[0..ctx], 0);
-
-                    self.grapheme_cursor
-                        .next_boundary(chunk, start_position)
-                        .expect("another grapheme boundary should exist after the cursor with the provided context");
-                }
-                _ => panic!("{err:?}"),
-            },
-        }
-    }
-
-    pub(crate) fn walk_backward(&mut self) {
-        // TODO: Add tests for this.
-        let start_position = self.grapheme_cursor.cur_cursor();
-        let chunk = &self.current_search_query[..start_position];
-
-        match self.grapheme_cursor.prev_boundary(chunk, 0) {
-            Ok(_) => {}
-            Err(err) => match err {
-                GraphemeIncomplete::PreContext(ctx) => {
-                    // Provide the entire string as context. Not efficient but should resolve
-                    // failures.
-                    self.grapheme_cursor
-                        .provide_context(&self.current_search_query[0..ctx], 0);
-
-                    self.grapheme_cursor
-                        .prev_boundary(chunk, 0)
-                        .expect("another grapheme boundary should exist before the cursor with the provided context");
-                }
-                _ => panic!("{err:?}"),
-            },
-        }
-    }
-
-    pub(crate) fn update_sizes(&mut self) {
-        self.size_mappings.clear();
-        let mut curr_offset = 0;
-        for (index, grapheme) in
-            UnicodeSegmentation::grapheme_indices(self.current_search_query.as_str(), true)
-        {
-            let width = grapheme_width(grapheme);
-            let end = curr_offset + width;
-
-            self.size_mappings.insert(index, curr_offset..end);
-
-            curr_offset = end;
-        }
-
-        self.size_mappings.shrink_to_fit();
     }
 }
 
@@ -361,93 +208,4 @@ impl AppBatteryState {
 pub struct ParagraphScrollState {
     pub current_scroll_index: u16,
     pub max_scroll_index: u16,
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    fn move_right(state: &mut AppSearchState) {
-        state.walk_forward();
-        state.cursor_direction = CursorDirection::Right;
-    }
-
-    fn move_left(state: &mut AppSearchState) {
-        state.walk_backward();
-        state.cursor_direction = CursorDirection::Left;
-    }
-
-    #[test]
-    fn search_cursor_moves() {
-        let mut state = AppSearchState::default();
-        state.current_search_query = "Hi, 你好! 🇦🇶".to_string();
-        state.grapheme_cursor = GraphemeCursor::new(0, state.current_search_query.len(), true);
-        state.update_sizes();
-
-        // Moving right.
-        state.get_start_position(4, false);
-        assert_eq!(state.grapheme_cursor.cur_cursor(), 0);
-        assert_eq!(state.display_start_char_index, 0);
-
-        move_right(&mut state);
-        state.get_start_position(4, false);
-        assert_eq!(state.grapheme_cursor.cur_cursor(), 1);
-        assert_eq!(state.display_start_char_index, 0);
-
-        move_right(&mut state);
-        state.get_start_position(4, false);
-        assert_eq!(state.grapheme_cursor.cur_cursor(), 2);
-        assert_eq!(state.display_start_char_index, 0);
-
-        move_right(&mut state);
-        state.get_start_position(4, false);
-        assert_eq!(state.grapheme_cursor.cur_cursor(), 3);
-        assert_eq!(state.display_start_char_index, 0);
-
-        move_right(&mut state);
-        state.get_start_position(4, false);
-        assert_eq!(state.grapheme_cursor.cur_cursor(), 4);
-        assert_eq!(state.display_start_char_index, 2);
-
-        move_right(&mut state);
-        state.get_start_position(4, false);
-        assert_eq!(state.grapheme_cursor.cur_cursor(), 7);
-        assert_eq!(state.display_start_char_index, 4);
-
-        move_right(&mut state);
-        state.get_start_position(4, false);
-        assert_eq!(state.grapheme_cursor.cur_cursor(), 10);
-        assert_eq!(state.display_start_char_index, 7);
-
-        move_right(&mut state);
-        move_right(&mut state);
-        state.get_start_position(4, false);
-        assert_eq!(state.grapheme_cursor.cur_cursor(), 12);
-        assert_eq!(state.display_start_char_index, 10);
-
-        // Moving left.
-        move_left(&mut state);
-        state.get_start_position(4, false);
-        assert_eq!(state.grapheme_cursor.cur_cursor(), 11);
-        assert_eq!(state.display_start_char_index, 10);
-
-        move_left(&mut state);
-        move_left(&mut state);
-        state.get_start_position(4, false);
-        assert_eq!(state.grapheme_cursor.cur_cursor(), 7);
-        assert_eq!(state.display_start_char_index, 7);
-
-        move_left(&mut state);
-        move_left(&mut state);
-        move_left(&mut state);
-        move_left(&mut state);
-        state.get_start_position(4, false);
-        assert_eq!(state.grapheme_cursor.cur_cursor(), 1);
-        assert_eq!(state.display_start_char_index, 1);
-
-        move_left(&mut state);
-        state.get_start_position(4, false);
-        assert_eq!(state.grapheme_cursor.cur_cursor(), 0);
-        assert_eq!(state.display_start_char_index, 0);
-    }
 }

--- a/src/app/states.rs
+++ b/src/app/states.rs
@@ -48,9 +48,6 @@ impl Default for AppHelpDialogState {
 /// AppSearchState deals with generic searching (I might do this in the future).
 pub struct AppSearchState {
     pub is_enabled: bool,
-
-    // TODO: Remove is blank search... not needed.
-    pub is_blank_search: bool,
     pub is_invalid_search: bool,
 
     pub input_field_state: InputFieldState,
@@ -65,7 +62,6 @@ impl Default for AppSearchState {
         AppSearchState {
             is_enabled: false,
             is_invalid_search: false,
-            is_blank_search: true,
             input_field_state: InputFieldState::default(),
             query: None,
             error_message: None,
@@ -85,7 +81,7 @@ impl AppSearchState {
 
     /// Returns whether the [`AppSearchState`] has an invalid or blank search.
     pub fn is_invalid_or_blank_search(&self) -> bool {
-        self.is_blank_search || self.is_invalid_search
+        self.input_field_state.current_query().is_empty() || self.is_invalid_search
     }
 }
 

--- a/src/app/states.rs
+++ b/src/app/states.rs
@@ -48,6 +48,8 @@ impl Default for AppHelpDialogState {
 /// AppSearchState deals with generic searching (I might do this in the future).
 pub struct AppSearchState {
     pub is_enabled: bool,
+
+    // TODO: Remove is blank search... not needed.
     pub is_blank_search: bool,
     pub is_invalid_search: bool,
 

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -5,7 +5,6 @@ use tui::{
     text::{Line, Span},
     widgets::Paragraph,
 };
-use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{
     app::{App, AppSearchState},
@@ -110,17 +109,18 @@ impl Painter {
             search_state: &AppSearchState, available_width: usize, is_on_widget: bool,
             currently_selected_text_style: Style, text_style: Style,
         ) -> Vec<Span<'_>> {
-            let start_index = search_state.display_start_char_index;
-            let cursor_index = search_state.grapheme_cursor.cur_cursor();
+            let start_index = search_state.input_field_state.display_start_index();
+            let cursor_index = search_state.input_field_state.cursor_index();
             let mut current_width = 0;
-            let query = search_state.current_search_query.as_str();
+            let query = search_state.input_field_state.current_query();
 
             if is_on_widget {
                 let mut res = Vec::with_capacity(available_width);
-                for ((index, grapheme), lengths) in
-                    UnicodeSegmentation::grapheme_indices(query, true)
-                        .zip(search_state.size_mappings.values())
-                {
+                for (&index, lengths) in search_state.input_field_state.size_mappings() {
+                    let start = lengths.start;
+                    let end = lengths.end;
+                    let grapheme = &query[start..end];
+
                     if index < start_index {
                         continue;
                     } else if current_width > available_width {
@@ -133,7 +133,7 @@ impl Painter {
                         };
 
                         res.push(styled);
-                        current_width += lengths.end - lengths.start;
+                        current_width += end - start;
                     }
                 }
 
@@ -171,6 +171,7 @@ impl Painter {
             proc_widget_state
                 .proc_search
                 .search_state
+                .input_field_state
                 .get_start_position(available_width, app_state.is_force_redraw);
 
             // TODO: [CURSOR] blinking cursor?

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -116,19 +116,10 @@ impl Painter {
 
             if is_on_widget {
                 let mut res = Vec::with_capacity(available_width);
-                let mut iter = search_state
-                    .input_field_state
-                    .size_mappings()
-                    .iter()
-                    .peekable();
-                while let Some((&index, lengths)) = iter.next() {
-                    let grapheme = {
-                        let start = index;
-                        let end = iter.peek().map(|&(&next, _)| next).unwrap_or(query.len());
 
-                        &query[start..end]
-                    };
-
+                for (index, grapheme, lengths) in
+                    search_state.input_field_state.graphemes_with_ranges()
+                {
                     if index < start_index {
                         continue;
                     } else if current_width > available_width {

--- a/src/canvas/widgets/process_table.rs
+++ b/src/canvas/widgets/process_table.rs
@@ -116,10 +116,18 @@ impl Painter {
 
             if is_on_widget {
                 let mut res = Vec::with_capacity(available_width);
-                for (&index, lengths) in search_state.input_field_state.size_mappings() {
-                    let start = lengths.start;
-                    let end = lengths.end;
-                    let grapheme = &query[start..end];
+                let mut iter = search_state
+                    .input_field_state
+                    .size_mappings()
+                    .iter()
+                    .peekable();
+                while let Some((&index, lengths)) = iter.next() {
+                    let grapheme = {
+                        let start = index;
+                        let end = iter.peek().map(|&(&next, _)| next).unwrap_or(query.len());
+
+                        &query[start..end]
+                    };
 
                     if index < start_index {
                         continue;
@@ -133,7 +141,7 @@ impl Painter {
                         };
 
                         res.push(styled);
-                        current_width += end - start;
+                        current_width += lengths.end - lengths.start;
                     }
                 }
 
@@ -145,7 +153,6 @@ impl Painter {
             } else {
                 // This is easier - we just need to get a range of graphemes, rather than
                 // dealing with possibly inserting a cursor (as none is shown!)
-
                 vec![Span::styled(query.to_string(), text_style)]
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod utils {
     pub(crate) mod int_hash;
     pub(crate) mod logging;
     pub(crate) mod process_killer;
+    pub(crate) mod input;
     pub(crate) mod strings;
 }
 pub(crate) mod canvas;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,10 @@ mod utils {
     pub(crate) mod conversion;
     pub(crate) mod data_units;
     pub(crate) mod general;
+    pub(crate) mod input;
     pub(crate) mod int_hash;
     pub(crate) mod logging;
     pub(crate) mod process_killer;
-    pub(crate) mod input;
     pub(crate) mod strings;
 }
 pub(crate) mod canvas;

--- a/src/utils/input.rs
+++ b/src/utils/input.rs
@@ -12,7 +12,7 @@ use crate::{app::CursorDirection, utils::int_hash::IntIndexMap};
 /// An input field's state.
 pub struct InputFieldState {
     /// The search query itself, what is shown.
-    current_search_query: String,
+    current_query: String,
 
     /// The internal grapheme cursor to track the current location.
     grapheme_cursor: GraphemeCursor,
@@ -26,7 +26,7 @@ pub struct InputFieldState {
     /// Determines where we start _displaying_ the search based on
     /// the user's scroll. For example, if they move the cursor 5
     /// units to the right from 0, the index should be 5.
-    display_start_char_index: usize,
+    display_start_index: usize,
 
     /// Used for internal tracking of _byte_ indices to the widths
     /// of the graphemes they represent. This is mostly used to cache
@@ -40,10 +40,10 @@ pub struct InputFieldState {
 impl Default for InputFieldState {
     fn default() -> Self {
         Self {
-            current_search_query: String::default(),
+            current_query: String::default(),
             grapheme_cursor: GraphemeCursor::new(0, 0, true),
             cursor_direction: CursorDirection::Right,
-            display_start_char_index: 0,
+            display_start_index: 0,
             size_mappings: IntIndexMap::default(),
         }
     }
@@ -53,7 +53,7 @@ impl InputFieldState {
     /// Get a reference to the current query.
     #[inline]
     pub(crate) fn current_query(&self) -> &str {
-        &self.current_search_query
+        &self.current_query
     }
 
     /// Get the current cursor index.
@@ -65,15 +65,7 @@ impl InputFieldState {
     /// Get the display start index.
     #[inline]
     pub(crate) fn display_start_index(&self) -> usize {
-        self.display_start_char_index
-    }
-
-    /// Get the size mappings.
-    ///
-    /// TODO: We may want to reconsider exposing this, or expose something more encapsulated?
-    #[inline]
-    pub(crate) fn size_mappings(&self) -> &IntIndexMap<usize, Range<usize>> {
-        &self.size_mappings
+        self.display_start_index
     }
 
     /// Sets the starting grapheme index to draw from.
@@ -87,7 +79,7 @@ impl InputFieldState {
         let start_index = if is_force_redraw {
             0
         } else {
-            self.display_start_char_index
+            self.display_start_index
         };
         let cursor_index = self.cursor_index();
 
@@ -109,7 +101,7 @@ impl InputFieldState {
             //
             // What differs is how we "scroll" based on the cursor movement direction.
 
-            self.display_start_char_index = match self.cursor_direction {
+            self.display_start_index = match self.cursor_direction {
                 CursorDirection::Right => {
                     if start_range.start + available_width >= cursor_range.end {
                         // Use the current index.
@@ -136,7 +128,7 @@ impl InputFieldState {
                 CursorDirection::Left => {
                     if cursor_range.start < start_range.end {
                         let mut index = 0;
-                        for i in cursor_index..(self.current_search_query.len()) {
+                        for i in cursor_index..(self.current_query.len()) {
                             if let Some(r) = self.size_mappings.get(&i) {
                                 if r.start + available_width >= cursor_range.end {
                                     index = i;
@@ -152,7 +144,7 @@ impl InputFieldState {
             };
         } else {
             // If we fail here somehow, just reset to 0 index + scroll left.
-            self.display_start_char_index = 0;
+            self.display_start_index = 0;
             self.cursor_direction = CursorDirection::Left;
         };
     }
@@ -160,7 +152,7 @@ impl InputFieldState {
     /// Move the cursor one _grapheme_ forward.
     fn walk_forward(&mut self) {
         let start_position = self.cursor_index();
-        let chunk = &self.current_search_query[start_position..];
+        let chunk = &self.current_query[start_position..];
 
         match self.grapheme_cursor.next_boundary(chunk, start_position) {
             Ok(_) => {}
@@ -169,7 +161,7 @@ impl InputFieldState {
                     // Provide the entire string as context. Not efficient but should resolve
                     // failures.
                     self.grapheme_cursor
-                        .provide_context(&self.current_search_query[0..ctx], 0);
+                        .provide_context(&self.current_query[0..ctx], 0);
 
                     self.grapheme_cursor
                         .next_boundary(chunk, start_position)
@@ -183,7 +175,7 @@ impl InputFieldState {
     /// Move the cursor one _grapheme_ backward.
     fn walk_backward(&mut self) {
         let start_position = self.cursor_index();
-        let chunk = &self.current_search_query[..start_position];
+        let chunk = &self.current_query[..start_position];
 
         match self.grapheme_cursor.prev_boundary(chunk, 0) {
             Ok(_) => {}
@@ -192,7 +184,7 @@ impl InputFieldState {
                     // Provide the entire string as context. Not efficient but should resolve
                     // failures.
                     self.grapheme_cursor
-                        .provide_context(&self.current_search_query[0..ctx], 0);
+                        .provide_context(&self.current_query[0..ctx], 0);
 
                     self.grapheme_cursor
                         .prev_boundary(chunk, 0)
@@ -203,11 +195,15 @@ impl InputFieldState {
         }
     }
 
+    /// Update the size mappings (mapping of index to the display width range) after the query has been updated in any
+    /// way. This should be called whenever the query is updated.
+    ///
+    /// TODO: This might be a bit expensive, maybe we could update this a bit more iteratively?
     fn update_sizes(&mut self) {
         self.size_mappings.clear();
         let mut curr_offset = 0;
         for (index, grapheme) in
-            UnicodeSegmentation::grapheme_indices(self.current_search_query.as_str(), true)
+            UnicodeSegmentation::grapheme_indices(self.current_query.as_str(), true)
         {
             let width = grapheme_width(grapheme);
             let end = curr_offset + width;
@@ -223,14 +219,14 @@ impl InputFieldState {
     /// Delete whatever the cursor is currently highlighting, if anything. This is analogous to pressing `Delete`.
     pub(crate) fn delete_at_cursor(&mut self) {
         let current_cursor = self.cursor_index();
-        if current_cursor < self.current_search_query.len() {
+        if current_cursor < self.current_query.len() {
             self.walk_forward();
             let new_cursor = self.cursor_index();
 
-            let _ = self.current_search_query.drain(current_cursor..new_cursor);
+            let _ = self.current_query.drain(current_cursor..new_cursor);
 
             self.grapheme_cursor =
-                GraphemeCursor::new(current_cursor, self.current_search_query.len(), true);
+                GraphemeCursor::new(current_cursor, self.current_query.len(), true);
 
             self.update_sizes();
         }
@@ -245,10 +241,9 @@ impl InputFieldState {
             let new_cursor = self.cursor_index();
 
             // Remove the indices in between.
-            let _ = self.current_search_query.drain(new_cursor..current_cursor);
+            let _ = self.current_query.drain(new_cursor..current_cursor);
 
-            self.grapheme_cursor =
-                GraphemeCursor::new(new_cursor, self.current_search_query.len(), true);
+            self.grapheme_cursor = GraphemeCursor::new(new_cursor, self.current_query.len(), true);
 
             self.cursor_direction = CursorDirection::Left;
 
@@ -276,13 +271,13 @@ impl InputFieldState {
 
     /// Move the cursor to the start.
     pub(crate) fn skip_to_beginning(&mut self) {
-        self.grapheme_cursor = GraphemeCursor::new(0, self.current_search_query.len(), true);
+        self.grapheme_cursor = GraphemeCursor::new(0, self.current_query.len(), true);
         self.cursor_direction = CursorDirection::Left;
     }
 
     /// Move the cursor to the end.
     pub(crate) fn skip_to_end(&mut self) {
-        let query_len = self.current_search_query.len();
+        let query_len = self.current_query.len();
         self.grapheme_cursor = GraphemeCursor::new(query_len, query_len, true);
         self.cursor_direction = CursorDirection::Right;
     }
@@ -314,10 +309,9 @@ impl InputFieldState {
             }
         }
 
-        let _ = self.current_search_query.drain(start_index..current_cursor);
+        let _ = self.current_query.drain(start_index..current_cursor);
 
-        self.grapheme_cursor =
-            GraphemeCursor::new(start_index, self.current_search_query.len(), true);
+        self.grapheme_cursor = GraphemeCursor::new(start_index, self.current_query.len(), true);
 
         self.cursor_direction = CursorDirection::Left;
 
@@ -326,10 +320,10 @@ impl InputFieldState {
 
     /// Insert a single [`char`].
     pub(crate) fn insert_char(&mut self, ch: char) {
-        self.current_search_query.insert(self.cursor_index(), ch);
+        self.current_query.insert(self.cursor_index(), ch);
 
         self.grapheme_cursor =
-            GraphemeCursor::new(self.cursor_index(), self.current_search_query.len(), true);
+            GraphemeCursor::new(self.cursor_index(), self.current_query.len(), true);
 
         self.walk_forward();
         self.cursor_direction = CursorDirection::Right;
@@ -339,21 +333,16 @@ impl InputFieldState {
 
     /// Insert a [`String`].
     pub(crate) fn insert_string(&mut self, s: String) {
-        // Partially copy-pasted from the single-char variant; should probably clean up
-        // this process in the future. In particular, encapsulate this entire
-        // logic and add some tests to make it less potentially error-prone.
-
         let left_bound = self.cursor_index();
 
-        let curr_query = &mut self.current_search_query;
-        let (left, right) = curr_query.split_at(left_bound);
+        let current_query = &mut self.current_query;
+        let (left, right) = current_query.split_at(left_bound);
         let num_runes = UnicodeSegmentation::graphemes(s.as_str(), true).count();
 
-        *curr_query = concat_string!(left, s, right);
+        *current_query = concat_string!(left, s, right);
 
-        self.grapheme_cursor = GraphemeCursor::new(left_bound, curr_query.len(), true);
+        self.grapheme_cursor = GraphemeCursor::new(left_bound, current_query.len(), true);
 
-        // TODO: We could probably do something smarter here...
         for _ in 0..num_runes {
             self.walk_forward();
         }
@@ -361,6 +350,22 @@ impl InputFieldState {
         self.cursor_direction = CursorDirection::Right;
 
         self.update_sizes();
+    }
+
+    /// Returns an iterator over graphemes with the byte index + display-width range.
+    pub(crate) fn graphemes_with_ranges(
+        &self,
+    ) -> impl Iterator<Item = (usize, &str, &Range<usize>)> {
+        let query = self.current_query();
+        let mut iter = self.size_mappings.iter().peekable();
+
+        std::iter::from_fn(move || {
+            let (&start, lengths) = iter.next()?;
+            let end = iter.peek().map(|&(&next, _)| next).unwrap_or(query.len());
+            let grapheme = &query[start..end];
+
+            Some((start, grapheme, lengths))
+        })
     }
 }
 
@@ -710,8 +715,45 @@ mod tests {
         assert_eq!(state.cursor_index(), 0);
     }
 
-    /// Tests that the cursor moves correctly when moving left and right.
-    /// In particular, tests [`InputFieldState::move_left`] and [`InputFieldState::move_right`].
+    /// Test that [`InputFieldState::graphemes_with_ranges`] returns the correct graphemes along with their
+    /// byte indices and display width ranges.
+    #[test]
+    fn test_graphemes_with_ranges() {
+        let query = "Test你🇨🇦".to_string();
+        let query_len = query.len();
+
+        assert_eq!(query_len, 15); // 4 + 3 + 8
+
+        let mut state = InputFieldState::default();
+        state.insert_string(query);
+
+        let graphemes: Vec<(usize, &str, &Range<usize>)> = state.graphemes_with_ranges().collect();
+        assert_eq!(graphemes.len(), 6);
+
+        assert_eq!(graphemes[0], (0, "T", &(0..1)));
+        assert_eq!(graphemes[1], (1, "e", &(1..2)));
+        assert_eq!(graphemes[2], (2, "s", &(2..3)));
+        assert_eq!(graphemes[3], (3, "t", &(3..4)));
+        assert_eq!(
+            graphemes[4],
+            (4, "你", &(4..6)),
+            "你 is 3 bytes long, total grapheme is 2-wide"
+        );
+        assert_eq!(
+            graphemes[5],
+            (7, "🇨🇦", &(6..8)),
+            "🇨🇦 is 8 bytes long, total grapheme is 2-wide"
+        );
+
+        assert_eq!(
+            query_len - graphemes[5].0,
+            8,
+            "flag grapheme is 8 bytes long"
+        );
+    }
+
+    /// Tests that the cursor moves correctly when moving left and right, as well as things work correctly around
+    /// updating the display start index.
     #[test]
     fn search_cursor_moves() {
         let mut state = InputFieldState::default();
@@ -721,55 +763,72 @@ mod tests {
         // Moving right.
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 0);
-        assert_eq!(state.display_start_char_index, 0);
+        assert_eq!(state.display_start_index, 0);
 
         state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 1);
-        assert_eq!(state.display_start_char_index, 0);
+        assert_eq!(state.display_start_index, 0);
 
         state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 2);
-        assert_eq!(state.display_start_char_index, 0);
+        assert_eq!(state.display_start_index, 0);
 
         state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 3);
-        assert_eq!(state.display_start_char_index, 0);
+        assert_eq!(state.display_start_index, 0);
 
         state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 4);
-        assert_eq!(state.display_start_char_index, 2);
+        assert_eq!(state.display_start_index, 2);
 
         state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 7);
-        assert_eq!(state.display_start_char_index, 4);
+        assert_eq!(state.display_start_index, 4);
 
         state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 10);
-        assert_eq!(state.display_start_char_index, 7);
+        assert_eq!(state.display_start_index, 7);
 
         state.move_right();
         state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 12);
-        assert_eq!(state.display_start_char_index, 10);
+        assert_eq!(state.display_start_index, 10);
 
-        // Moving left.
+        // Move past the flag emoji (🇨🇦 = 8 bytes) to the end of string (byte 20).
+        state.move_right();
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 20);
+        assert_eq!(state.display_start_index, 11);
+
+        // Clamped at the end — no further movement.
+        state.move_right();
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 20);
+        assert_eq!(state.display_start_index, 11);
+
+        // Moving left — back over the flag emoji.
+        state.move_left();
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 12);
+        assert_eq!(state.display_start_index, 11);
+
         state.move_left();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 11);
-        assert_eq!(state.display_start_char_index, 10);
+        assert_eq!(state.display_start_index, 11);
 
         state.move_left();
         state.move_left();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 7);
-        assert_eq!(state.display_start_char_index, 7);
+        assert_eq!(state.display_start_index, 7);
 
         state.move_left();
         state.move_left();
@@ -777,11 +836,11 @@ mod tests {
         state.move_left();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 1);
-        assert_eq!(state.display_start_char_index, 1);
+        assert_eq!(state.display_start_index, 1);
 
         state.move_left();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 0);
-        assert_eq!(state.display_start_char_index, 0);
+        assert_eq!(state.display_start_index, 0);
     }
 }

--- a/src/utils/input.rs
+++ b/src/utils/input.rs
@@ -379,6 +379,7 @@ impl InputFieldState {
 mod tests {
     use super::*;
 
+    /// Tests that inserting ASCII chars appends them to the query and advances the cursor by 1 byte each.
     #[test]
     fn insert_char_ascii() {
         let mut state = InputFieldState::default();
@@ -392,8 +393,9 @@ mod tests {
         assert_eq!(state.cursor_index(), 2);
     }
 
+    /// Tests that inserting multi-byte Unicode chars (e.g. CJK) advances the cursor by the correct byte width.
     #[test]
-    fn insert_char_multibyte_unicode() {
+    fn insert_char_unicode() {
         let mut state = InputFieldState::default();
 
         state.insert_char('你'); // 3-byte UTF-8
@@ -405,6 +407,7 @@ mod tests {
         assert_eq!(state.cursor_index(), 6);
     }
 
+    /// Tests that inserting a 4-byte emoji advances the cursor to byte offset 4.
     #[test]
     fn insert_char_emoji() {
         let mut state = InputFieldState::default();
@@ -414,6 +417,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 4);
     }
 
+    /// Tests that inserting a char at a mid-string cursor position shifts the rest of the string
+    /// right and places the cursor immediately after the newly inserted char.
     #[test]
     fn insert_char_at_middle() {
         let mut state = InputFieldState::default();
@@ -430,6 +435,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 3);
     }
 
+    /// Tests that inserting an ASCII string at once places the entire string in the query
+    /// and lands the cursor at the end.
     #[test]
     fn insert_string_ascii() {
         let mut state = InputFieldState::default();
@@ -438,6 +445,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 5);
     }
 
+    /// Tests that inserting a mixed multi-byte + emoji string reflects the correct total byte length
+    /// in the cursor position.
     #[test]
     fn insert_string_unicode() {
         let mut state = InputFieldState::default();
@@ -447,6 +456,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 18);
     }
 
+    /// Tests that inserting a string at position 0 prepends it, leaving the cursor after the
+    /// inserted portion and the rest of the original string intact.
     #[test]
     fn insert_string_at_middle() {
         let mut state = InputFieldState::default();
@@ -457,6 +468,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 4);
     }
 
+    /// Tests that [`InputFieldState::delete_at_cursor`] removes the grapheme under the cursor
+    /// without moving the cursor position.
     #[test]
     fn delete_at_cursor_basic() {
         let mut state = InputFieldState::default();
@@ -472,6 +485,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 0);
     }
 
+    /// Tests that [`InputFieldState::delete_at_cursor`] is a no-op when the cursor is already
+    /// at the end of the string.
     #[test]
     fn delete_at_cursor_at_end_is_noop() {
         let mut state = InputFieldState::default();
@@ -483,6 +498,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 2);
     }
 
+    /// Tests that [`InputFieldState::delete_at_cursor`] correctly removes a full multi-byte
+    /// grapheme cluster in one operation.
     #[test]
     fn delete_at_cursor_unicode() {
         let mut state = InputFieldState::default();
@@ -494,6 +511,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 0);
     }
 
+    /// Tests that [`InputFieldState::delete_behind_cursor`] removes the grapheme immediately
+    /// before the cursor and moves the cursor back accordingly.
     #[test]
     fn delete_behind_cursor_basic() {
         let mut state = InputFieldState::default();
@@ -508,6 +527,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 3);
     }
 
+    /// Tests that [`InputFieldState::delete_behind_cursor`] is a no-op when the cursor is at
+    /// position 0.
     #[test]
     fn delete_behind_cursor_at_start_is_noop() {
         let mut state = InputFieldState::default();
@@ -519,6 +540,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 0);
     }
 
+    /// Tests that [`InputFieldState::delete_behind_cursor`] correctly removes multi-byte grapheme
+    /// clusters one at a time, adjusting the byte cursor each time.
     #[test]
     fn delete_behind_cursor_unicode() {
         let mut state = InputFieldState::default();
@@ -533,6 +556,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 0);
     }
 
+    /// Tests that [`InputFieldState::move_left`] and [`InputFieldState::move_right`] step one
+    /// byte per ASCII grapheme and are clamped at both ends of the string.
     #[test]
     fn move_left_right_ascii() {
         let mut state = InputFieldState::default();
@@ -562,6 +587,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 3);
     }
 
+    /// Tests that [`InputFieldState::move_left`] and [`InputFieldState::move_right`] jump the
+    /// full byte width of each grapheme, including multi-byte CJK characters.
     #[test]
     fn move_left_right_unicode() {
         let mut state = InputFieldState::default();
@@ -578,6 +605,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 0);
     }
 
+    /// Tests that [`InputFieldState::skip_to_beginning`] moves the cursor to byte 0 and
+    /// [`InputFieldState::skip_to_end`] moves it past the last byte.
     #[test]
     fn skip_to_beginning_and_end() {
         let mut state = InputFieldState::default();
@@ -590,6 +619,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 5);
     }
 
+    /// Tests that [`InputFieldState::skip_to_beginning`] sets the cursor direction to
+    /// [`CursorDirection::Left`] so that scrolling logic behaves correctly.
     #[test]
     fn skip_to_beginning_sets_direction_left() {
         let mut state = InputFieldState::default();
@@ -598,6 +629,8 @@ mod tests {
         assert!(matches!(state.cursor_direction, CursorDirection::Left));
     }
 
+    /// Tests that [`InputFieldState::skip_to_end`] sets the cursor direction to
+    /// [`CursorDirection::Right`] so that scrolling logic behaves correctly.
     #[test]
     fn skip_to_end_sets_direction_right() {
         let mut state = InputFieldState::default();
@@ -607,6 +640,8 @@ mod tests {
         assert!(matches!(state.cursor_direction, CursorDirection::Right));
     }
 
+    /// Tests that [`InputFieldState::delete_previous_word`] removes a single word with no
+    /// preceding whitespace, leaving an empty query.
     #[test]
     fn delete_previous_word_single_word() {
         let mut state = InputFieldState::default();
@@ -617,6 +652,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 0);
     }
 
+    /// Tests that [`InputFieldState::delete_previous_word`] removes exactly one word per call
+    /// when the query contains multiple words separated by a space.
     #[test]
     fn delete_previous_word_two_words() {
         let mut state = InputFieldState::default();
@@ -631,6 +668,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 0);
     }
 
+    /// Tests that [`InputFieldState::delete_previous_word`] skips trailing whitespace before
+    /// deleting the preceding non-whitespace word.
     #[test]
     fn delete_previous_word_trailing_spaces() {
         let mut state = InputFieldState::default();
@@ -642,6 +681,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 0);
     }
 
+    /// Tests that [`InputFieldState::delete_previous_word`] only removes the portion of a word
+    /// that lies behind the cursor when the cursor is mid-word.
     #[test]
     fn delete_previous_word_from_middle() {
         let mut state = InputFieldState::default();
@@ -658,6 +699,8 @@ mod tests {
         assert_eq!(state.cursor_index(), 0);
     }
 
+    /// Tests that [`InputFieldState::reset`] returns all fields — query, cursor position,
+    /// display start index, and size mappings — to their default values.
     #[test]
     fn reset_clears_state() {
         let mut state = InputFieldState::default();

--- a/src/utils/input.rs
+++ b/src/utils/input.rs
@@ -52,19 +52,19 @@ impl Default for InputFieldState {
 impl InputFieldState {
     /// Get a reference to the current query.
     #[inline]
-    pub fn current_query(&self) -> &str {
+    pub(crate) fn current_query(&self) -> &str {
         &self.current_search_query
     }
 
     /// Get the current cursor index.
     #[inline]
-    pub fn cursor_index(&self) -> usize {
+    pub(crate) fn cursor_index(&self) -> usize {
         self.grapheme_cursor.cur_cursor()
     }
 
     /// Get the display start index.
     #[inline]
-    pub fn display_start_index(&self) -> usize {
+    pub(crate) fn display_start_index(&self) -> usize {
         self.display_start_char_index
     }
 
@@ -72,21 +72,15 @@ impl InputFieldState {
     ///
     /// TODO: We may want to reconsider exposing this, or expose something more encapsulated?
     #[inline]
-    pub fn size_mappings(&self) -> &IntIndexMap<usize, Range<usize>> {
+    pub(crate) fn size_mappings(&self) -> &IntIndexMap<usize, Range<usize>> {
         &self.size_mappings
-    }
-
-    /// Reset the input field state.
-    #[inline]
-    pub fn reset(&mut self) {
-        *self = Self::default();
     }
 
     /// Sets the starting grapheme index to draw from.
     ///
     /// TODO: This is kinda weird, we might want to decouple this in some way such that this
     /// is clear this only matters for drawing... but it also changes states...
-    pub fn get_start_position(&mut self, available_width: usize, is_force_redraw: bool) {
+    pub(crate) fn get_start_position(&mut self, available_width: usize, is_force_redraw: bool) {
         // Remember - the number of columns != the number of grapheme slots/sizes, you
         // cannot use index to determine this reliably!
 
@@ -227,7 +221,7 @@ impl InputFieldState {
     }
 
     /// Delete whatever the cursor is currently highlighting, if anything. This is analogous to pressing `Delete`.
-    pub fn delete_at_cursor(&mut self) {
+    pub(crate) fn delete_at_cursor(&mut self) {
         let current_cursor = self.cursor_index();
         if current_cursor < self.current_search_query.len() {
             self.walk_forward();
@@ -243,7 +237,7 @@ impl InputFieldState {
     }
 
     /// Delete what is _behind_ the cursor. This is analogous to pressing `Backspace`.
-    pub fn delete_behind_cursor(&mut self) {
+    pub(crate) fn delete_behind_cursor(&mut self) {
         let current_cursor = self.cursor_index();
 
         if current_cursor > 0 {
@@ -263,7 +257,7 @@ impl InputFieldState {
     }
 
     /// Move the cursor left one unit if possible.
-    pub fn move_left(&mut self) {
+    pub(crate) fn move_left(&mut self) {
         let current_cursor = self.cursor_index();
         self.walk_backward();
         if self.cursor_index() < current_cursor {
@@ -272,7 +266,7 @@ impl InputFieldState {
     }
 
     /// Move the cursor right one unit if possible.
-    pub fn move_right(&mut self) {
+    pub(crate) fn move_right(&mut self) {
         let current_cursor = self.cursor_index();
         self.walk_forward();
         if self.cursor_index() > current_cursor {
@@ -281,20 +275,20 @@ impl InputFieldState {
     }
 
     /// Move the cursor to the start.
-    pub fn skip_to_beginning(&mut self) {
+    pub(crate) fn skip_to_beginning(&mut self) {
         self.grapheme_cursor = GraphemeCursor::new(0, self.current_search_query.len(), true);
         self.cursor_direction = CursorDirection::Left;
     }
 
     /// Move the cursor to the end.
-    pub fn skip_to_end(&mut self) {
+    pub(crate) fn skip_to_end(&mut self) {
         let query_len = self.current_search_query.len();
         self.grapheme_cursor = GraphemeCursor::new(query_len, query_len, true);
         self.cursor_direction = CursorDirection::Right;
     }
 
     /// Delete the previous "word".
-    pub fn delete_previous_word(&mut self) {
+    pub(crate) fn delete_previous_word(&mut self) {
         // Traverse backwards from the current cursor location until you hit
         // non-whitespace characters, then continue to traverse (and
         // delete) backwards until you hit a whitespace character.  Halt.
@@ -331,7 +325,7 @@ impl InputFieldState {
     }
 
     /// Insert a single [`char`].
-    pub fn insert_char(&mut self, ch: char) {
+    pub(crate) fn insert_char(&mut self, ch: char) {
         self.current_search_query.insert(self.cursor_index(), ch);
 
         self.grapheme_cursor =
@@ -344,7 +338,7 @@ impl InputFieldState {
     }
 
     /// Insert a [`String`].
-    pub fn insert_string(&mut self, s: String) {
+    pub(crate) fn insert_string(&mut self, s: String) {
         // Partially copy-pasted from the single-char variant; should probably clean up
         // this process in the future. In particular, encapsulate this entire
         // logic and add some tests to make it less potentially error-prone.
@@ -714,21 +708,6 @@ mod tests {
         state.delete_previous_word();
         assert_eq!(state.current_query(), "");
         assert_eq!(state.cursor_index(), 0);
-    }
-
-    /// Tests that [`InputFieldState::reset`] returns all fields — query, cursor position,
-    /// display start index, and size mappings — to their default values.
-    #[test]
-    fn reset_clears_state() {
-        let mut state = InputFieldState::default();
-        state.insert_string("Something".to_string());
-        assert_eq!(state.current_query(), "Something");
-
-        state.reset();
-        assert_eq!(state.current_query(), "");
-        assert_eq!(state.cursor_index(), 0);
-        assert_eq!(state.display_start_index(), 0);
-        assert!(state.size_mappings().is_empty());
     }
 
     /// Tests that the cursor moves correctly when moving left and right.

--- a/src/utils/input.rs
+++ b/src/utils/input.rs
@@ -1,0 +1,45 @@
+//! Generalized input logic, to make it easier to reuse logic like unicode handling
+//! and cursor movement.
+
+use std::ops::Range;
+
+use indexmap::IndexMap;
+use unicode_segmentation::GraphemeCursor;
+
+use crate::{app::CursorDirection, utils::int_hash::IntHashMap};
+
+/// An input field's state.
+pub struct InputFieldState {
+    /// The search query itself, what is shown.
+    current_search_query: String,
+
+    /// The internal grapheme cursor to track the current location.
+    grapheme_cursor: GraphemeCursor,
+
+    /// The direction the cursor is heading at the moment. Modified
+    /// by user actions, e.g. adding text moves it right, deleting
+    /// text moves it left, the user scrolling changes it based
+    /// on where they scroll, etc.
+    cursor_direction: CursorDirection,
+
+    /// Determines where we start _displaying_ the search based on
+    /// the user's scroll. For example, if they move the cursor 5
+    /// units to the right from 0, the index should be 5.
+    display_start_char_index: usize,
+
+    /// Used for internal tracking of _byte_ indices to the widths
+    /// of the graphemes they represent. This is mostly used to cache
+    /// and avoid having to re-calculate widths each time it needs to
+    /// be accessed.
+    ///
+    /// Should always be updated after the search query updates in any way.
+    size_mappings: IntHashMap<usize, Range<usize>>,
+}
+
+impl InputFieldState {
+    /// Get a reference to the current query.
+    #[inline]
+    pub fn current_query(&self) -> &str {
+        &self.current_search_query
+    }
+}

--- a/src/utils/input.rs
+++ b/src/utils/input.rs
@@ -237,6 +237,8 @@ impl InputFieldState {
 
             self.grapheme_cursor =
                 GraphemeCursor::new(current_cursor, self.current_search_query.len(), true);
+
+            self.update_sizes();
         }
     }
 
@@ -255,6 +257,8 @@ impl InputFieldState {
                 GraphemeCursor::new(new_cursor, self.current_search_query.len(), true);
 
             self.cursor_direction = CursorDirection::Left;
+
+            self.update_sizes();
         }
     }
 
@@ -327,6 +331,8 @@ impl InputFieldState {
             GraphemeCursor::new(start_index, self.current_search_query.len(), true);
 
         self.cursor_direction = CursorDirection::Left;
+
+        self.update_sizes();
     }
 
     /// Insert a single [`char`].
@@ -338,6 +344,8 @@ impl InputFieldState {
 
         self.walk_forward();
         self.cursor_direction = CursorDirection::Right;
+
+        self.update_sizes();
     }
 
     /// Insert a [`String`].
@@ -362,6 +370,8 @@ impl InputFieldState {
         }
 
         self.cursor_direction = CursorDirection::Right;
+
+        self.update_sizes();
     }
 }
 

--- a/src/utils/input.rs
+++ b/src/utils/input.rs
@@ -56,18 +56,36 @@ impl InputFieldState {
         &self.current_search_query
     }
 
-    /// Get a mutable reference to the current query.
+    /// Get the current cursor index.
     #[inline]
-    pub fn current_query_mut(&mut self) -> &mut String {
-        &mut self.current_search_query
+    pub fn cursor_index(&self) -> usize {
+        self.grapheme_cursor.cur_cursor()
+    }
+
+    /// Get the display start index.
+    #[inline]
+    pub fn display_start_index(&self) -> usize {
+        self.display_start_char_index
+    }
+
+    /// Get the size mappings.
+    ///
+    /// TODO: We may want to reconsider exposing this, or expose something more encapsulated?
+    #[inline]
+    pub fn size_mappings(&self) -> &IntIndexMap<usize, Range<usize>> {
+        &self.size_mappings
     }
 
     /// Reset the input field state.
+    #[inline]
     pub fn reset(&mut self) {
         *self = Self::default();
     }
 
     /// Sets the starting grapheme index to draw from.
+    ///
+    /// TODO: This is kinda weird, we might want to decouple this in some way such that this
+    /// is clear this only matters for drawing... but it also changes states...
     pub fn get_start_position(&mut self, available_width: usize, is_force_redraw: bool) {
         // Remember - the number of columns != the number of grapheme slots/sizes, you
         // cannot use index to determine this reliably!
@@ -77,7 +95,7 @@ impl InputFieldState {
         } else {
             self.display_start_char_index
         };
-        let cursor_index = self.grapheme_cursor.cur_cursor();
+        let cursor_index = self.cursor_index();
 
         if let Some(start_range) = self.size_mappings.get(&start_index) {
             let cursor_range = self
@@ -147,7 +165,7 @@ impl InputFieldState {
 
     /// Move the cursor one _grapheme_ forward.
     pub(crate) fn walk_forward(&mut self) {
-        let start_position = self.grapheme_cursor.cur_cursor();
+        let start_position = self.cursor_index();
         let chunk = &self.current_search_query[start_position..];
 
         match self.grapheme_cursor.next_boundary(chunk, start_position) {
@@ -170,7 +188,7 @@ impl InputFieldState {
 
     /// Move the cursor one _grapheme_ backward.
     pub(crate) fn walk_backward(&mut self) {
-        let start_position = self.grapheme_cursor.cur_cursor();
+        let start_position = self.cursor_index();
         let chunk = &self.current_search_query[..start_position];
 
         match self.grapheme_cursor.prev_boundary(chunk, 0) {
@@ -210,10 +228,10 @@ impl InputFieldState {
 
     /// Delete whatever the cursor is currently highlighting, if anything. This is analogous to pressing `Delete`.
     pub fn delete_at_cursor(&mut self) {
-        let current_cursor = self.grapheme_cursor.cur_cursor();
+        let current_cursor = self.cursor_index();
         if current_cursor < self.current_search_query.len() {
             self.walk_forward();
-            let new_cursor = self.grapheme_cursor.cur_cursor();
+            let new_cursor = self.cursor_index();
 
             let _ = self.current_search_query.drain(current_cursor..new_cursor);
 
@@ -224,11 +242,11 @@ impl InputFieldState {
 
     /// Delete what is _behind_ the cursor. This is analogous to pressing `Backspace`.
     pub fn delete_behind_cursor(&mut self) {
-        let current_cursor = self.grapheme_cursor.cur_cursor();
+        let current_cursor = self.cursor_index();
 
         if current_cursor > 0 {
             self.walk_backward();
-            let new_cursor = self.grapheme_cursor.cur_cursor();
+            let new_cursor = self.cursor_index();
 
             // Remove the indices in between.
             let _ = self.current_search_query.drain(new_cursor..current_cursor);
@@ -242,18 +260,18 @@ impl InputFieldState {
 
     /// Move the cursor left one unit if possible.
     pub fn move_left(&mut self) {
-        let current_cursor = self.grapheme_cursor.cur_cursor();
+        let current_cursor = self.cursor_index();
         self.walk_backward();
-        if self.grapheme_cursor.cur_cursor() < current_cursor {
+        if self.cursor_index() < current_cursor {
             self.cursor_direction = CursorDirection::Left;
         }
     }
 
     /// Move the cursor right one unit if possible.
     pub fn move_right(&mut self) {
-        let current_cursor = self.grapheme_cursor.cur_cursor();
+        let current_cursor = self.cursor_index();
         self.walk_forward();
-        if self.grapheme_cursor.cur_cursor() > current_cursor {
+        if self.cursor_index() > current_cursor {
             self.cursor_direction = CursorDirection::Right;
         }
     }
@@ -279,7 +297,7 @@ impl InputFieldState {
 
         // So... first, let's get our current cursor position in terms of char
         // indices. This is the "end" index we care about.
-        let current_cursor = self.grapheme_cursor.cur_cursor();
+        let current_cursor = self.cursor_index();
 
         // Then, let's crawl backwards until we hit our location, and store the
         // "head"...
@@ -313,14 +331,10 @@ impl InputFieldState {
 
     /// Insert a single [`char`].
     pub fn insert_char(&mut self, ch: char) {
-        self.current_search_query
-            .insert(self.grapheme_cursor.cur_cursor(), ch);
+        self.current_search_query.insert(self.cursor_index(), ch);
 
-        self.grapheme_cursor = GraphemeCursor::new(
-            self.grapheme_cursor.cur_cursor(),
-            self.current_search_query.len(),
-            true,
-        );
+        self.grapheme_cursor =
+            GraphemeCursor::new(self.cursor_index(), self.current_search_query.len(), true);
 
         self.walk_forward();
         self.cursor_direction = CursorDirection::Right;
@@ -332,7 +346,7 @@ impl InputFieldState {
         // this process in the future. In particular, encapsulate this entire
         // logic and add some tests to make it less potentially error-prone.
 
-        let left_bound = self.grapheme_cursor.cur_cursor();
+        let left_bound = self.cursor_index();
 
         let curr_query = &mut self.current_search_query;
         let (left, right) = curr_query.split_at(left_bound);

--- a/src/utils/input.rs
+++ b/src/utils/input.rs
@@ -3,6 +3,7 @@
 
 use std::ops::Range;
 
+use concat_string::concat_string;
 use unicode_ellipsis::grapheme_width;
 use unicode_segmentation::{GraphemeCursor, GraphemeIncomplete, UnicodeSegmentation};
 
@@ -308,6 +309,45 @@ impl InputFieldState {
             GraphemeCursor::new(start_index, self.current_search_query.len(), true);
 
         self.cursor_direction = CursorDirection::Left;
+    }
+
+    /// Insert a single [`char`].
+    pub fn insert_char(&mut self, ch: char) {
+        self.current_search_query
+            .insert(self.grapheme_cursor.cur_cursor(), ch);
+
+        self.grapheme_cursor = GraphemeCursor::new(
+            self.grapheme_cursor.cur_cursor(),
+            self.current_search_query.len(),
+            true,
+        );
+
+        self.walk_forward();
+        self.cursor_direction = CursorDirection::Right;
+    }
+
+    /// Insert a [`String`].
+    pub fn insert_string(&mut self, s: String) {
+        // Partially copy-pasted from the single-char variant; should probably clean up
+        // this process in the future. In particular, encapsulate this entire
+        // logic and add some tests to make it less potentially error-prone.
+
+        let left_bound = self.grapheme_cursor.cur_cursor();
+
+        let curr_query = &mut self.current_search_query;
+        let (left, right) = curr_query.split_at(left_bound);
+        let num_runes = UnicodeSegmentation::graphemes(s.as_str(), true).count();
+
+        *curr_query = concat_string!(left, s, right);
+
+        self.grapheme_cursor = GraphemeCursor::new(left_bound, curr_query.len(), true);
+
+        // TODO: We could probably do something smarter here...
+        for _ in 0..num_runes {
+            self.walk_forward();
+        }
+
+        self.cursor_direction = CursorDirection::Right;
     }
 }
 

--- a/src/utils/input.rs
+++ b/src/utils/input.rs
@@ -309,15 +309,10 @@ impl InputFieldState {
         let mut start_index = 0;
         let mut saw_non_whitespace = false;
 
-        for (itx, c) in query
-            .chars()
-            .rev()
-            .enumerate()
-            .skip(query.len() - current_cursor)
-        {
+        for (itx, c) in query[..current_cursor].char_indices().rev() {
             if c.is_whitespace() {
                 if saw_non_whitespace {
-                    start_index = query.len() - itx;
+                    start_index = itx + c.len_utf8();
                     break;
                 }
             } else {
@@ -696,6 +691,28 @@ mod tests {
 
         state.delete_previous_word(); // deletes "Hel"
         assert_eq!(state.current_query(), "lo World");
+        assert_eq!(state.cursor_index(), 0);
+    }
+
+    /// Tests that [`InputFieldState::delete_previous_word`] correctly handles multibyte
+    /// characters. The char/byte index mismatch bug would cause `.skip(query.len() -
+    /// current_cursor)` to skip the wrong number of chars and `query.len() - itx` to land
+    /// on a non-char-boundary, either producing the wrong result or panicking.
+    #[test]
+    fn delete_previous_word_unicode() {
+        // "你好 world" — '你'=3 bytes, '好'=3 bytes, ' '=1, "world"=5, so 12 bytes total
+        let mut state = InputFieldState::default();
+        state.insert_string("你好 world".to_string());
+
+        // Cursor is at the end (byte 12). Deleting the previous word should remove "world",
+        // leaving "你好 " (7 bytes).
+        state.delete_previous_word();
+        assert_eq!(state.current_query(), "你好 ");
+        assert_eq!(state.cursor_index(), 7);
+
+        // Deleting again skips the trailing space then removes "你好", leaving "".
+        state.delete_previous_word();
+        assert_eq!(state.current_query(), "");
         assert_eq!(state.cursor_index(), 0);
     }
 

--- a/src/utils/input.rs
+++ b/src/utils/input.rs
@@ -446,7 +446,7 @@ mod tests {
         let mut state = InputFieldState::default();
         state.insert_string("你好🇨🇦🦀".to_string());
         assert_eq!(state.current_query(), "你好🇨🇦🦀");
-        // '你'=3, '好'=3, '🦀'=4, '🇨🇦'=8, so 14 bytes
+        // '你'=3, '好'=3, '🦀'=4, '🇨🇦'=8, so 18 bytes
         assert_eq!(state.cursor_index(), 18);
     }
 

--- a/src/utils/input.rs
+++ b/src/utils/input.rs
@@ -164,7 +164,7 @@ impl InputFieldState {
     }
 
     /// Move the cursor one _grapheme_ forward.
-    pub(crate) fn walk_forward(&mut self) {
+    fn walk_forward(&mut self) {
         let start_position = self.cursor_index();
         let chunk = &self.current_search_query[start_position..];
 
@@ -187,7 +187,7 @@ impl InputFieldState {
     }
 
     /// Move the cursor one _grapheme_ backward.
-    pub(crate) fn walk_backward(&mut self) {
+    fn walk_backward(&mut self) {
         let start_position = self.cursor_index();
         let chunk = &self.current_search_query[..start_position];
 
@@ -379,85 +379,368 @@ impl InputFieldState {
 mod tests {
     use super::*;
 
-    fn move_right(state: &mut InputFieldState) {
-        state.walk_forward();
-        state.cursor_direction = CursorDirection::Right;
-    }
+    #[test]
+    fn insert_char_ascii() {
+        let mut state = InputFieldState::default();
 
-    fn move_left(state: &mut InputFieldState) {
-        state.walk_backward();
-        state.cursor_direction = CursorDirection::Left;
+        state.insert_char('H');
+        assert_eq!(state.current_query(), "H");
+        assert_eq!(state.cursor_index(), 1);
+
+        state.insert_char('i');
+        assert_eq!(state.current_query(), "Hi");
+        assert_eq!(state.cursor_index(), 2);
     }
 
     #[test]
+    fn insert_char_multibyte_unicode() {
+        let mut state = InputFieldState::default();
+
+        state.insert_char('你'); // 3-byte UTF-8
+        assert_eq!(state.current_query(), "你");
+        assert_eq!(state.cursor_index(), 3);
+
+        state.insert_char('好');
+        assert_eq!(state.current_query(), "你好");
+        assert_eq!(state.cursor_index(), 6);
+    }
+
+    #[test]
+    fn insert_char_emoji() {
+        let mut state = InputFieldState::default();
+
+        state.insert_char('🦀'); // 4-byte UTF-8
+        assert_eq!(state.current_query(), "🦀");
+        assert_eq!(state.cursor_index(), 4);
+    }
+
+    #[test]
+    fn insert_char_at_middle() {
+        let mut state = InputFieldState::default();
+        state.insert_char('H');
+        state.insert_char('i');
+        state.insert_char('!');
+
+        // Move back to before '!'
+        state.move_left();
+        assert_eq!(state.cursor_index(), 2);
+
+        state.insert_char(' ');
+        assert_eq!(state.current_query(), "Hi !");
+        assert_eq!(state.cursor_index(), 3);
+    }
+
+    #[test]
+    fn insert_string_ascii() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Hello".to_string());
+        assert_eq!(state.current_query(), "Hello");
+        assert_eq!(state.cursor_index(), 5);
+    }
+
+    #[test]
+    fn insert_string_unicode() {
+        let mut state = InputFieldState::default();
+        state.insert_string("你好🇨🇦🦀".to_string());
+        assert_eq!(state.current_query(), "你好🇨🇦🦀");
+        // '你'=3, '好'=3, '🦀'=4, '🇨🇦'=8, so 14 bytes
+        assert_eq!(state.cursor_index(), 18);
+    }
+
+    #[test]
+    fn insert_string_at_middle() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Hello".to_string());
+        state.skip_to_beginning();
+        state.insert_string("Say ".to_string());
+        assert_eq!(state.current_query(), "Say Hello");
+        assert_eq!(state.cursor_index(), 4);
+    }
+
+    #[test]
+    fn delete_at_cursor_basic() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Hello".to_string());
+        state.skip_to_beginning();
+
+        state.delete_at_cursor(); // removes 'H'
+        assert_eq!(state.current_query(), "ello");
+        assert_eq!(state.cursor_index(), 0);
+
+        state.delete_at_cursor(); // removes 'e'
+        assert_eq!(state.current_query(), "llo");
+        assert_eq!(state.cursor_index(), 0);
+    }
+
+    #[test]
+    fn delete_at_cursor_at_end_is_noop() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Hi".to_string());
+        // cursor is already at end after inserting
+
+        state.delete_at_cursor();
+        assert_eq!(state.current_query(), "Hi");
+        assert_eq!(state.cursor_index(), 2);
+    }
+
+    #[test]
+    fn delete_at_cursor_unicode() {
+        let mut state = InputFieldState::default();
+        state.insert_string("你好".to_string());
+        state.skip_to_beginning();
+
+        state.delete_at_cursor(); // removes '你' (3 bytes)
+        assert_eq!(state.current_query(), "好");
+        assert_eq!(state.cursor_index(), 0);
+    }
+
+    #[test]
+    fn delete_behind_cursor_basic() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Hello".to_string());
+
+        state.delete_behind_cursor(); // removes 'o'
+        assert_eq!(state.current_query(), "Hell");
+        assert_eq!(state.cursor_index(), 4);
+
+        state.delete_behind_cursor(); // removes 'l'
+        assert_eq!(state.current_query(), "Hel");
+        assert_eq!(state.cursor_index(), 3);
+    }
+
+    #[test]
+    fn delete_behind_cursor_at_start_is_noop() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Hi".to_string());
+        state.skip_to_beginning();
+
+        state.delete_behind_cursor();
+        assert_eq!(state.current_query(), "Hi");
+        assert_eq!(state.cursor_index(), 0);
+    }
+
+    #[test]
+    fn delete_behind_cursor_unicode() {
+        let mut state = InputFieldState::default();
+        state.insert_string("你好".to_string());
+
+        state.delete_behind_cursor(); // removes '好' (3 bytes)
+        assert_eq!(state.current_query(), "你");
+        assert_eq!(state.cursor_index(), 3);
+
+        state.delete_behind_cursor(); // removes '你' (3 bytes)
+        assert_eq!(state.current_query(), "");
+        assert_eq!(state.cursor_index(), 0);
+    }
+
+    #[test]
+    fn move_left_right_ascii() {
+        let mut state = InputFieldState::default();
+        state.insert_string("abc".to_string());
+        assert_eq!(state.cursor_index(), 3);
+
+        state.move_left();
+        assert_eq!(state.cursor_index(), 2);
+        state.move_left();
+        assert_eq!(state.cursor_index(), 1);
+        state.move_left();
+        assert_eq!(state.cursor_index(), 0);
+
+        // At the start — no further movement
+        state.move_left();
+        assert_eq!(state.cursor_index(), 0);
+
+        state.move_right();
+        assert_eq!(state.cursor_index(), 1);
+        state.move_right();
+        assert_eq!(state.cursor_index(), 2);
+        state.move_right();
+        assert_eq!(state.cursor_index(), 3);
+
+        // At the end — no further movement
+        state.move_right();
+        assert_eq!(state.cursor_index(), 3);
+    }
+
+    #[test]
+    fn move_left_right_unicode() {
+        let mut state = InputFieldState::default();
+        state.insert_string("a你b".to_string()); // 1 + 3 + 1 = 5 bytes
+        assert_eq!(state.cursor_index(), 5);
+
+        state.move_left(); // over 'b' (1 byte)
+        assert_eq!(state.cursor_index(), 4);
+
+        state.move_left(); // over '你' (3 bytes)
+        assert_eq!(state.cursor_index(), 1);
+
+        state.move_left(); // over 'a' (1 byte)
+        assert_eq!(state.cursor_index(), 0);
+    }
+
+    #[test]
+    fn skip_to_beginning_and_end() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Hello".to_string());
+
+        state.skip_to_beginning();
+        assert_eq!(state.cursor_index(), 0);
+
+        state.skip_to_end();
+        assert_eq!(state.cursor_index(), 5);
+    }
+
+    #[test]
+    fn skip_to_beginning_sets_direction_left() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Hello".to_string());
+        state.skip_to_beginning();
+        assert!(matches!(state.cursor_direction, CursorDirection::Left));
+    }
+
+    #[test]
+    fn skip_to_end_sets_direction_right() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Hello".to_string());
+        state.skip_to_beginning();
+        state.skip_to_end();
+        assert!(matches!(state.cursor_direction, CursorDirection::Right));
+    }
+
+    #[test]
+    fn delete_previous_word_single_word() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Hello".to_string());
+
+        state.delete_previous_word();
+        assert_eq!(state.current_query(), "");
+        assert_eq!(state.cursor_index(), 0);
+    }
+
+    #[test]
+    fn delete_previous_word_two_words() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Hello World".to_string());
+
+        state.delete_previous_word(); // deletes "World"
+        assert_eq!(state.current_query(), "Hello ");
+        assert_eq!(state.cursor_index(), 6);
+
+        state.delete_previous_word(); // deletes "Hello "
+        assert_eq!(state.current_query(), "");
+        assert_eq!(state.cursor_index(), 0);
+    }
+
+    #[test]
+    fn delete_previous_word_trailing_spaces() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Hello   ".to_string()); // trailing spaces
+
+        // Should skip spaces first, then delete "Hello"
+        state.delete_previous_word();
+        assert_eq!(state.current_query(), "");
+        assert_eq!(state.cursor_index(), 0);
+    }
+
+    #[test]
+    fn delete_previous_word_from_middle() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Hello World".to_string());
+        state.skip_to_beginning();
+        // Advance 3 chars ('H','e','l')
+        state.move_right();
+        state.move_right();
+        state.move_right();
+        assert_eq!(state.cursor_index(), 3);
+
+        state.delete_previous_word(); // deletes "Hel"
+        assert_eq!(state.current_query(), "lo World");
+        assert_eq!(state.cursor_index(), 0);
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        let mut state = InputFieldState::default();
+        state.insert_string("Something".to_string());
+        assert_eq!(state.current_query(), "Something");
+
+        state.reset();
+        assert_eq!(state.current_query(), "");
+        assert_eq!(state.cursor_index(), 0);
+        assert_eq!(state.display_start_index(), 0);
+        assert!(state.size_mappings().is_empty());
+    }
+
+    /// Tests that the cursor moves correctly when moving left and right.
+    /// In particular, tests [`InputFieldState::move_left`] and [`InputFieldState::move_right`].
+    #[test]
     fn search_cursor_moves() {
         let mut state = InputFieldState::default();
-        state.current_search_query = "Hi, 你好! 🇦🇶".to_string();
-        state.grapheme_cursor = GraphemeCursor::new(0, state.current_search_query.len(), true);
-        state.update_sizes();
+        state.insert_string("Hi, 你好! 🇨🇦".to_string());
+        state.skip_to_beginning();
 
         // Moving right.
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 0);
         assert_eq!(state.display_start_char_index, 0);
 
-        move_right(&mut state);
+        state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 1);
         assert_eq!(state.display_start_char_index, 0);
 
-        move_right(&mut state);
+        state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 2);
         assert_eq!(state.display_start_char_index, 0);
 
-        move_right(&mut state);
+        state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 3);
         assert_eq!(state.display_start_char_index, 0);
 
-        move_right(&mut state);
+        state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 4);
         assert_eq!(state.display_start_char_index, 2);
 
-        move_right(&mut state);
+        state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 7);
         assert_eq!(state.display_start_char_index, 4);
 
-        move_right(&mut state);
+        state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 10);
         assert_eq!(state.display_start_char_index, 7);
 
-        move_right(&mut state);
-        move_right(&mut state);
+        state.move_right();
+        state.move_right();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 12);
         assert_eq!(state.display_start_char_index, 10);
 
         // Moving left.
-        move_left(&mut state);
+        state.move_left();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 11);
         assert_eq!(state.display_start_char_index, 10);
 
-        move_left(&mut state);
-        move_left(&mut state);
+        state.move_left();
+        state.move_left();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 7);
         assert_eq!(state.display_start_char_index, 7);
 
-        move_left(&mut state);
-        move_left(&mut state);
-        move_left(&mut state);
-        move_left(&mut state);
+        state.move_left();
+        state.move_left();
+        state.move_left();
+        state.move_left();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 1);
         assert_eq!(state.display_start_char_index, 1);
 
-        move_left(&mut state);
+        state.move_left();
         state.get_start_position(4, false);
         assert_eq!(state.grapheme_cursor.cur_cursor(), 0);
         assert_eq!(state.display_start_char_index, 0);

--- a/src/utils/input.rs
+++ b/src/utils/input.rs
@@ -239,7 +239,7 @@ impl InputFieldState {
         }
     }
 
-    /// Move the cursor left.
+    /// Move the cursor left one unit if possible.
     pub fn move_left(&mut self) {
         let current_cursor = self.grapheme_cursor.cur_cursor();
         self.walk_backward();
@@ -248,13 +248,66 @@ impl InputFieldState {
         }
     }
 
-    /// Move the cursor right.
+    /// Move the cursor right one unit if possible.
     pub fn move_right(&mut self) {
         let current_cursor = self.grapheme_cursor.cur_cursor();
         self.walk_forward();
         if self.grapheme_cursor.cur_cursor() > current_cursor {
             self.cursor_direction = CursorDirection::Right;
         }
+    }
+
+    /// Move the cursor to the start.
+    pub fn skip_to_beginning(&mut self) {
+        self.grapheme_cursor = GraphemeCursor::new(0, self.current_search_query.len(), true);
+        self.cursor_direction = CursorDirection::Left;
+    }
+
+    /// Move the cursor to the end.
+    pub fn skip_to_end(&mut self) {
+        let query_len = self.current_search_query.len();
+        self.grapheme_cursor = GraphemeCursor::new(query_len, query_len, true);
+        self.cursor_direction = CursorDirection::Right;
+    }
+
+    /// Delete the previous "word".
+    pub fn delete_previous_word(&mut self) {
+        // Traverse backwards from the current cursor location until you hit
+        // non-whitespace characters, then continue to traverse (and
+        // delete) backwards until you hit a whitespace character.  Halt.
+
+        // So... first, let's get our current cursor position in terms of char
+        // indices. This is the "end" index we care about.
+        let current_cursor = self.grapheme_cursor.cur_cursor();
+
+        // Then, let's crawl backwards until we hit our location, and store the
+        // "head"...
+        let query = self.current_query();
+        let mut start_index = 0;
+        let mut saw_non_whitespace = false;
+
+        for (itx, c) in query
+            .chars()
+            .rev()
+            .enumerate()
+            .skip(query.len() - current_cursor)
+        {
+            if c.is_whitespace() {
+                if saw_non_whitespace {
+                    start_index = query.len() - itx;
+                    break;
+                }
+            } else {
+                saw_non_whitespace = true;
+            }
+        }
+
+        let _ = self.current_search_query.drain(start_index..current_cursor);
+
+        self.grapheme_cursor =
+            GraphemeCursor::new(start_index, self.current_search_query.len(), true);
+
+        self.cursor_direction = CursorDirection::Left;
     }
 }
 

--- a/src/utils/input.rs
+++ b/src/utils/input.rs
@@ -3,10 +3,10 @@
 
 use std::ops::Range;
 
-use indexmap::IndexMap;
-use unicode_segmentation::GraphemeCursor;
+use unicode_ellipsis::grapheme_width;
+use unicode_segmentation::{GraphemeCursor, GraphemeIncomplete, UnicodeSegmentation};
 
-use crate::{app::CursorDirection, utils::int_hash::IntHashMap};
+use crate::{app::CursorDirection, utils::int_hash::IntIndexMap};
 
 /// An input field's state.
 pub struct InputFieldState {
@@ -33,7 +33,19 @@ pub struct InputFieldState {
     /// be accessed.
     ///
     /// Should always be updated after the search query updates in any way.
-    size_mappings: IntHashMap<usize, Range<usize>>,
+    size_mappings: IntIndexMap<usize, Range<usize>>,
+}
+
+impl Default for InputFieldState {
+    fn default() -> Self {
+        Self {
+            current_search_query: String::default(),
+            grapheme_cursor: GraphemeCursor::new(0, 0, true),
+            cursor_direction: CursorDirection::Right,
+            display_start_char_index: 0,
+            size_mappings: IntIndexMap::default(),
+        }
+    }
 }
 
 impl InputFieldState {
@@ -41,5 +53,296 @@ impl InputFieldState {
     #[inline]
     pub fn current_query(&self) -> &str {
         &self.current_search_query
+    }
+
+    /// Get a mutable reference to the current query.
+    #[inline]
+    pub fn current_query_mut(&mut self) -> &mut String {
+        &mut self.current_search_query
+    }
+
+    /// Reset the input field state.
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Sets the starting grapheme index to draw from.
+    pub fn get_start_position(&mut self, available_width: usize, is_force_redraw: bool) {
+        // Remember - the number of columns != the number of grapheme slots/sizes, you
+        // cannot use index to determine this reliably!
+
+        let start_index = if is_force_redraw {
+            0
+        } else {
+            self.display_start_char_index
+        };
+        let cursor_index = self.grapheme_cursor.cur_cursor();
+
+        if let Some(start_range) = self.size_mappings.get(&start_index) {
+            let cursor_range = self
+                .size_mappings
+                .get(&cursor_index)
+                .cloned()
+                .unwrap_or_else(|| {
+                    self.size_mappings
+                        .last()
+                        .map(|(_, r)| r.end..(r.end + 1))
+                        .unwrap_or(start_range.end..(start_range.end + 1))
+                });
+
+            // Cases to handle in both cases:
+            // - The current start index can show the cursor's word.
+            // - The current start index cannot show the cursor's word.
+            //
+            // What differs is how we "scroll" based on the cursor movement direction.
+
+            self.display_start_char_index = match self.cursor_direction {
+                CursorDirection::Right => {
+                    if start_range.start + available_width >= cursor_range.end {
+                        // Use the current index.
+                        start_index
+                    } else if cursor_range.end >= available_width {
+                        // If the current position is past the last visible element, skip until we
+                        // see it.
+
+                        let mut index = 0;
+                        for i in 0..(cursor_index + 1) {
+                            if let Some(r) = self.size_mappings.get(&i) {
+                                if r.start + available_width >= cursor_range.end {
+                                    index = i;
+                                    break;
+                                }
+                            }
+                        }
+
+                        index
+                    } else {
+                        0
+                    }
+                }
+                CursorDirection::Left => {
+                    if cursor_range.start < start_range.end {
+                        let mut index = 0;
+                        for i in cursor_index..(self.current_search_query.len()) {
+                            if let Some(r) = self.size_mappings.get(&i) {
+                                if r.start + available_width >= cursor_range.end {
+                                    index = i;
+                                    break;
+                                }
+                            }
+                        }
+                        index
+                    } else {
+                        start_index
+                    }
+                }
+            };
+        } else {
+            // If we fail here somehow, just reset to 0 index + scroll left.
+            self.display_start_char_index = 0;
+            self.cursor_direction = CursorDirection::Left;
+        };
+    }
+
+    /// Move the cursor one _grapheme_ forward.
+    pub(crate) fn walk_forward(&mut self) {
+        let start_position = self.grapheme_cursor.cur_cursor();
+        let chunk = &self.current_search_query[start_position..];
+
+        match self.grapheme_cursor.next_boundary(chunk, start_position) {
+            Ok(_) => {}
+            Err(err) => match err {
+                GraphemeIncomplete::PreContext(ctx) => {
+                    // Provide the entire string as context. Not efficient but should resolve
+                    // failures.
+                    self.grapheme_cursor
+                        .provide_context(&self.current_search_query[0..ctx], 0);
+
+                    self.grapheme_cursor
+                        .next_boundary(chunk, start_position)
+                        .expect("another grapheme boundary should exist after the cursor with the provided context");
+                }
+                _ => panic!("{err:?}"),
+            },
+        }
+    }
+
+    /// Move the cursor one _grapheme_ backward.
+    pub(crate) fn walk_backward(&mut self) {
+        let start_position = self.grapheme_cursor.cur_cursor();
+        let chunk = &self.current_search_query[..start_position];
+
+        match self.grapheme_cursor.prev_boundary(chunk, 0) {
+            Ok(_) => {}
+            Err(err) => match err {
+                GraphemeIncomplete::PreContext(ctx) => {
+                    // Provide the entire string as context. Not efficient but should resolve
+                    // failures.
+                    self.grapheme_cursor
+                        .provide_context(&self.current_search_query[0..ctx], 0);
+
+                    self.grapheme_cursor
+                        .prev_boundary(chunk, 0)
+                        .expect("another grapheme boundary should exist before the cursor with the provided context");
+                }
+                _ => panic!("{err:?}"),
+            },
+        }
+    }
+
+    fn update_sizes(&mut self) {
+        self.size_mappings.clear();
+        let mut curr_offset = 0;
+        for (index, grapheme) in
+            UnicodeSegmentation::grapheme_indices(self.current_search_query.as_str(), true)
+        {
+            let width = grapheme_width(grapheme);
+            let end = curr_offset + width;
+
+            self.size_mappings.insert(index, curr_offset..end);
+
+            curr_offset = end;
+        }
+
+        self.size_mappings.shrink_to_fit();
+    }
+
+    /// Delete whatever the cursor is currently highlighting, if anything. This is analogous to pressing `Delete`.
+    pub fn delete_at_cursor(&mut self) {
+        let current_cursor = self.grapheme_cursor.cur_cursor();
+        if current_cursor < self.current_search_query.len() {
+            self.walk_forward();
+            let new_cursor = self.grapheme_cursor.cur_cursor();
+
+            let _ = self.current_search_query.drain(current_cursor..new_cursor);
+
+            self.grapheme_cursor =
+                GraphemeCursor::new(current_cursor, self.current_search_query.len(), true);
+        }
+    }
+
+    /// Delete what is _behind_ the cursor. This is analogous to pressing `Backspace`.
+    pub fn delete_behind_cursor(&mut self) {
+        let current_cursor = self.grapheme_cursor.cur_cursor();
+
+        if current_cursor > 0 {
+            self.walk_backward();
+            let new_cursor = self.grapheme_cursor.cur_cursor();
+
+            // Remove the indices in between.
+            let _ = self.current_search_query.drain(new_cursor..current_cursor);
+
+            self.grapheme_cursor =
+                GraphemeCursor::new(new_cursor, self.current_search_query.len(), true);
+
+            self.cursor_direction = CursorDirection::Left;
+        }
+    }
+
+    /// Move the cursor left.
+    pub fn move_left(&mut self) {
+        let current_cursor = self.grapheme_cursor.cur_cursor();
+        self.walk_backward();
+        if self.grapheme_cursor.cur_cursor() < current_cursor {
+            self.cursor_direction = CursorDirection::Left;
+        }
+    }
+
+    /// Move the cursor right.
+    pub fn move_right(&mut self) {
+        let current_cursor = self.grapheme_cursor.cur_cursor();
+        self.walk_forward();
+        if self.grapheme_cursor.cur_cursor() > current_cursor {
+            self.cursor_direction = CursorDirection::Right;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn move_right(state: &mut InputFieldState) {
+        state.walk_forward();
+        state.cursor_direction = CursorDirection::Right;
+    }
+
+    fn move_left(state: &mut InputFieldState) {
+        state.walk_backward();
+        state.cursor_direction = CursorDirection::Left;
+    }
+
+    #[test]
+    fn search_cursor_moves() {
+        let mut state = InputFieldState::default();
+        state.current_search_query = "Hi, 你好! 🇦🇶".to_string();
+        state.grapheme_cursor = GraphemeCursor::new(0, state.current_search_query.len(), true);
+        state.update_sizes();
+
+        // Moving right.
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 0);
+        assert_eq!(state.display_start_char_index, 0);
+
+        move_right(&mut state);
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 1);
+        assert_eq!(state.display_start_char_index, 0);
+
+        move_right(&mut state);
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 2);
+        assert_eq!(state.display_start_char_index, 0);
+
+        move_right(&mut state);
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 3);
+        assert_eq!(state.display_start_char_index, 0);
+
+        move_right(&mut state);
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 4);
+        assert_eq!(state.display_start_char_index, 2);
+
+        move_right(&mut state);
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 7);
+        assert_eq!(state.display_start_char_index, 4);
+
+        move_right(&mut state);
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 10);
+        assert_eq!(state.display_start_char_index, 7);
+
+        move_right(&mut state);
+        move_right(&mut state);
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 12);
+        assert_eq!(state.display_start_char_index, 10);
+
+        // Moving left.
+        move_left(&mut state);
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 11);
+        assert_eq!(state.display_start_char_index, 10);
+
+        move_left(&mut state);
+        move_left(&mut state);
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 7);
+        assert_eq!(state.display_start_char_index, 7);
+
+        move_left(&mut state);
+        move_left(&mut state);
+        move_left(&mut state);
+        move_left(&mut state);
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 1);
+        assert_eq!(state.display_start_char_index, 1);
+
+        move_left(&mut state);
+        state.get_start_position(4, false);
+        assert_eq!(state.grapheme_cursor.cur_cursor(), 0);
+        assert_eq!(state.display_start_char_index, 0);
     }
 }

--- a/src/utils/input.rs
+++ b/src/utils/input.rs
@@ -212,8 +212,6 @@ impl InputFieldState {
 
             curr_offset = end;
         }
-
-        self.size_mappings.shrink_to_fit();
     }
 
     /// Delete whatever the cursor is currently highlighting, if anything. This is analogous to pressing `Delete`.

--- a/src/utils/int_hash.rs
+++ b/src/utils/int_hash.rs
@@ -7,12 +7,19 @@ use std::{
     marker::PhantomData,
 };
 
+use indexmap::IndexMap;
+
+type IntHasherState<K> = BuildHasherDefault<IntHasher<K>>;
+
 /// A hash map that directly maps from an integer key to a value.
-pub type IntHashMap<K, V> = std::collections::HashMap<K, V, BuildHasherDefault<IntHasher<K>>>;
+pub type IntHashMap<K, V> = std::collections::HashMap<K, V, IntHasherState<K>>;
 
 /// A hash set that directly uses integer keys.
 #[allow(dead_code)]
-pub type IntHashSet<K> = std::collections::HashSet<K, BuildHasherDefault<IntHasher<K>>>;
+pub type IntHashSet<K> = std::collections::HashSet<K, IntHasherState<K>>;
+
+/// An [`IndexMap`] wrapper such that it tracks insertion order, but uses integer keys.
+pub type IntIndexMap<K, V> = IndexMap<K, V, IntHasherState<K>>;
 
 pub trait SupportedInt {}
 
@@ -175,5 +182,23 @@ mod tests {
         assert!(set.contains(&1));
         assert!(set.contains(&2));
         assert!(!set.contains(&3));
+    }
+
+    #[test]
+    fn test_int_index_map() {
+        let mut map = IntIndexMap::<u32, &str>::default();
+        map.insert(1, "one");
+        map.insert(3, "three");
+        map.insert(2, "two");
+        assert_eq!(map.get(&1), Some(&"one"));
+        assert_eq!(map.get(&2), Some(&"two"));
+        assert_eq!(map.get(&3), Some(&"three"));
+        assert_eq!(map.get(&4), None);
+
+        assert_eq!(map.keys().cloned().collect::<Vec<_>>(), vec![1, 3, 2]);
+        assert_eq!(
+            map.values().cloned().collect::<Vec<_>>(),
+            vec!["one", "three", "two"]
+        );
     }
 }

--- a/src/widgets/process_table.rs
+++ b/src/widgets/process_table.rs
@@ -32,6 +32,7 @@ use crate::{
 /// state.
 #[derive(Default)]
 pub struct ProcessSearchState {
+    // TODO: Flatten AppSearchState as it's been generalized further.
     pub search_state: AppSearchState,
     pub query_options: QueryOptions,
 }

--- a/src/widgets/process_table.rs
+++ b/src/widgets/process_table.rs
@@ -1067,16 +1067,8 @@ impl ProcWidgetState {
             .collect::<Vec<_>>()
     }
 
-    pub fn cursor_char_index(&self) -> usize {
-        self.proc_search.search_state.grapheme_cursor.cur_cursor()
-    }
-
     pub fn is_search_enabled(&self) -> bool {
         self.proc_search.search_state.is_enabled
-    }
-
-    pub fn current_search_query(&self) -> &str {
-        &self.proc_search.search_state.current_search_query
     }
 
     /// Update the current search query.

--- a/src/widgets/process_table.rs
+++ b/src/widgets/process_table.rs
@@ -1082,19 +1082,16 @@ impl ProcWidgetState {
             .current_query();
 
         if current_query.is_empty() {
-            self.proc_search.search_state.is_blank_search = true;
             self.proc_search.search_state.is_invalid_search = false;
             self.proc_search.search_state.error_message = None;
         } else {
             match parse_query(current_query, &self.proc_search.query_options) {
                 Ok(parsed_query) => {
                     self.proc_search.search_state.query = Some(parsed_query);
-                    self.proc_search.search_state.is_blank_search = false;
                     self.proc_search.search_state.is_invalid_search = false;
                     self.proc_search.search_state.error_message = None;
                 }
                 Err(err) => {
-                    self.proc_search.search_state.is_blank_search = false;
                     self.proc_search.search_state.is_invalid_search = true;
                     self.proc_search.search_state.error_message = Some(err.to_string());
                 }

--- a/src/widgets/process_table.rs
+++ b/src/widgets/process_table.rs
@@ -1075,20 +1075,18 @@ impl ProcWidgetState {
     ///
     /// TODO: Maybe debounce this.
     pub fn update_query(&mut self) {
-        if self
+        let current_query = self
             .proc_search
             .search_state
-            .current_search_query
-            .is_empty()
-        {
+            .input_field_state
+            .current_query();
+
+        if current_query.is_empty() {
             self.proc_search.search_state.is_blank_search = true;
             self.proc_search.search_state.is_invalid_search = false;
             self.proc_search.search_state.error_message = None;
         } else {
-            match parse_query(
-                &self.proc_search.search_state.current_search_query,
-                &self.proc_search.query_options,
-            ) {
+            match parse_query(current_query, &self.proc_search.query_options) {
                 Ok(parsed_query) => {
                     self.proc_search.search_state.query = Some(parsed_query);
                     self.proc_search.search_state.is_blank_search = false;
@@ -1105,23 +1103,12 @@ impl ProcWidgetState {
         self.table.state.display_start_index = 0;
         self.table.state.current_index = 0;
 
-        // Update the internal sizes too.
-        self.proc_search.search_state.update_sizes();
-
         self.force_data_update();
     }
 
     pub fn clear_search(&mut self) {
         self.proc_search.search_state.reset();
         self.force_data_update();
-    }
-
-    pub fn search_walk_forward(&mut self) {
-        self.proc_search.search_state.walk_forward();
-    }
-
-    pub fn search_walk_back(&mut self) {
-        self.proc_search.search_state.walk_backward();
     }
 
     /// Sets the [`ProcWidgetState`]'s current sort index to whatever was in the


### PR DESCRIPTION
<!-- Please use this template (unless you have a very good reason not to). PRs that do not use the template may be closed. -->

## Description

_A description of the change, what it does, and why it was made. If relevant (e.g. UI changes), **please also provide screenshots/recordings**:_

This came up while I was reviewing/updating https://github.com/ClementTsang/bottom/pull/1953 - we probably want to generalize the really hairy input field logic so it can be reused anywhere. This PR further generalizes it so it's not as tied into app state logic. It also fixes a found bug around deleting whole words if they were were more than one byte long.

## Issue

_If applicable, what issue does this address?_

Closes: #<issue-number>

## Testing

_If relevant, please state how this was tested (including steps):_

_If this change affects the program, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS (specify version below)_
- [x] _Linux (specify distro below)_
- [ ] _Other (specify below)_

## Checklist

_Ensure **all** of these are met:_

- [ ] _If this PR adds or changes a dependency, please justify this in the description_
- [x] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [x] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [x] _If this is a code change, new tests were added if relevant_
- [x] _If this is a code change, your changes pass `cargo test`_
- [x] _The change has been tested to work (see above) and doesn't appear to break other things_
- [ ] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [x] _There are no merge conflicts_
- [x] _You have reviewed your changes first_
- [x] _The pull request passes the provided CI pipeline_

## Other

_Anything else that maintainers should know about this PR:_
