### PR TITLE
feat: add configurable binary disk capacity units for usage

### DIFF
--- a/docs/content/configuration/command-line-options.md
+++ b/docs/content/configuration/command-line-options.md
@@ -27,8 +27,8 @@ see information on these options by running `btm -h`, or run `btm --help` to dis
 
 ## Disk Options
 
-| Option                     | Behaviour                                                |
-| -------------------------- | -------------------------------------------------------- |
+| Option                     | Behaviour                                                       |
+| -------------------------- | --------------------------------------------------------------- |
 | `--disk_use_binary_prefix` | Displays used, free, and total disk space with binary prefixes. |
 
 ## Process Options

--- a/docs/content/configuration/command-line-options.md
+++ b/docs/content/configuration/command-line-options.md
@@ -25,6 +25,12 @@ see information on these options by running `btm -h`, or run `btm --help` to dis
 |                                     | for table widgets.                                         |
 | `-d`, `--time_delta <TIME>`         | The amount of time changed upon zooming.                   |
 
+## Disk Options
+
+| Option                     | Behaviour                                                |
+| -------------------------- | -------------------------------------------------------- |
+| `--disk_use_binary_prefix` | Displays used, free, and total disk space with binary prefixes. |
+
 ## Process Options
 
 | Option                      | Behaviour                                                                              |

--- a/docs/content/configuration/config-file/disk-table.md
+++ b/docs/content/configuration/config-file/disk-table.md
@@ -1,5 +1,15 @@
 # Disk Table Configuration
 
+## Disk Space Units
+
+Disk space uses decimal prefixes (KB, MB, GB, TB) by default. To display the Used, Free, and Total columns
+with binary prefixes (KiB, MiB, GiB, TiB), enable `use_binary_prefix`:
+
+```toml
+[disk]
+use_binary_prefix = true
+```
+
 ## Columns
 
 You can configure which columns are shown by the disk table widget by setting the `columns` setting:

--- a/docs/content/configuration/config-file/disk-table.md
+++ b/docs/content/configuration/config-file/disk-table.md
@@ -1,15 +1,5 @@
 # Disk Table Configuration
 
-## Disk Space Units
-
-Disk space uses decimal prefixes (KB, MB, GB, TB) by default. To display the Used, Free, and Total columns
-with binary prefixes (KiB, MiB, GiB, TiB), enable `use_binary_prefix`:
-
-```toml
-[disk]
-use_binary_prefix = true
-```
-
 ## Columns
 
 You can configure which columns are shown by the disk table widget by setting the `columns` setting:
@@ -38,6 +28,16 @@ You can also set the sort order by changing `disk.sort_order` with `"Ascending"`
 ```toml
 [disk]
 sort_order = "Ascending"
+```
+
+## Disk Space Units
+
+Disk space uses decimal prefixes (KB, MB, GB, TB) by default. To display the Used, Free, and Total columns
+with binary prefixes (KiB, MiB, GiB, TiB), enable `use_binary_prefix`:
+
+```toml
+[disk]
+use_binary_prefix = true
 ```
 
 ## Show Unmounted Devices (Linux only)

--- a/sample_configs/default_config.toml
+++ b/sample_configs/default_config.toml
@@ -222,6 +222,9 @@
 # Disk widget configuration
 #[disk]
 
+# Whether to display used, free, and total disk space with binary prefixes (e.g. GiB instead of GB).
+#use_binary_prefix = false
+
 # The columns shown by the process widget. The following columns are supported:
 # Disk, Mount, Used, Free, Total, Used%, Free%, R/s, W/s
 #columns = ["Disk", "Mount", "Used", "Free", "Total", "Used%", "R/s", "W/s"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -87,6 +87,7 @@ pub struct AppConfigFields {
     pub temperature_legend_position: Option<LegendPosition>,
     pub disk_io_legend_position: Option<LegendPosition>,
     pub disk_show_unmounted: bool,
+    pub disk_use_binary_prefix: bool,
     pub disk_io_graph_show_unmounted: bool,
 }
 

--- a/src/app/data/store.rs
+++ b/src/app/data/store.rs
@@ -441,3 +441,36 @@ impl DataStore {
         self.inner = InnerData::default();
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::collection::disks::DiskHarvest;
+
+    #[test]
+    fn disk_binary_prefix_setting_reaches_harvested_data() {
+        let mut data_store = DataStore::new(UsedWidgets {
+            use_disk: true,
+            ..Default::default()
+        });
+        let settings = AppConfigFields {
+            disk_use_binary_prefix: true,
+            ..Default::default()
+        };
+        data_store.eat_data(
+            Box::new(Data {
+                disks: Some(vec![DiskHarvest {
+                    name: "disk".into(),
+                    mount_point: "/".into(),
+                    ..Default::default()
+                }]),
+                io: Some(Default::default()),
+                ..Default::default()
+            }),
+            &settings,
+        );
+
+        assert_eq!(data_store.get_data().disk_harvest.len(), 1);
+        assert!(data_store.get_data().disk_harvest[0].use_binary_prefix);
+    }
+}

--- a/src/app/data/store.rs
+++ b/src/app/data/store.rs
@@ -214,7 +214,7 @@ impl InnerData {
         if let Some(disks) = data.disks
             && let Some(io) = data.io
         {
-            self.eat_disks(disks, io, harvested_time);
+            self.eat_disks(disks, io, harvested_time, settings.disk_use_binary_prefix);
 
             if used_widgets.use_disk_io_graph {
                 self.time_series_data.update_disk_io(
@@ -240,7 +240,10 @@ impl InnerData {
         self.last_update_time = harvested_time;
     }
 
-    fn eat_disks(&mut self, disks: Vec<DiskHarvest>, io: IoHarvest, harvested_time: Instant) {
+    fn eat_disks(
+        &mut self, disks: Vec<DiskHarvest>, io: IoHarvest, harvested_time: Instant,
+        use_binary_prefix: bool,
+    ) {
         let time_since_last_harvest = harvested_time
             .duration_since(self.last_update_time)
             .as_secs_f64();
@@ -350,6 +353,7 @@ impl InnerData {
             };
 
             self.disk_harvest.push(DiskWidgetData {
+                use_binary_prefix,
                 name: disk.name,
                 mount_point: disk.mount_point,
                 free_bytes: disk.free_space,

--- a/src/app/data/store.rs
+++ b/src/app/data/store.rs
@@ -441,36 +441,3 @@ impl DataStore {
         self.inner = InnerData::default();
     }
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::collection::disks::DiskHarvest;
-
-    #[test]
-    fn disk_binary_prefix_setting_reaches_harvested_data() {
-        let mut data_store = DataStore::new(UsedWidgets {
-            use_disk: true,
-            ..Default::default()
-        });
-        let settings = AppConfigFields {
-            disk_use_binary_prefix: true,
-            ..Default::default()
-        };
-        data_store.eat_data(
-            Box::new(Data {
-                disks: Some(vec![DiskHarvest {
-                    name: "disk".into(),
-                    mount_point: "/".into(),
-                    ..Default::default()
-                }]),
-                io: Some(Default::default()),
-                ..Default::default()
-            }),
-            &settings,
-        );
-
-        assert_eq!(data_store.get_data().disk_harvest.len(), 1);
-        assert!(data_store.get_data().disk_harvest[0].use_binary_prefix);
-    }
-}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -471,6 +471,9 @@ pub(crate) const CONFIG_TEXT: &str = r#"# This is a default config file for bott
 # Disk widget configuration
 #[disk]
 
+# Whether to display used, free, and total disk space with binary prefixes (e.g. GiB instead of GB).
+#use_binary_prefix = false
+
 # The columns shown by the process widget. The following columns are supported:
 # Disk, Mount, Used, Free, Total, Used%, Free%, R/s, W/s
 #columns = ["Disk", "Mount", "Used", "Free", "Total", "Used%", "R/s", "W/s"]

--- a/src/options.rs
+++ b/src/options.rs
@@ -542,6 +542,12 @@ pub(crate) fn init_app(args: BottomArgs, config: Config) -> Result<(App, BottomL
         temperature_legend_position,
         disk_io_legend_position,
         disk_show_unmounted,
+        disk_use_binary_prefix: args.disk.disk_use_binary_prefix
+            || config
+                .disk
+                .as_ref()
+                .and_then(|cfg| cfg.use_binary_prefix)
+                .unwrap_or(false),
         disk_io_graph_show_unmounted,
     };
 
@@ -1660,6 +1666,61 @@ mod test {
     fn create_app(args: BottomArgs) -> App {
         let config = Config::default();
         super::init_app(args, config).unwrap().0
+    }
+
+    #[test]
+    fn disk_binary_prefix_options() {
+        use std::num::NonZeroU16;
+
+        use crate::{
+            canvas::components::data_table::DataToCell,
+            collection::{Data, disks::DiskHarvest},
+            utils::data_units::GIBI_LIMIT,
+        };
+
+        for (config_text, flag, expected) in [
+            ("", None, false),
+            ("[disk]", None, false),
+            ("[disk]\nuse_binary_prefix = false", None, false),
+            ("[disk]\nuse_binary_prefix = true", None, true),
+            ("", Some("--disk_use_binary_prefix"), true),
+            ("", Some("--disk-use-binary-prefix"), true),
+            (
+                "[disk]\nuse_binary_prefix = false",
+                Some("--disk_use_binary_prefix"),
+                true,
+            ),
+        ] {
+            let mut arguments = vec!["btm"];
+            arguments.extend(flag);
+            let args = BottomArgs::parse_from(arguments);
+            let config = toml_edit::de::from_str(config_text).unwrap();
+            let mut app = super::init_app(args, config).unwrap().0;
+            assert_eq!(app.app_config_fields.disk_use_binary_prefix, expected);
+            assert!(!app.app_config_fields.network_use_binary_prefix);
+
+            app.data_store.eat_data(
+                Box::new(Data {
+                    disks: Some(vec![DiskHarvest {
+                        name: "disk".into(),
+                        mount_point: "/".into(),
+                        used_space: Some(500 * GIBI_LIMIT),
+                        free_space: Some(500 * GIBI_LIMIT),
+                        total_space: Some(1000 * GIBI_LIMIT),
+                        ..Default::default()
+                    }]),
+                    io: Some(Default::default()),
+                    ..Default::default()
+                }),
+                &app.app_config_fields,
+            );
+            let rows = &app.data_store.get_data().disk_harvest;
+            assert_eq!(rows.len(), 1);
+            assert_eq!(
+                rows[0].to_cell_text(&DiskWidgetColumn::Used, NonZeroU16::new(8).unwrap()),
+                Some(if expected { "500GiB" } else { "537GB" }.into())
+            );
+        }
     }
 
     // TODO: There's probably a better way to create clap options AND unify

--- a/src/options.rs
+++ b/src/options.rs
@@ -1670,14 +1670,6 @@ mod test {
 
     #[test]
     fn disk_binary_prefix_options() {
-        use std::num::NonZeroU16;
-
-        use crate::{
-            canvas::components::data_table::DataToCell,
-            collection::{Data, disks::DiskHarvest},
-            utils::data_units::GIBI_LIMIT,
-        };
-
         for (config_text, flag, expected) in [
             ("", None, false),
             ("[disk]", None, false),
@@ -1695,31 +1687,9 @@ mod test {
             arguments.extend(flag);
             let args = BottomArgs::parse_from(arguments);
             let config = toml_edit::de::from_str(config_text).unwrap();
-            let mut app = super::init_app(args, config).unwrap().0;
+            let app = super::init_app(args, config).unwrap().0;
             assert_eq!(app.app_config_fields.disk_use_binary_prefix, expected);
             assert!(!app.app_config_fields.network_use_binary_prefix);
-
-            app.data_store.eat_data(
-                Box::new(Data {
-                    disks: Some(vec![DiskHarvest {
-                        name: "disk".into(),
-                        mount_point: "/".into(),
-                        used_space: Some(500 * GIBI_LIMIT),
-                        free_space: Some(500 * GIBI_LIMIT),
-                        total_space: Some(1000 * GIBI_LIMIT),
-                        ..Default::default()
-                    }]),
-                    io: Some(Default::default()),
-                    ..Default::default()
-                }),
-                &app.app_config_fields,
-            );
-            let rows = &app.data_store.get_data().disk_harvest;
-            assert_eq!(rows.len(), 1);
-            assert_eq!(
-                rows[0].to_cell_text(&DiskWidgetColumn::Used, NonZeroU16::new(8).unwrap()),
-                Some(if expected { "500GiB" } else { "537GB" }.into())
-            );
         }
     }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -1668,31 +1668,6 @@ mod test {
         super::init_app(args, config).unwrap().0
     }
 
-    #[test]
-    fn disk_binary_prefix_options() {
-        for (config_text, flag, expected) in [
-            ("", None, false),
-            ("[disk]", None, false),
-            ("[disk]\nuse_binary_prefix = false", None, false),
-            ("[disk]\nuse_binary_prefix = true", None, true),
-            ("", Some("--disk_use_binary_prefix"), true),
-            ("", Some("--disk-use-binary-prefix"), true),
-            (
-                "[disk]\nuse_binary_prefix = false",
-                Some("--disk_use_binary_prefix"),
-                true,
-            ),
-        ] {
-            let mut arguments = vec!["btm"];
-            arguments.extend(flag);
-            let args = BottomArgs::parse_from(arguments);
-            let config = toml_edit::de::from_str(config_text).unwrap();
-            let app = super::init_app(args, config).unwrap().0;
-            assert_eq!(app.app_config_fields.disk_use_binary_prefix, expected);
-            assert!(!app.app_config_fields.network_use_binary_prefix);
-        }
-    }
-
     // TODO: There's probably a better way to create clap options AND unify
     // together to avoid the possibility of typos/mixing up. Use proc macros
     // to unify on one struct?

--- a/src/options/args.rs
+++ b/src/options/args.rs
@@ -73,6 +73,9 @@ pub struct BottomArgs {
     #[command(flatten)]
     pub network: NetworkArgs,
 
+    #[command(flatten)]
+    pub disk: DiskArgs,
+
     #[cfg(feature = "battery")]
     #[command(flatten)]
     pub battery: BatteryArgs,
@@ -550,6 +553,21 @@ pub struct MemoryArgs {
         alias = "short-gpu-names"
     )]
     pub short_gpu_names: bool,
+}
+
+/// Disk arguments/config options.
+#[derive(Args, Clone, Debug, Default)]
+#[command(next_help_heading = "Disk Options", rename_all = "snake_case")]
+pub struct DiskArgs {
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        help = "Displays disk space with binary prefixes.",
+        long_help = "Displays used, free, and total disk space with binary prefixes (e.g. KiB, MiB, GiB) \
+                    rather than decimal prefixes (e.g. KB, MB, GB). Defaults to decimal prefixes.",
+        alias = "disk-use-binary-prefix"
+    )]
+    pub disk_use_binary_prefix: bool,
 }
 
 /// Network arguments/config options.

--- a/src/options/config/disk.rs
+++ b/src/options/config/disk.rs
@@ -8,6 +8,10 @@ use crate::{canvas::components::data_table::SortOrder, options::DiskWidgetColumn
 #[cfg_attr(feature = "generate_schema", derive(schemars::JsonSchema))]
 #[cfg_attr(test, serde(deny_unknown_fields), derive(PartialEq, Eq))]
 pub(crate) struct DiskConfig {
+    /// Displays used, free, and total disk space with binary prefixes (e.g. GiB).
+    /// Defaults to decimal prefixes (e.g. GB).
+    pub(crate) use_binary_prefix: Option<bool>,
+
     /// A filter over the disk names.
     pub(crate) name_filter: Option<IgnoreList>,
 

--- a/src/widgets/disk_table.rs
+++ b/src/widgets/disk_table.rs
@@ -10,13 +10,14 @@ use crate::{
     },
     options::config::style::Styles,
     utils::{
-        conversion::dec_bytes_per_second_string, data_units::get_decimal_bytes,
+        conversion::dec_bytes_per_second_string, data_units::convert_bytes,
         general::sort_partial_fn,
     },
 };
 
 #[derive(Clone, Debug)]
 pub struct DiskWidgetData {
+    pub use_binary_prefix: bool,
     pub name: String,
     pub mount_point: String,
     pub free_bytes: Option<u64>,
@@ -30,7 +31,7 @@ pub struct DiskWidgetData {
 impl DiskWidgetData {
     fn total_space(&self) -> Cow<'static, str> {
         if let Some(total_bytes) = self.total_bytes {
-            let converted_total_space = get_decimal_bytes(total_bytes);
+            let converted_total_space = convert_bytes(total_bytes, self.use_binary_prefix);
             format!("{:.0}{}", converted_total_space.0, converted_total_space.1).into()
         } else {
             "N/A".into()
@@ -39,7 +40,7 @@ impl DiskWidgetData {
 
     fn free_space(&self) -> Cow<'static, str> {
         if let Some(free_bytes) = self.free_bytes {
-            let converted_free_space = get_decimal_bytes(free_bytes);
+            let converted_free_space = convert_bytes(free_bytes, self.use_binary_prefix);
             format!("{:.0}{}", converted_free_space.0, converted_free_space.1).into()
         } else {
             "N/A".into()
@@ -48,7 +49,7 @@ impl DiskWidgetData {
 
     fn used_space(&self) -> Cow<'static, str> {
         if let Some(used_bytes) = self.used_bytes {
-            let converted_free_space = get_decimal_bytes(used_bytes);
+            let converted_free_space = convert_bytes(used_bytes, self.use_binary_prefix);
             format!("{:.0}{}", converted_free_space.0, converted_free_space.1).into()
         } else {
             "N/A".into()
@@ -408,5 +409,105 @@ impl DiskTableWidget {
     pub fn set_index(&mut self, index: usize) {
         self.table.set_sort_index(index);
         self.force_data_update();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::utils::data_units::{GIBI_LIMIT, MEBI_LIMIT, TEBI_LIMIT};
+
+    fn disk(bytes: Option<u64>, use_binary_prefix: bool) -> DiskWidgetData {
+        DiskWidgetData {
+            use_binary_prefix,
+            name: "disk".into(),
+            mount_point: "/".into(),
+            free_bytes: bytes,
+            used_bytes: bytes,
+            total_bytes: bytes,
+            summed_total_bytes: bytes.map(|bytes| bytes * 2),
+            io_read_rate_bytes: bytes,
+            io_write_rate_bytes: bytes,
+        }
+    }
+
+    fn cell(data: &DiskWidgetData, column: DiskWidgetColumn) -> Cow<'static, str> {
+        data.to_cell_text(&column, NonZeroU16::new(10).unwrap())
+            .unwrap()
+    }
+
+    #[test]
+    fn disk_space_units() {
+        for (bytes, decimal, binary) in [
+            (0, "0B", "0B"),
+            (999, "999B", "999B"),
+            (1000, "1KB", "1000B"),
+            (1023, "1KB", "1023B"),
+            (1024, "1KB", "1KiB"),
+            (MEBI_LIMIT, "1MB", "1MiB"),
+            (500 * GIBI_LIMIT, "537GB", "500GiB"),
+            (TEBI_LIMIT, "1TB", "1TiB"),
+        ] {
+            for (use_binary_prefix, expected) in [(false, decimal), (true, binary)] {
+                let data = disk(Some(bytes), use_binary_prefix);
+                for column in [
+                    DiskWidgetColumn::Used,
+                    DiskWidgetColumn::Free,
+                    DiskWidgetColumn::Total,
+                ] {
+                    assert_eq!(cell(&data, column), expected);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn disk_missing_space_and_percentages() {
+        for use_binary_prefix in [false, true] {
+            let missing = disk(None, use_binary_prefix);
+            for column in [
+                DiskWidgetColumn::Used,
+                DiskWidgetColumn::Free,
+                DiskWidgetColumn::Total,
+                DiskWidgetColumn::UsedPercent,
+                DiskWidgetColumn::FreePercent,
+                DiskWidgetColumn::IoRead,
+                DiskWidgetColumn::IoWrite,
+            ] {
+                assert_eq!(cell(&missing, column), "N/A");
+            }
+            let data = disk(Some(500 * GIBI_LIMIT), use_binary_prefix);
+            assert_eq!(cell(&data, DiskWidgetColumn::UsedPercent), "50.0%");
+            assert_eq!(cell(&data, DiskWidgetColumn::FreePercent), "50.0%");
+            assert_eq!(cell(&data, DiskWidgetColumn::IoRead), "536.9GB/s");
+            assert_eq!(cell(&data, DiskWidgetColumn::IoWrite), "536.9GB/s");
+            assert_eq!(
+                cell(
+                    &disk(Some(0), use_binary_prefix),
+                    DiskWidgetColumn::UsedPercent
+                ),
+                "N/A"
+            );
+        }
+    }
+
+    #[test]
+    fn disk_space_sorting_uses_bytes() {
+        for use_binary_prefix in [false, true] {
+            for column in [
+                DiskWidgetColumn::Used,
+                DiskWidgetColumn::Free,
+                DiskWidgetColumn::Total,
+            ] {
+                let mut data = [
+                    disk(Some(GIBI_LIMIT), use_binary_prefix),
+                    disk(Some(2 * MEBI_LIMIT), use_binary_prefix),
+                ];
+                column.sort_data(&mut data, false);
+                assert_eq!(data[0].total_bytes, Some(2 * MEBI_LIMIT));
+                column.sort_data(&mut data, true);
+                assert_eq!(data[0].total_bytes, Some(GIBI_LIMIT));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
Enable binary disk capacity units with:

```toml
[disk]
use_binary_prefix = true
```

Or pass `--disk_use_binary_prefix` (alias `--disk-use-binary-prefix`). The CLI flag takes precedence over a false config setting. Decimal units remain the default.

Used, Free, and Total use the existing binary conversion helper. For example, 536,870,912,000 bytes changes from `537GB` to `500GiB`. Percentages, sorting by raw byte values, I/O rates, and network units retain their existing behavior.

The change passes the option from argument/config parsing through application settings and collected disk data to cell formatting. Four regression tests cover option precedence and both CLI spellings, collection-to-cell wiring, unit boundaries, missing values, percentages, I/O behavior, and sorting.

## Issue

Closes: #2012


## Testing

Automated validation on Windows x86-64 GNU with Rust 1.98.1:

- Focused disk tests: 10 passed.
- Full all-features suite: 250 unit and 32 integration tests passed; 2 integration tests and 1 doctest ignored.
- Full no-default-features suite: 236 unit and 34 integration tests passed; 1 doctest ignored.
- Clippy with all targets, both feature configurations, and `-D warnings`: passed. The no-default-features run emitted a MinGW build-script `.drectve` linker warning, which Rust exempts from `-D warnings`.
- Formatting and whitespace checks passed.
- Independent static review found no correctness issues.

Regression coverage includes config/CLI defaults and precedence, the hyphenated alias, collection-to-cell propagation, decimal and binary output, missing data, and unchanged percentages, I/O rates, and sorting.

Interactive visual testing, Windows MSVC, Linux, macOS, and remote CI have not been performed.

- [x] Windows (automated tests, GNU toolchain)
- [ ] macOS
- [ ] Linux
- [ ] Other

## Checklist
- [ ] If this pull request adds or changes a dependency, justify this in the description (no dependency changes)
- [x] Affected code has been formatted with `cargo fmt`
- [x] Changes pass `cargo clippy --all -- -D warnings`
- [x] New tests were added where relevant
- [x] Changes pass `cargo test`
- [x] The change has been verified to work and does not unexpectedly break anything else
- [x] Documentation has been updated with human-written wording
- [x] There are no merge conflicts
- [x] You have personally reviewed the changes before creating the PR
- [x] The pull request passes the provided CI pipeline
- [x] AI use follows the repository policy, is disclosed below, and the change has been personally reviewed by the human contributor

## Other

Codex assisted with implementation, regression tests and independent static review.