### PR TITLE
Treat uppercase Q as quit shortcut

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -57,7 +57,7 @@ pub fn handle_key_event_or_break(
 
     if event.modifiers.is_empty() {
         match event.code {
-            KeyCode::Char('q') if !app.is_in_any_search() => return true,
+            KeyCode::Char('q' | 'Q') if !app.is_in_any_search() => return true,
             KeyCode::End => app.skip_to_last(),
             KeyCode::Home => app.skip_to_first(),
             KeyCode::Up => app.on_up_key(),


### PR DESCRIPTION
## Description

Makes the quit shortcut accept uppercase `Q` as well as lowercase `q` when no modifiers are present and the user is not in a search field. This helps terminals that report Caps Lock as an uppercase character while leaving the existing uppercase-only shortcuts unchanged.

## Issue

Related: #572

## Testing

Not rerun for this description-only cleanup. The code diff remains the same one-line shortcut match change.

Platforms tested:

- [ ] _Windows_
- [x] _macOS (15.7.5)_
- [ ] _Linux_
- [ ] _Other_

## Checklist

- [x] _If this PR adds or changes a dependency, please justify this in the description_
- [x] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [x] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [ ] _If this is a code change, new tests were added if relevant_
- [x] _If this is a code change, your changes pass `cargo test`_
- [x] _The change has been tested to work (see above) and doesn't appear to break other things_
- [x] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [x] _There are no merge conflicts_
- [x] _You have reviewed your changes first_
- [ ] _The pull request passes the provided CI pipeline_

## Other

AI assistance was used for this small change, and the final code was reviewed before submission.
