### PR TITLE
bug: fix parsing issue certain comm entries to be missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ That said, these are more guidelines rather than hard rules, though the project 
 ### Bug Fixes
 
 - [#2144](https://github.com/ClementTsang/bottom/pull/2144): Fix bug with Linux signals 34 or higher being off by 2.
+- [#2145](https://github.com/ClementTsang/bottom/pull/2145): Fix parsing issue certain comm entries to be missing.
 
 ## 0.14.4 - 2026-07-09
 

--- a/src/canvas/widgets/mem_basic.rs
+++ b/src/canvas/widgets/mem_basic.rs
@@ -68,9 +68,9 @@ impl Painter {
             (
                 0.0,
                 if app_state.basic_mode_use_percent {
-                    "0.0B/0.0B".into()
-                } else {
                     "  0%".into()
+                } else {
+                    "0.0B/0.0B".into()
                 },
             )
         };

--- a/src/collection/processes/linux/mod.rs
+++ b/src/collection/processes/linux/mod.rs
@@ -119,7 +119,7 @@ fn get_linux_cpu_usage(
 ) -> (f32, u64) {
     // Based heavily on https://stackoverflow.com/a/23376195 and https://stackoverflow.com/a/1424556
     let new_proc_times = stat.utime + stat.stime;
-    let diff = (new_proc_times - prev_proc_times) as f64; // No try_from for u64 -> f64... oh well.
+    let diff = new_proc_times.saturating_sub(prev_proc_times) as f64; // No try_from for u64 -> f64... oh well.
 
     if cpu_usage == 0.0 {
         (0.0, new_proc_times)

--- a/src/collection/processes/linux/process.rs
+++ b/src/collection/processes/linux/process.rs
@@ -84,11 +84,23 @@ impl Stat {
         // TODO: Is this needed?
         let line = buffer.trim();
 
+        // Comm is represented by a string in parentheses (e.g. `(foo)`, `((bar))`).
+        // To handle that second case, we need to find the "last" closing parentheses.
         let (comm, rest) = {
             let start_paren = line
                 .find('(')
                 .ok_or_else(|| anyhow!("start paren missing"))?;
-            let end_paren = line.find(')').ok_or_else(|| anyhow!("end paren missing"))?;
+            // So, we _could_ parse the entire line from the end with rfind, but this is kinda inefficient, since we
+            // know the comm field is in the start. But, we know that he comm field is never more than 16 bytes +
+            // the start/end bracket characters, for a total of 18 bytes max. So we can bound our search! So starting
+            // from start_paren, just add 18 and rfind!
+            //
+            // Source: https://man.archlinux.org/man/proc_pid_stat.5.en
+            const TASK_COMM_LEN: usize = 16;
+            let end_paren = line[start_paren..start_paren + TASK_COMM_LEN + 2]
+                .rfind(')')
+                .ok_or_else(|| anyhow!("end paren missing"))?
+                + start_paren;
 
             (
                 line[start_paren + 1..end_paren].to_string(),

--- a/src/collection/temperature/linux.rs
+++ b/src/collection/temperature/linux.rs
@@ -99,10 +99,10 @@ fn read_to_string_lossy<P: AsRef<Path>>(path: P) -> Option<String> {
 }
 
 #[inline]
-fn humanize_name(name: String, sensor_name: Option<&String>) -> String {
+fn humanize_name(name: &str, sensor_name: Option<&String>) -> String {
     match sensor_name {
         Some(ty) => format!("{name} ({ty})"),
-        None => name,
+        None => name.to_string(),
     }
 }
 
@@ -271,10 +271,7 @@ fn hwmon_temperatures(filter: &Option<Filter>, graph_filter: &Option<Filter>) ->
                                 cards.flatten().find_map(|card| {
                                     card.file_name().to_str().and_then(|name| {
                                         name.starts_with("card").then(|| {
-                                            humanize_name(
-                                                name.trim().to_string(),
-                                                sensor_name.as_ref(),
-                                            )
+                                            humanize_name(name.trim(), sensor_name.as_ref())
                                         })
                                     })
                                 })
@@ -289,10 +286,7 @@ fn hwmon_temperatures(filter: &Option<Filter>, graph_filter: &Option<Filter>) ->
                                 cards.flatten().find_map(|card| {
                                     card.file_name().to_str().and_then(|name| {
                                         name.starts_with("card").then(|| {
-                                            humanize_name(
-                                                name.trim().to_string(),
-                                                sensor_name.as_ref(),
-                                            )
+                                            humanize_name(name.trim(), sensor_name.as_ref())
                                         })
                                     })
                                 })
@@ -307,16 +301,15 @@ fn hwmon_temperatures(filter: &Option<Filter>, graph_filter: &Option<Filter>) ->
                         // else. If the first character is alphabetic, it's an actual name like
                         // k10temp or nvme0, not a PCI bus.
                         fs::read_link(device).ok().and_then(|link| {
-                            let link = link
-                                .file_name()
-                                .and_then(|f| f.to_str())
-                                .map(|s| s.trim().to_owned());
+                            let link = link.file_name().and_then(|f| f.to_str()).map(|s| s.trim());
 
-                            match link {
-                                Some(link) if link.as_bytes()[0].is_ascii_alphabetic() => {
-                                    Some(humanize_name(link, sensor_name.as_ref()))
-                                }
-                                _ => None,
+                            if let Some(link) = &link
+                                && let Some(first_char) = link.as_bytes().first()
+                                && first_char.is_ascii_alphabetic()
+                            {
+                                Some(humanize_name(link, sensor_name.as_ref()))
+                            } else {
+                                None
                             }
                         })
                     }


### PR DESCRIPTION
<!-- Please use this template (unless you have a very good reason not to). PRs that do not use the template may be closed. -->

## Description

_A description of the change, what it does, and why it was made. If relevant (e.g. UI changes), **please also provide screenshots/recordings**:_

The bug would cause something like `(sd-pam)` to be missing, because what would happen is this:

1. We have something like `"123 ((sd-pam)) blah blah blah"`
2. We parse `start_paren` to be index 5.
3. We parse `end_paren` to be index 13.
4. Our `comm` is `"(sd-pam"`, and the rest of our string is `") blah blah blah"`... which is problematic, as then the rest of the parsing will be incorrect, and the entry gets rejected!

## Issue

_If applicable, what issue does this address?_

Closes: #<issue-number>

## Testing

_If relevant, please state how this was tested (including steps):_

_If this change affects the program, please also indicate which platforms were tested:_

- [ ] _Windows_
- [ ] _macOS (specify version below)_
- [ ] _Linux (specify distro below)_
- [ ] _Other (specify below)_

## Checklist

_Ensure **all** of these are met:_

- [ ] _If this PR adds or changes a dependency, please justify this in the description_
- [ ] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [ ] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [ ] _If this is a code change, new tests were added if relevant_
- [ ] _If this is a code change, your changes pass `cargo test`_
- [ ] _The change has been verified to work (see the Testing section) and doesn't unexpectedly break anything else_
- [ ] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [ ] _There are no merge conflicts_
- [ ] _You have personally reviewed your changes already before creating the PR_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _If this PR was generated with AI, please specify how in the "Other" section, and that you as a human have personally reviewed it_

## Other

_Anything else that maintainers should know about this PR:_
