### PR TITLE
fix: widen PID column so multi-digit PIDs aren't truncated

### DIFF
--- a/src/canvas/components/data_table/column.rs
+++ b/src/canvas/components/data_table/column.rs
@@ -259,3 +259,63 @@ where
         calculated_widths
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    struct TestHeader(&'static str);
+
+    impl ColumnHeader for TestHeader {
+        fn text(&self) -> Cow<'static, str> {
+            Cow::Borrowed(self.0)
+        }
+    }
+
+    /// A [`ColumnWidthBounds::FollowHeader`] column always resolves to the
+    /// header's length, and has no way to grow to fit wider content. This is
+    /// what caused the process widget's PID column to truncate multi-digit
+    /// PIDs (see <https://github.com/ClementTsang/bottom/issues/2159>) - the
+    /// column was frozen at `"PID".len() == 3` no matter how wide the actual
+    /// PID values were.
+    #[test]
+    fn test_follow_header_width_ignores_content() {
+        let columns = [
+            Column::new(TestHeader("PID")),
+            Column::hard(TestHeader("OTHER"), 20),
+        ];
+
+        let widths = columns.calculate_column_widths(24, true);
+        assert_eq!(
+            widths[0].get(),
+            3,
+            "PID column should just be the header width"
+        );
+        assert_eq!(widths[1].get(), 20);
+    }
+
+    /// A [`ColumnWidthBounds::Soft`] column's desired width is recalculated
+    /// from the actual data before each draw (see `column_widths` in
+    /// `process_data.rs`), so it can grow past the header length to fit
+    /// wider content, like multi-digit PIDs.
+    #[test]
+    fn test_soft_width_grows_for_wide_content() {
+        let mut pid_column = Column::soft(TestHeader("PID"), None);
+        if let ColumnWidthBounds::Soft { desired, .. } = pid_column.bounds_mut() {
+            // Simulate a 7-digit PID (e.g. "1234567") being the widest value
+            // in the current data.
+            *desired = 7;
+        }
+
+        let columns = [pid_column, Column::hard(TestHeader("OTHER"), 20)];
+
+        let widths = columns.calculate_column_widths(28, true);
+        assert_eq!(
+            widths[0].get(),
+            7,
+            "PID column should widen to fit the widest PID in the data"
+        );
+        assert_eq!(widths[1].get(), 20);
+    }
+}

--- a/src/widgets/process_table.rs
+++ b/src/widgets/process_table.rs
@@ -144,7 +144,7 @@ fn make_column(column: ProcColumn) -> SortColumn<ProcColumn> {
         MemValue => SortColumn::new(MemValue).default_descending(),
         MemPercent => SortColumn::new(MemPercent).default_descending(),
         VirtualMem => SortColumn::new(VirtualMem).default_descending(),
-        Pid => SortColumn::new(Pid),
+        Pid => SortColumn::soft(Pid, None),
         Count => SortColumn::new(Count),
         Name => SortColumn::soft(Name, Some(0.3)),
         Command => SortColumn::soft(Command, Some(0.3)),


### PR DESCRIPTION
## Description

The PID column in the process widget was pinned to `ColumnWidthBounds::FollowHeader`, which always sizes the column to the header text ("PID" = 3 chars) no matter what's actually in the data. Once PIDs go past 3 digits (pretty normal on any system that's been up a while), the column truncates values like `27201` down to something like `272...`, which is what's reported in the issue.

The fix is small: switch the PID column to `SortColumn::soft(Pid, None)`, the same approach already used for the `User` column. Soft columns get their desired width recalculated from the actual data on every draw (see `ProcWidgetData::column_widths`), so the PID column now grows to fit the widest PID currently displayed instead of being frozen at the header width. I left `max_percentage` as `None` since PIDs are numeric and bounded in length, so there's no real risk of the column eating the whole screen the way an unbounded text column could.

## Issue

Fixes #2159
https://github.com/ClementTsang/bottom/issues/2159

## Testing

I added two unit tests in `src/canvas/components/data_table/column.rs` that exercise `calculate_column_widths` directly: one showing that a `FollowHeader` column stays stuck at the header length regardless of content (documenting the root cause), and one showing that a `Soft` column widens when given a larger desired width, the way it now will for multi-digit PIDs.

Ran locally on macOS:
- `cargo test --lib` (full suite, including the new tests and the existing `widgets::process_table` and `canvas::components::data_table` modules) — all passing
- `cargo fmt --check` — clean
- `cargo clippy --lib --all-features -- -D warnings` — clean

I didn't test on Windows/Linux, just macOS, but the change is a one-line switch to an existing, already-used column width mode (`soft`), so I don't expect platform-specific behavior.

- [ ] Windows
- [x] macOS (26 Tahoe)
- [ ] Linux
- [ ] Other

## Checklist

- [x] If this pull request adds or changes a dependency, please justify this in the description (n/a, no dependency changes)
- [x] If this is a code change, areas your change affects have been linted using (`cargo fmt`)
- [x] If this is a code change, your changes pass `cargo clippy --all -- -D warnings`
- [x] If this is a code change, new tests were added if relevant
- [x] If this is a code change, your changes pass `cargo test`
- [x] The change has been verified to work (see the Testing section) and doesn't unexpectedly break anything else
- [x] Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.) (n/a, no user-facing docs to update for this)
- [x] There are no merge conflicts
- [x] You have personally reviewed your changes already before creating the PR
- [x] The pull request passes the provided CI pipeline
- [x] If the changes were generated with AI tools, ensure it follows the AI policy. Specify how it was used in the "Other" section, and that you as a human have personally reviewed the change

## Other

I used an AI coding assistant to help locate the root cause and draft the patch/tests, and I reviewed the diff and test output myself before opening this PR, per the AI policy.
