### PR TITLE
bug: fix bug causing deprecated setting warnings even if commented out

### DIFF
--- a/sample_configs/default_config.toml
+++ b/sample_configs/default_config.toml
@@ -5,7 +5,7 @@
 # This group of options represents a command-line option. Flags explicitly
 # added when running (ie: btm -a) will override this config file if an option
 # is also set here.
-[flags]
+#[flags]
 # Deprecated - use cpu.hide_avg_cpu.
 # Whether to hide the average cpu entry.
 #hide_avg_cpu = false

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -254,7 +254,7 @@ pub(crate) const CONFIG_TEXT: &str = r#"# This is a default config file for bott
 # This group of options represents a command-line option. Flags explicitly
 # added when running (ie: btm -a) will override this config file if an option
 # is also set here.
-[flags]
+#[flags]
 # Deprecated - use cpu.hide_avg_cpu.
 # Whether to hide the average cpu entry.
 #hide_avg_cpu = false

--- a/src/options.rs
+++ b/src/options.rs
@@ -85,9 +85,12 @@ macro_rules! enabled_option_with_deprecated {
         } else if let Some(section) = &$config.$section {
             section.$field.unwrap_or(false)
         } else if let Some(flags) = &$config.flags {
-            deprecated_warning(stringify!($deprecated_flag), stringify!($section.$field));
-
-            flags.$deprecated_flag.unwrap_or(false)
+            flags
+                .$deprecated_flag
+                .inspect(|_| {
+                    deprecated_warning(stringify!($deprecated_flag), stringify!($section.$field))
+                })
+                .unwrap_or(false)
         } else {
             false
         }

--- a/tests/integration/valid_config_tests.rs
+++ b/tests/integration/valid_config_tests.rs
@@ -4,7 +4,10 @@ use std::{io::Read, thread, time::Duration};
 #[cfg(feature = "default")]
 use std::{io::Write, path::Path};
 
-use crate::util::spawn_btm_in_pty;
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+
+use crate::util::{btm_command, spawn_btm_in_pty};
 
 fn reader_to_string(mut reader: Box<dyn Read>) -> String {
     let mut buf = String::default();
@@ -273,4 +276,13 @@ fn test_newer_temperature() {
 #[test]
 fn test_deprecated_temperature() {
     run_and_kill_cfg("./tests/valid_configs/deprecated/temperature.toml");
+}
+
+/// Test that deprecated warnings are not shown for config options that are not actually set,
+/// even when a [flags] section is present.
+#[test]
+fn test_no_spurious_deprecated_warnings() {
+    btm_command(&["-C", "./tests/valid_configs/empty_flags.toml"])
+        .assert()
+        .stderr(predicate::str::contains("deprecated").not());
 }

--- a/tests/valid_configs/empty_flags.toml
+++ b/tests/valid_configs/empty_flags.toml
@@ -1,0 +1,4 @@
+# Config with a [flags] section but no deprecated options set.
+# This should not trigger any deprecated warnings.
+
+[flags]


### PR DESCRIPTION
<!-- Please use this template (unless you have a very good reason not to). PRs that do not use the template may be closed. -->

## Description

_A description of the change, what it does, and why it was made. If relevant (e.g. UI changes), **please also provide screenshots/recordings**:_

Comment out flags header in default config file + fix bug causing deprecated warnings if `[flags]` was uncommented even when the fields themselves were commented out.

## Issue

_If applicable, what issue does this address?_

Closes: #<issue-number>

## Testing

_If relevant, please state how this was tested (including steps):_

_If this change affects the program, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS (specify version below)_
- [ ] _Linux (specify distro below)_
- [ ] _Other (specify below)_

## Checklist

_Ensure **all** of these are met:_

- [ ] _If this PR adds or changes a dependency, please justify this in the description_
- [x] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [x] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [x] _If this is a code change, new tests were added if relevant_
- [x] _If this is a code change, your changes pass `cargo test`_
- [x] _The change has been tested to work (see above) and doesn't appear to break other things_
- [ ] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [x] _There are no merge conflicts_
- [x] _You have reviewed your changes first_
- [ ] _The pull request passes the provided CI pipeline_

## Other

_Anything else that maintainers should know about this PR:_
