### PR TITLE
bug: fix issue with parsing quoted delimiters in process search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ That said, these are more guidelines rather than hard rules, though the project 
 
 - [#2035](https://github.com/ClementTsang/bottom/pull/2035): Fix panic when deleting unicode words in search.
 - [#2042](https://github.com/ClementTsang/bottom/pull/2042): Address possible memory usage growth for AMD GPU stat gathering on Linux.
+- [#2069](https://github.com/ClementTsang/bottom/pull/2069): Fix issue in process search with parsing quoted delimiters.
 
 ### Features
 

--- a/src/widgets/process_table/query.rs
+++ b/src/widgets/process_table/query.rs
@@ -120,16 +120,30 @@ pub(crate) fn parse_query(search_query: &str, options: &QueryOptions) -> QueryRe
     }
 
     let mut split_query = VecDeque::new();
+    let mut in_quotes = false;
 
     search_query.split_whitespace().for_each(|s| {
         // From https://stackoverflow.com/a/56923739 get a split but include the parentheses
         let mut last = 0;
         for (index, matched) in s.match_indices(|x| DELIMITER_LIST.contains(&x)) {
-            if last != index {
-                split_query.push_back(s[last..index].to_owned());
+            if matched == "\"" {
+                // Always split on quote delimiters to open/close quoted sections.
+                if last != index {
+                    split_query.push_back(s[last..index].to_owned());
+                }
+                split_query.push_back(matched.to_owned());
+                last = index + matched.len();
+                in_quotes = !in_quotes;
+            } else if !in_quotes {
+                // Only split on other delimiters when outside a quoted section,
+                // so that special chars like `<` and `>` in `"Thread<15>"` are
+                // preserved as literals.
+                if last != index {
+                    split_query.push_back(s[last..index].to_owned());
+                }
+                split_query.push_back(matched.to_owned());
+                last = index + matched.len();
             }
-            split_query.push_back(matched.to_owned());
-            last = index + matched.len();
         }
         if last < s.len() {
             split_query.push_back(s[last..].to_owned());
@@ -1096,6 +1110,54 @@ mod tests {
 
         assert!(query.check(&with_bang, false));
         assert!(!query.check(&without, false));
+    }
+
+    /// Quoted angle brackets should be treated as literal characters in name matches.
+    #[test]
+    fn quoted_angle_brackets_match_literal() {
+        let query = parse_query_no_options("\"Thread<15>\"").unwrap();
+
+        let matching = simple_process("Thread<15>");
+        let non_matching = simple_process("Thread");
+
+        assert!(query.check(&matching, false));
+        assert!(!query.check(&non_matching, false));
+    }
+
+    /// A quoted `=` should be treated as a literal character in name matches.
+    #[test]
+    fn quoted_equals_matches_literal() {
+        let query = parse_query_no_options("\"a=b\"").unwrap();
+
+        let matching = simple_process("a=b");
+        let non_matching = simple_process("ab");
+
+        assert!(query.check(&matching, false));
+        assert!(!query.check(&non_matching, false));
+    }
+
+    /// A quoted `!=` should be treated as a literal character sequence in name matches.
+    #[test]
+    fn quoted_not_equals_matches_literal() {
+        let query = parse_query_no_options("\"a!=b\"").unwrap();
+
+        let matching = simple_process("a!=b");
+        let non_matching = simple_process("ab");
+
+        assert!(query.check(&matching, false));
+        assert!(!query.check(&non_matching, false));
+    }
+
+    /// Quoted parentheses should be treated as literal characters in name matches.
+    #[test]
+    fn quoted_parens_match_literal() {
+        let query = parse_query_no_options("\"a(b)\"").unwrap();
+
+        let matching = simple_process("a(b)");
+        let non_matching = simple_process("ab");
+
+        assert!(query.check(&matching, false));
+        assert!(!query.check(&non_matching, false));
     }
 
     /// Trailing operators with no RHS must error.


### PR DESCRIPTION
<!-- Please use this template (unless you have a very good reason not to). PRs that do not use the template may be closed. -->

## Description

_A description of the change, what it does, and why it was made. If relevant (e.g. UI changes), **please also provide screenshots/recordings**:_

Noticed this when trying to parse something with `<` and `>` in the name, even when quoted. The fix is to just check for quotes when delimiting. This PR adds tests as well for this case.

## Issue

_If applicable, what issue does this address?_

Closes: #<issue-number>

## Testing

_If relevant, please state how this was tested (including steps):_

_If this change affects the program, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS (specify version below)_
- [x] _Linux (specify distro below)_
- [ ] _Other (specify below)_

## Checklist

_Ensure **all** of these are met:_

- [ ] _If this PR adds or changes a dependency, please justify this in the description_
- [x] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [x] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [x] _If this is a code change, new tests were added if relevant_
- [x] _If this is a code change, your changes pass `cargo test`_
- [ ] _The change has been tested to work (see above) and doesn't appear to break other things_
- [ ] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [x] _There are no merge conflicts_
- [x] _You have reviewed your changes first_
- [x] _The pull request passes the provided CI pipeline_

## Other

_Anything else that maintainers should know about this PR:_
