### PR TITLE
docs: fix typo in the '--help' flag

### DIFF
--- a/src/options/args.rs
+++ b/src/options/args.rs
@@ -685,7 +685,7 @@ pub struct StyleArgs {
 #[derive(Args, Clone, Debug)]
 #[command(next_help_heading = "Other Options", rename_all = "snake_case")]
 pub struct OtherArgs {
-    #[arg(short = 'h', long, action = ArgAction::Help, help = "Prints help info (for more details use '--help'.")]
+    #[arg(short = 'h', long, action = ArgAction::Help, help = "Prints help info (for more details use '--help').")]
     help: (),
 
     #[arg(short = 'V', long, action = ArgAction::Version, help = "Prints version information.")]


### PR DESCRIPTION
## Description

It's a simple typo fix in the `--help` flag, a closing parenthesis `)` was missing at the end only.

## Issue

None

## Testing

Although I don't think testing is necessary here, I still ran it and they all pass.
Platform: Linux

## Checklist

_Ensure **all** of these are met:_

- [ ] _If this pull request adds or changes a dependency, please justify this in the description_
- [ ] _If this is a code change, areas your change affects have been linted using (`cargo fmt`)_
- [ ] _If this is a code change, your changes pass `cargo clippy --all -- -D warnings`_
- [ ] _If this is a code change, new tests were added if relevant_
- [ ] _If this is a code change, your changes pass `cargo test`_
- [ ] _The change has been verified to work (see the Testing section) and doesn't unexpectedly break anything else_
- [x] _Documentation has been updated if needed (`README.md`, help menu, docs, configs, etc.)_
- [x] _There are no merge conflicts_
- [x] _You have personally reviewed your changes already before creating the PR_
- [ ] _The pull request passes the provided CI pipeline_
- [ ] _If the changes were generated with AI tools, ensure it follows the [AI policy](https://github.com/ClementTsang/bottom/blob/main/AI_POLICY.md). Specify how it was used in the "Other" section, and that you as a human have personally reviewed the change_

## Other

_Anything else that maintainers should know about this PR:_
